### PR TITLE
Add browser-based telos login and logout

### DIFF
--- a/cmd/telos/login.go
+++ b/cmd/telos/login.go
@@ -75,11 +75,9 @@ func browserLogin(endpoint string) (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("First, confirm this code in your browser: %s\n", start.UserCode)
-	fmt.Printf("Opening %s\n", start.VerificationURL)
-	if err := openBrowser(start.VerificationURL); err != nil {
-		fmt.Println("Couldn't open a browser here. Visit the link above on any device.")
-	}
+	fmt.Println("Opening your browser to approve this login...")
+	fmt.Printf("If it doesn't open, visit this link on any device: %s\n", start.VerificationURL)
+	_ = openBrowser(start.VerificationURL)
 	fmt.Print("Waiting for approval")
 
 	interval := start.Interval

--- a/cmd/telos/login.go
+++ b/cmd/telos/login.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+	"os/exec"
+	"runtime"
+	"time"
 
 	"github.com/telos-org/telos/internal/cloud"
 	"github.com/telos-org/telos/internal/config"
@@ -14,8 +19,8 @@ import (
 func cmdLogin(args []string) {
 	fs := flag.NewFlagSet("login", flag.ExitOnError)
 	endpoint := fs.String("endpoint", cloud.DefaultAPIEndpoint, "API endpoint")
-	token := fs.String("token", "", "API token")
-	noPrompt := fs.Bool("no-prompt", false, "No interactive prompt")
+	token := fs.String("token", "", "API token (skips the browser flow)")
+	noPrompt := fs.Bool("no-prompt", false, "Never open a browser or prompt; require --token or TELOS_AUTH_TOKEN")
 	parseFlags(fs, args)
 
 	ep := cloud.NormalizeEndpoint(*endpoint)
@@ -24,8 +29,12 @@ func cmdLogin(args []string) {
 		tok = os.Getenv("TELOS_AUTH_TOKEN")
 	}
 	if tok == "" && !*noPrompt {
-		fmt.Print("Telos API token: ")
-		fmt.Scanln(&tok)
+		var err error
+		tok, err = browserLogin(ep)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	if tok == "" {
 		fmt.Fprintln(os.Stderr, "error: token required")
@@ -39,5 +48,94 @@ func cmdLogin(args []string) {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+	if me, err := cloud.NewClient(ep, tok).Me(); err == nil {
+		who := me.Subject
+		if me.Email != nil && *me.Email != "" {
+			who = *me.Email
+		}
+		fmt.Printf("logged in to %s as %s\n", ep, who)
+		return
+	}
 	fmt.Printf("logged in to %s\n", ep)
+}
+
+// browserLogin runs the browser handshake: start a login request, send the
+// user to the approval page, and poll until a token can be claimed.
+func browserLogin(endpoint string) (string, error) {
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown device"
+	}
+	start, err := cloud.StartCLIAuth(endpoint, hostname)
+	if err != nil {
+		if cloud.IsStatus(err, http.StatusNotFound) {
+			// Control plane predates browser login; fall back to pasting.
+			return promptForToken(), nil
+		}
+		return "", err
+	}
+
+	fmt.Printf("First, confirm this code in your browser: %s\n", start.UserCode)
+	fmt.Printf("Opening %s\n", start.VerificationURL)
+	if err := openBrowser(start.VerificationURL); err != nil {
+		fmt.Println("Couldn't open a browser here. Visit the link above on any device.")
+	}
+	fmt.Print("Waiting for approval")
+
+	interval := start.Interval
+	if interval <= 0 {
+		interval = 5
+	}
+	ttl := start.ExpiresIn
+	if ttl <= 0 {
+		ttl = 600
+	}
+	deadline := time.Now().Add(time.Duration(ttl) * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(time.Duration(interval) * time.Second)
+		poll, err := cloud.PollCLIAuth(endpoint, start.RequestID, start.PollSecret)
+		if err != nil {
+			fmt.Println()
+			return "", err
+		}
+		if poll.Interval > 0 {
+			interval = poll.Interval
+		}
+		switch poll.Status {
+		case "pending":
+			fmt.Print(".")
+		case "approved":
+			fmt.Println()
+			if poll.Token == "" {
+				return "", errors.New("login was approved but no token was returned")
+			}
+			return poll.Token, nil
+		case "denied":
+			fmt.Println()
+			return "", errors.New("login was denied in the browser")
+		default: // expired, claimed
+			fmt.Println()
+			return "", fmt.Errorf("login request %s; run `telos login` again", poll.Status)
+		}
+	}
+	fmt.Println()
+	return "", errors.New("timed out waiting for approval; run `telos login` again")
+}
+
+func promptForToken() string {
+	var tok string
+	fmt.Print("Telos API token: ")
+	fmt.Scanln(&tok)
+	return tok
+}
+
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default:
+		return exec.Command("xdg-open", url).Start()
+	}
 }

--- a/cmd/telos/logout.go
+++ b/cmd/telos/logout.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/telos-org/telos/internal/cloud"
+	"github.com/telos-org/telos/internal/config"
+)
+
+// -- logout -------------------------------------------------------------------
+
+func cmdLogout(args []string) {
+	fs := flag.NewFlagSet("logout", flag.ExitOnError)
+	parseFlags(fs, args)
+
+	cfg := config.LoadConfig()
+	if cfg.AuthToken == "" {
+		fmt.Println("not logged in")
+		return
+	}
+	if os.Getenv(config.AuthTokenEnv) != "" {
+		fmt.Fprintf(os.Stderr, "warning: %s is set; unset it to fully log out\n", config.AuthTokenEnv)
+	} else if tokenID := cloud.APITokenID(cfg.AuthToken); tokenID != "" {
+		endpoint := cfg.APIEndpoint
+		if endpoint == "" {
+			endpoint = cloud.DefaultAPIEndpoint
+		}
+		// Best-effort server-side revoke so the credential dies with the login.
+		if err := cloud.NewClient(endpoint, cfg.AuthToken).RevokeAPIToken(tokenID); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: token not revoked server-side: %v\n", err)
+		}
+	}
+
+	cfg.AuthToken = ""
+	if err := config.SaveConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("logged out")
+}

