### PR TITLE
Add a telos usage command for token/cost visibility

### DIFF
--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -8,6 +8,7 @@
 //	telos run SPEC.md [--workspace DIR] [--model MODEL] [--thinking EFFORT]
 //	    [--until N] [--max-cost-usd USD] [--agent-timeout-sec SEC|0] [--json]
 //	telos list [--limit N] [--wide] [--local] [--cloud] [--json]
+//	telos usage [--limit N] [--local] [--json]
 //	telos describe SESSION|DEPLOYMENT [--json]
 //	telos logs [-f] [--verbose] SESSION|DEPLOYMENT
 //	telos stop SESSION|DEPLOYMENT [--json]
@@ -53,6 +54,8 @@ func main() {
 		cmdRun(os.Args[2:])
 	case "list":
 		cmdList(os.Args[2:])
+	case "usage":
+		cmdUsage(os.Args[2:])
 	case "describe":
 		cmdDescribe(os.Args[2:])
 	case "logs":
@@ -83,6 +86,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  apply SPEC.md      Publish and deploy a spec package")
 	fmt.Fprintln(out, "  run SPEC.md        Run a local or delegated spec")
 	fmt.Fprintln(out, "  list               List cloud deployments, or local sessions with --local")
+	fmt.Fprintln(out, "  usage              Show per-session token and cost usage with totals")
 	fmt.Fprintln(out, "  describe ID        Show cloud deployment or runtime session details")
 	fmt.Fprintln(out, "  logs ID            Show cloud deployment or runtime session progress")
 	fmt.Fprintln(out, "  stop ID            Stop a session; cloud deployment IDs are deleted")

--- a/cmd/telos/usage.go
+++ b/cmd/telos/usage.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/telos-org/telos/internal/sessionapi"
+)
+
+// -- usage --------------------------------------------------------------------
+
+type sessionUsage struct {
+	Name                string   `json:"spec_name"`
+	SessionID           string   `json:"session_id"`
+	Status              string   `json:"status"`
+	InputTokens         *int     `json:"total_input_tokens,omitempty"`
+	OutputTokens        *int     `json:"total_output_tokens,omitempty"`
+	CacheReadTokens     *int     `json:"total_cache_read_tokens,omitempty"`
+	CacheCreationTokens *int     `json:"total_cache_creation_tokens,omitempty"`
+	CostUSD             *float64 `json:"total_cost_usd,omitempty"`
+}
+
+type usageTotals struct {
+	Sessions            int     `json:"sessions"`
+	InputTokens         int     `json:"total_input_tokens"`
+	OutputTokens        int     `json:"total_output_tokens"`
+	CacheReadTokens     int     `json:"total_cache_read_tokens"`
+	CacheCreationTokens int     `json:"total_cache_creation_tokens"`
+	CostUSD             float64 `json:"total_cost_usd"`
+}
+
+type usageReport struct {
+	Sessions []sessionUsage `json:"sessions"`
+	Totals   usageTotals    `json:"totals"`
+}
+
+func cmdUsage(args []string) {
+	fs := flag.NewFlagSet("usage", flag.ExitOnError)
+	limit := fs.Int("limit", 0, "Limit results")
+	localOnly := fs.Bool("local", false, "Local sessions only")
+	jsonOut := fs.Bool("json", false, "JSON output")
+	parseFlags(fs, args)
+
+	// Usage lives on runtime sessions, not cloud deployments: use the root
+	// session tree when running delegated, otherwise the local store.
+	var sessions []sessionapi.Session
+	if !*localOnly {
+		rootSessions, handled, err := rootListSessions(*limit)
+		if handled {
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+			sessions = rootSessions
+		} else {
+			sessions = listLocalSessions()
+		}
+	} else {
+		sessions = listLocalSessions()
+	}
+	// Child sessions carry their own turn stats, so they stay in the report;
+	// hiding them would undercount the totals.
+	sessions = limitListSessions(sessions, *limit)
+
+	report := usageReportFromSessions(sessions)
+	if *jsonOut {
+		printJSON(report)
+		return
+	}
+	if len(report.Sessions) == 0 {
+		fmt.Println("no sessions")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSTATUS\tINPUT\tOUTPUT\tCACHE-R\tCACHE-W\tCOST\tSESSION")
+	for _, row := range report.Sessions {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.Name,
+			row.Status,
+			usageTokens(row.InputTokens),
+			usageTokens(row.OutputTokens),
+			usageTokens(row.CacheReadTokens),
+			usageTokens(row.CacheCreationTokens),
+			formatDetailCost(row.CostUSD),
+			row.SessionID,
+		)
+	}
+	totals := report.Totals
+	fmt.Fprintf(w, "TOTAL\t%d sessions\t%d\t%d\t%d\t%d\t%s\t\n",
+		totals.Sessions,
+		totals.InputTokens,
+		totals.OutputTokens,
+		totals.CacheReadTokens,
+		totals.CacheCreationTokens,
+		usageTotalCost(report),
+	)
+	_ = w.Flush()
+}
+
+func usageReportFromSessions(sessions []sessionapi.Session) usageReport {
+	report := usageReport{Sessions: make([]sessionUsage, 0, len(sessions))}
+	for _, sess := range sessions {
+		row := sessionUsage{
+			Name:                sessionName(sess),
+			SessionID:           sess.SessionID,
+			Status:              sessionDisplayStatus(sess),
+			InputTokens:         sess.TotalInputTokens,
+			OutputTokens:        sess.TotalOutputTokens,
+			CacheReadTokens:     sess.TotalCacheReadTokens,
+			CacheCreationTokens: sess.TotalCacheCreateTokens,
+			CostUSD:             sess.TotalCostUSD,
+		}
+		report.Sessions = append(report.Sessions, row)
+		report.Totals.Sessions++
+		report.Totals.InputTokens += intOrZero(row.InputTokens)
+		report.Totals.OutputTokens += intOrZero(row.OutputTokens)
+		report.Totals.CacheReadTokens += intOrZero(row.CacheReadTokens)
+		report.Totals.CacheCreationTokens += intOrZero(row.CacheCreationTokens)
+		if row.CostUSD != nil {
+			report.Totals.CostUSD += *row.CostUSD
+		}
+	}
+	return report
+}
+
+func usageTokens(value *int) string {
+	if value == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *value)
+}
+
+func usageTotalCost(report usageReport) string {
+	for _, row := range report.Sessions {
+		if row.CostUSD != nil {
+			return fmt.Sprintf("$%.4f", report.Totals.CostUSD)
+		}
+	}
+	return "-"
+}
+
+func intOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/cmd/telos/usage_test.go
+++ b/cmd/telos/usage_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/telos-org/telos/internal/sessionapi"
+)
+
+func TestUsageReportFromSessionsSumsTotals(t *testing.T) {
+	name := "hello-service"
+	inA, outA, cacheReadA, cacheWriteA, costA := 1200, 300, 5000, 800, 0.25
+	inB, outB := 100, 50
+	sessions := []sessionapi.Session{
+		{
+			SessionID:              "sess_a",
+			SpecName:               &name,
+			Status:                 sessionapi.StatusCompleted,
+			TotalInputTokens:       &inA,
+			TotalOutputTokens:      &outA,
+			TotalCacheReadTokens:   &cacheReadA,
+			TotalCacheCreateTokens: &cacheWriteA,
+			TotalCostUSD:           &costA,
+		},
+		{
+			SessionID:         "sess_b",
+			Status:            sessionapi.StatusRunning,
+			TotalInputTokens:  &inB,
+			TotalOutputTokens: &outB,
+		},
+	}
+
+	report := usageReportFromSessions(sessions)
+	if report.Totals.Sessions != 2 {
+		t.Fatalf("total sessions: got %d, want 2", report.Totals.Sessions)
+	}
+	if report.Totals.InputTokens != 1300 || report.Totals.OutputTokens != 350 {
+		t.Fatalf("token totals: got in=%d out=%d, want in=1300 out=350",
+			report.Totals.InputTokens, report.Totals.OutputTokens)
+	}
+	if report.Totals.CacheReadTokens != 5000 || report.Totals.CacheCreationTokens != 800 {
+		t.Fatalf("cache totals: got read=%d write=%d, want read=5000 write=800",
+			report.Totals.CacheReadTokens, report.Totals.CacheCreationTokens)
+	}
+	if report.Totals.CostUSD != 0.25 {
+		t.Fatalf("cost total: got %f, want 0.25", report.Totals.CostUSD)
+	}
+	if report.Sessions[0].Name != "hello-service" || report.Sessions[1].Name != "-" {
+		t.Fatalf("row names: got %q, %q", report.Sessions[0].Name, report.Sessions[1].Name)
+	}
+}
+
+func TestUsageReportKeepsMissingStatsUnset(t *testing.T) {
+	report := usageReportFromSessions([]sessionapi.Session{
+		{SessionID: "sess_new", Status: sessionapi.StatusPending},
+	})
+	row := report.Sessions[0]
+	if row.InputTokens != nil || row.OutputTokens != nil || row.CostUSD != nil {
+		t.Fatalf("missing stats should stay nil, got %#v", row)
+	}
+	if usageTokens(row.InputTokens) != "-" {
+		t.Fatalf("missing tokens should render as -, got %q", usageTokens(row.InputTokens))
+	}
+	if usageTotalCost(report) != "-" {
+		t.Fatalf("all-nil cost should render as -, got %q", usageTotalCost(report))
+	}
+}
+
+func TestUsageTotalCostRendersWhenAnySessionHasCost(t *testing.T) {
+	cost := 0.0
+	report := usageReportFromSessions([]sessionapi.Session{
+		{SessionID: "sess_free", TotalCostUSD: &cost},
+	})
+	if usageTotalCost(report) != "$0.0000" {
+		t.Fatalf("zero cost should render, got %q", usageTotalCost(report))
+	}
+}
+
+func TestCmdUsageEmptyLocalStore(t *testing.T) {
+	configureLocalOnlyTest(t)
+	t.Setenv("TELOS_SESSION_DIR", t.TempDir())
+
+	out := captureStdout(t, func() {
+		cmdUsage([]string{"--local"})
+	})
+	if !strings.Contains(out, "no sessions") {
+		t.Fatalf("empty store output: got %q", out)
+	}
+}


### PR DESCRIPTION
Hey! Was good chatting yesterday. We're trying Telos out for our deploy agent's background work — running pi with Cerebras GLM 4.7 as the model — and the first thing we reached for was a quick way to see token burn across sessions. `list` has the COST column, but with a custom provider the pricing comes back zero, so the raw token counts are what actually matter for us.

This adds a small, purely additive `telos usage` command:

```
$ telos usage
NAME           STATUS      INPUT  OUTPUT  CACHE-R  CACHE-W  COST     SESSION
hello-service  completed   1200   300     5000     800      $0.2500  sess_a
TOTAL          1 sessions  1200   300     5000     800      $0.2500
```

- Reads the same stores as `list` (root session tree when delegated, local store otherwise); child sessions stay in the report so totals don't undercount
- `--json` emits rows plus aggregated totals (we feed this into our usage dashboard)
- Sessions that haven't reported stats yet render `-`

gofmt clean, `go build ./...` and `go test ./...` pass locally.

Happy to rename/reshape (e.g. fold it into `list --usage`) if you'd prefer. Also noticed usage totals only land in the store at game_end, so running sessions show nothing — happy to take a swing at live running totals as a follow-up if that'd be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)