--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -12,6 +12,7 @@
 //	telos logs [-f] [--verbose] SESSION
 //	telos delete SESSION [--json]
 //	telos login [--endpoint URL] [--token TOKEN] [--no-prompt]
+//	telos logout
 //	telos version
 //	telos --version
 package main
@@ -60,6 +61,8 @@ func main() {
 		cmdDelete(os.Args[2:])
 	case "login":
 		cmdLogin(os.Args[2:])
+	case "logout":
+		cmdLogout(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		usage(os.Stderr)
@@ -83,7 +86,8 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  describe SESSION   Show session details")
 	fmt.Fprintln(out, "  logs SESSION       Show session progress")
 	fmt.Fprintln(out, "  delete SESSION     Delete a session (local history is preserved)")
-	fmt.Fprintln(out, "  login              Log in to Telos Cloud")
+	fmt.Fprintln(out, "  login              Log in to Telos Cloud via the browser")
+	fmt.Fprintln(out, "  logout             Log out and revoke this device's token")
 	fmt.Fprintln(out, "  version            Show version")
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "global flags:")

--- a/internal/cloud/cliauth.go
+++ b/internal/cloud/cliauth.go
@@ -1,0 +1,130 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// Browser-login handshake against /api/cli/auth/*. Start and Poll run before
+// the CLI has a credential, so they send no Authorization header. The token
+// can only be claimed with the poll secret, which never leaves this process.
+
+type CLIAuthStart struct {
+	RequestID       string `json:"request_id"`
+	UserCode        string `json:"user_code"`
+	PollSecret      string `json:"poll_secret"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type CLIAuthPoll struct {
+	Status   string `json:"status"`
+	Token    string `json:"token"`
+	Interval int    `json:"interval"`
+}
+
+// preauthClient makes requests on a fresh connection each time: polls are
+// spaced at about the server's keep-alive idle timeout, so a reused
+// connection races the server-side close and surfaces as a reset.
+func preauthClient(endpoint string) *Client {
+	return &Client{
+		Endpoint: NormalizeEndpoint(endpoint),
+		HTTP: &http.Client{
+			Timeout:   DefaultTimeout,
+			Transport: &http.Transport{DisableKeepAlives: true},
+		},
+	}
+}
+
+func StartCLIAuth(endpoint, clientName string) (*CLIAuthStart, error) {
+	body, err := json.Marshal(map[string]string{"client_name": clientName})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := preauthClient(endpoint).do("POST", "/api/cli/auth/start", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+	var start CLIAuthStart
+	if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+		return nil, err
+	}
+	return &start, nil
+}
+
+func PollCLIAuth(endpoint, requestID, pollSecret string) (*CLIAuthPoll, error) {
+	body, err := json.Marshal(map[string]string{
+		"request_id":  requestID,
+		"poll_secret": pollSecret,
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := preauthClient(endpoint).do("POST", "/api/cli/auth/poll", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+	var poll CLIAuthPoll
+	if err := json.NewDecoder(resp.Body).Decode(&poll); err != nil {
+		return nil, err
+	}
+	return &poll, nil
+}
+
+type MeRecord struct {
+	Subject string  `json:"subject"`
+	Email   *string `json:"email,omitempty"`
+	Name    *string `json:"name,omitempty"`
+}
+
+func (c *Client) Me() (*MeRecord, error) {
+	resp, err := c.do("GET", "/api/me", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+	var me MeRecord
+	if err := json.NewDecoder(resp.Body).Decode(&me); err != nil {
+		return nil, err
+	}
+	return &me, nil
+}
+
+// APITokenID extracts the token id embedded in a telos_pat_<id>.<secret>
+// token, or "" if the token has another shape (legacy shared secrets).
+func APITokenID(token string) string {
+	const prefix = "telos_pat_"
+	if !strings.HasPrefix(token, prefix) {
+		return ""
+	}
+	id, _, found := strings.Cut(strings.TrimPrefix(token, prefix), ".")
+	if !found || !strings.HasPrefix(id, "tok_") {
+		return ""
+	}
+	return id
+}
+
+func (c *Client) RevokeAPIToken(tokenID string) error {
+	resp, err := c.do("DELETE", "/api/api-tokens/"+tokenID, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return readError(resp)
+	}
+	return nil
+}

--- a/internal/cloud/cliauth_test.go
+++ b/internal/cloud/cliauth_test.go
@@ -1,0 +1,119 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAPITokenID(t *testing.T) {
+	tests := []struct {
+		token    string
+		expected string
+	}{
+		{"telos_pat_tok_abc123.supersecret", "tok_abc123"},
+		{"telos_pat_tok_abc123.", "tok_abc123"},
+		{"telos_pat_abc123.supersecret", ""},
+		{"telos_pat_tok_abc123-no-secret", ""},
+		{"legacy-shared-secret", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := APITokenID(tt.token); got != tt.expected {
+			t.Errorf("APITokenID(%q) = %q, want %q", tt.token, got, tt.expected)
+		}
+	}
+}
+
+func TestStartAndPollCLIAuth(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("pre-auth endpoint got Authorization header %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case "/api/cli/auth/start":
+			var body struct {
+				ClientName string `json:"client_name"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.ClientName != "test-host" {
+				t.Errorf("client_name = %q, want test-host", body.ClientName)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"request_id":       "cli_req_1",
+				"user_code":        "WDJB-MJHT",
+				"poll_secret":      "psecret",
+				"verification_url": "https://usetelos.ai/cli-auth?code=WDJB-MJHT",
+				"expires_in":       600,
+				"interval":         5,
+			})
+		case "/api/cli/auth/poll":
+			var body struct {
+				RequestID  string `json:"request_id"`
+				PollSecret string `json:"poll_secret"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.RequestID != "cli_req_1" || body.PollSecret != "psecret" {
+				t.Errorf("poll body = %+v", body)
+			}
+			polls++
+			if polls == 1 {
+				json.NewEncoder(w).Encode(map[string]any{"status": "pending", "token": nil, "interval": 5})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"status":   "approved",
+				"token":    "telos_pat_tok_new.secret",
+				"interval": 5,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	start, err := StartCLIAuth(srv.URL, "test-host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start.UserCode != "WDJB-MJHT" || start.PollSecret != "psecret" {
+		t.Errorf("start = %+v", start)
+	}
+
+	first, err := PollCLIAuth(srv.URL, start.RequestID, start.PollSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != "pending" || first.Token != "" {
+		t.Errorf("first poll = %+v", first)
+	}
+
+	second, err := PollCLIAuth(srv.URL, start.RequestID, start.PollSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Status != "approved" || second.Token != "telos_pat_tok_new.secret" {
+		t.Errorf("second poll = %+v", second)
+	}
+}
+
+func TestStartCLIAuthSurfacesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := StartCLIAuth(srv.URL, "test-host")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsStatus(err, http.StatusNotFound) {
+		t.Errorf("IsStatus(err, 404) = false, err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `telos login` now runs a browser handshake by default: prints a short code, opens the approve page, polls until approved, then saves the minted token and confirms identity via `/api/me`. `--token`, `TELOS_AUTH_TOKEN`, and `--no-prompt` behave exactly as before (CI unaffected); a paste prompt remains as fallback when the control plane predates the endpoints (404).
- New `telos logout`: best-effort server-side token revoke (skipped with a warning when `TELOS_AUTH_TOKEN` is set), then clears the config.
- Pre-auth requests use fresh connections per poll to avoid a keep-alive race with the server's idle timeout (found during e2e: 5s poll interval == uvicorn's default keep-alive, surfacing as connection resets).

## Testing
- New unit tests for token-id parsing and the start/poll handshake (httptest); `go build`/`vet`/`gofmt`/full test suite green.
- Verified end-to-end against a local control plane and QA: login → approve in browser → token claimed → logout revokes server-side (revoked token then 401s).

Companion PRs: telos-org/cloud#34 (endpoints), telos-org/web (approve page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kmg7XzmHM2eY34eMqwqASq