### PR TITLE
feat(local): configure generator and verifier models separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Providers, models, and credentials are managed by pi; run `pi` and use
 [pi's model documentation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md)
 for configuration details.
 
+Local runs can optionally override the generator and verifier independently:
+
+```bash
+telos run SPEC.md \
+  --generator-model openai-codex/gpt-5.5 --generator-thinking high \
+  --verifier-model anthropic/claude-sonnet-4 --verifier-thinking medium
+```
+
+Omitted role settings inherit `--model` and `--thinking`. The equivalent
+environment variables are `TELOS_GENERATOR_MODEL`, `TELOS_GENERATOR_THINKING`,
+`TELOS_VERIFIER_MODEL`, and `TELOS_VERIFIER_THINKING`.
+
 ### Using registry skills
 
 Reference an exact registry skill version directly from `SPEC.md`:

--- a/cmd/telos/flags.go
+++ b/cmd/telos/flags.go
@@ -91,6 +91,10 @@ func resolveLocalRunConfigFromFlags(
 	workspace string,
 	model string,
 	thinking string,
+	generatorModel string,
+	generatorThinking string,
+	verifierModel string,
+	verifierThinking string,
 	maxCostUSD float64,
 ) (cli.LocalRunConfig, error) {
 	cost, err := positiveFloatOption(fs, "max-cost-usd", maxCostUSD, "TELOS_MAX_COST_USD", 20.0)
@@ -98,11 +102,43 @@ func resolveLocalRunConfigFromFlags(
 		return cli.LocalRunConfig{}, err
 	}
 	return cli.LocalRunConfig{
-		Workspace:  stringOption(fs, "workspace", workspace, "TELOS_WORKSPACE"),
-		Model:      modelOption(fs, model),
-		Thinking:   stringOptionDefault(fs, "thinking", thinking, "TELOS_THINKING", cli.DefaultLocalThinking),
+		Workspace: stringOption(fs, "workspace", workspace, "TELOS_WORKSPACE"),
+		Model:     modelOption(fs, model),
+		Thinking:  stringOptionDefault(fs, "thinking", thinking, "TELOS_THINKING", cli.DefaultLocalThinking),
+		Generator: roleConfig(
+			stringOption(fs, "generator-model", generatorModel, "TELOS_GENERATOR_MODEL"),
+			stringOption(fs, "generator-thinking", generatorThinking, "TELOS_GENERATOR_THINKING"),
+		),
+		Verifier: roleConfig(
+			stringOption(fs, "verifier-model", verifierModel, "TELOS_VERIFIER_MODEL"),
+			stringOption(fs, "verifier-thinking", verifierThinking, "TELOS_VERIFIER_THINKING"),
+		),
 		MaxCostUSD: &cost,
 	}, nil
+}
+
+func roleConfig(model, thinking string) *sessionapi.RoleConfig {
+	if model == "" && thinking == "" {
+		return nil
+	}
+	return &sessionapi.RoleConfig{Model: model, Thinking: thinking}
+}
+
+func roleConfigSet(fs *flag.FlagSet) bool {
+	if flagNamesSet(fs, "generator-model", "generator-thinking", "verifier-model", "verifier-thinking") {
+		return true
+	}
+	for _, key := range []string{
+		"TELOS_GENERATOR_MODEL",
+		"TELOS_GENERATOR_THINKING",
+		"TELOS_VERIFIER_MODEL",
+		"TELOS_VERIFIER_THINKING",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 type sessionRuntimeConfig struct {

--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -37,6 +37,10 @@ func cmdLaunch(command, action string, args []string) {
 	}
 	model := fs.String("model", "", "pi model as <provider>/<model> (e.g. openai-codex/gpt-5.5); defaults to $TELOS_MODEL")
 	thinking := fs.String("thinking", "", "Thinking effort; defaults to $TELOS_THINKING, then high for local runs")
+	generatorModel := fs.String("generator-model", "", "Optional generator model; defaults to --model")
+	generatorThinking := fs.String("generator-thinking", "", "Optional generator thinking effort; defaults to --thinking")
+	verifierModel := fs.String("verifier-model", "", "Optional verifier model; defaults to --model")
+	verifierThinking := fs.String("verifier-thinking", "", "Optional verifier thinking effort; defaults to --thinking")
 	untilValue := ""
 	until := &untilValue
 	if command == "run" {
@@ -111,6 +115,10 @@ func cmdLaunch(command, action string, args []string) {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+	if launchMode != launchLocal && roleConfigSet(fs) {
+		fmt.Fprintln(os.Stderr, "error: per-role model configuration is currently supported for local runs only")
+		os.Exit(1)
+	}
 	localRootID, inLocalRoot := localRootSessionID()
 	if inLocalRoot {
 		if command == "apply" {
@@ -158,6 +166,10 @@ func cmdLaunch(command, action string, args []string) {
 		*workspace,
 		*model,
 		*thinking,
+		*generatorModel,
+		*generatorThinking,
+		*verifierModel,
+		*verifierThinking,
 		*maxCostUSD,
 	)
 	if err != nil {

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -164,7 +164,7 @@ func TestResolveLocalRunConfigUsesEnvironmentDefaults(t *testing.T) {
 	t.Setenv("TELOS_THINKING", "high")
 	t.Setenv("TELOS_MAX_COST_USD", "12.5")
 
-	cfg, err := resolveLocalRunConfigFromFlags(fs, "", "", "medium", 20.0)
+	cfg, err := resolveLocalRunConfigFromFlags(fs, "", "", "medium", "", "", "", "", 20.0)
 	if err != nil {
 		t.Fatalf("resolveLocalRunConfigFromFlags: %v", err)
 	}
@@ -185,12 +185,44 @@ func TestResolveLocalRunConfigUsesDefaultThinking(t *testing.T) {
 	fs.Float64("max-cost-usd", 20.0, "")
 	parseFlags(fs, []string{"SPEC.md"})
 
-	cfg, err := resolveLocalRunConfigFromFlags(fs, "", "", "", 20.0)
+	cfg, err := resolveLocalRunConfigFromFlags(fs, "", "", "", "", "", "", "", 20.0)
 	if err != nil {
 		t.Fatalf("resolveLocalRunConfigFromFlags: %v", err)
 	}
 	if cfg.Thinking != cli.DefaultLocalThinking {
 		t.Fatalf("thinking: got %q, want %q", cfg.Thinking, cli.DefaultLocalThinking)
+	}
+}
+
+func TestResolveLocalRunConfigUsesOptionalPerRoleOverrides(t *testing.T) {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.String("workspace", "", "")
+	fs.String("model", "", "")
+	fs.String("thinking", "", "")
+	fs.String("generator-model", "", "")
+	fs.String("generator-thinking", "", "")
+	fs.String("verifier-model", "", "")
+	fs.String("verifier-thinking", "", "")
+	fs.Float64("max-cost-usd", 20.0, "")
+	parseFlags(fs, []string{
+		"--generator-model", "openai-codex/gpt-generator",
+		"--generator-thinking", "high",
+		"--verifier-model", "anthropic/claude-verifier",
+		"SPEC.md",
+	})
+
+	cfg, err := resolveLocalRunConfigFromFlags(
+		fs, "", "", "", "openai-codex/gpt-generator", "high",
+		"anthropic/claude-verifier", "", 20.0,
+	)
+	if err != nil {
+		t.Fatalf("resolveLocalRunConfigFromFlags: %v", err)
+	}
+	if cfg.Generator == nil || cfg.Generator.Model != "openai-codex/gpt-generator" || cfg.Generator.Thinking != "high" {
+		t.Fatalf("generator: got %#v", cfg.Generator)
+	}
+	if cfg.Verifier == nil || cfg.Verifier.Model != "anthropic/claude-verifier" || cfg.Verifier.Thinking != "" {
+		t.Fatalf("verifier: got %#v", cfg.Verifier)
 	}
 }
 

--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -31,6 +31,8 @@ type LocalRunConfig struct {
 	Workspace       string
 	Model           string
 	Thinking        string
+	Generator       *sessionapi.RoleConfig
+	Verifier        *sessionapi.RoleConfig
 	Until           int
 	UntilSeconds    int
 	MaxCostUSD      *float64
@@ -262,11 +264,29 @@ func createPiExecutor(workspace string, cfg LocalRunConfig) (*executor.PiExecuto
 	if err := validatePiModel(model); err != nil {
 		return nil, err
 	}
+	if cfg.Generator != nil && cfg.Generator.Model != "" {
+		if err := validatePiModel(cfg.Generator.Model); err != nil {
+			return nil, fmt.Errorf("generator model: %w", err)
+		}
+	}
+	if cfg.Verifier != nil && cfg.Verifier.Model != "" {
+		if err := validatePiModel(cfg.Verifier.Model); err != nil {
+			return nil, fmt.Errorf("verifier model: %w", err)
+		}
+	}
 	thinking := cfg.Thinking
 	if thinking == "" {
 		thinking = DefaultLocalThinking
 	}
-	return executor.NewPiExecutor(p, model, thinking, cfg.AgentTimeoutSec), nil
+	return executor.NewPiExecutor(p, model, thinking, cfg.AgentTimeoutSec).
+		WithRoleConfig(toExecutorRoleConfig(cfg.Generator), toExecutorRoleConfig(cfg.Verifier)), nil
+}
+
+func toExecutorRoleConfig(config *sessionapi.RoleConfig) executor.RoleConfig {
+	if config == nil {
+		return executor.RoleConfig{}
+	}
+	return executor.RoleConfig{Model: config.Model, Thinking: config.Thinking}
 }
 
 type piModelsConfig struct {
@@ -486,6 +506,8 @@ func writeLocalManifest(sessionDir string, compiled *spec.CompiledEnvironment, s
 		ApplyPackageLock:   applyPackageLock,
 		Config: sessionapi.SessionConfig{
 			Model:           model,
+			Generator:       cfg.Generator,
+			Verifier:        cfg.Verifier,
 			Until:           cfg.Until,
 			UntilSeconds:    cfg.UntilSeconds,
 			MaxCostUSD:      cfg.MaxCostUSD,
@@ -517,6 +539,8 @@ func manifestToConfig(manifest *sessionapi.Manifest) LocalRunConfig {
 	lrc := LocalRunConfig{
 		Model:           cfg.Model,
 		Thinking:        cfg.Thinking,
+		Generator:       cfg.Generator,
+		Verifier:        cfg.Verifier,
 		Until:           cfg.Until,
 		UntilSeconds:    cfg.UntilSeconds,
 		MaxCostUSD:      cfg.MaxCostUSD,

--- a/internal/executor/pi.go
+++ b/internal/executor/pi.go
@@ -17,10 +17,18 @@ import (
 
 // PiExecutor runs Pi as one PVG agent turn on the given LocalPlatform.
 type PiExecutor struct {
-	Platform *platform.LocalPlatform
+	Platform  *platform.LocalPlatform
+	Model     string
+	Thinking  string
+	Timeout   int
+	Generator RoleConfig
+	Verifier  RoleConfig
+}
+
+// RoleConfig optionally overrides the shared model configuration for one PVG role.
+type RoleConfig struct {
 	Model    string
 	Thinking string
-	Timeout  int
 }
 
 const piEnvPromptMaxBytes = 256 * 1024
@@ -38,10 +46,36 @@ func NewPiExecutor(p *platform.LocalPlatform, model, thinking string, timeout in
 	}
 }
 
+// WithRoleConfig sets optional generator and verifier overrides.
+func (pe *PiExecutor) WithRoleConfig(generator, verifier RoleConfig) *PiExecutor {
+	pe.Generator = generator
+	pe.Verifier = verifier
+	return pe
+}
+
+func (pe *PiExecutor) configForRole(role string) (string, string) {
+	config := RoleConfig{}
+	if role == "prover" {
+		config = pe.Generator
+	} else if role == "verifier" {
+		config = pe.Verifier
+	}
+	model := config.Model
+	if model == "" {
+		model = pe.Model
+	}
+	thinking := config.Thinking
+	if thinking == "" {
+		thinking = pe.Thinking
+	}
+	return model, thinking
+}
+
 // ExecuteTurn runs one Pi agent turn.
 func (pe *PiExecutor) ExecuteTurn(task string, role string, turnState *game.TurnState) game.TurnResult {
 	var stats game.TurnStats
-	stats.Model = pe.Model
+	model, thinking := pe.configForRole(role)
+	stats.Model = model
 	var agentError string
 	var taskPath string
 	var sessionPath string
@@ -58,7 +92,7 @@ func (pe *PiExecutor) ExecuteTurn(task string, role string, turnState *game.Turn
 		promptPath = taskPath
 		taskEnv = ""
 	}
-	argv := BuildPiArgv(pe.Model, pe.Thinking, promptPath, sessionPath)
+	argv := BuildPiArgv(model, thinking, promptPath, sessionPath)
 	projector := startPiLiveProjector(sessionPath, turnState)
 	if projector != nil {
 		defer projector.Stop()

--- a/internal/executor/pi_test.go
+++ b/internal/executor/pi_test.go
@@ -21,6 +21,23 @@ func TestNewPiExecutorDefaultsToNoTimeout(t *testing.T) {
 	}
 }
 
+func TestPiExecutorResolvesPerRoleConfigWithSharedFallbacks(t *testing.T) {
+	exec := NewPiExecutor(nil, "shared/model", "medium", 0).WithRoleConfig(
+		RoleConfig{Model: "generator/model", Thinking: "high"},
+		RoleConfig{Model: "verifier/model"},
+	)
+
+	if model, thinking := exec.configForRole("prover"); model != "generator/model" || thinking != "high" {
+		t.Fatalf("generator config: got %q/%q", model, thinking)
+	}
+	if model, thinking := exec.configForRole("verifier"); model != "verifier/model" || thinking != "medium" {
+		t.Fatalf("verifier config: got %q/%q", model, thinking)
+	}
+	if model, thinking := exec.configForRole("other"); model != "shared/model" || thinking != "medium" {
+		t.Fatalf("fallback config: got %q/%q", model, thinking)
+	}
+}
+
 func TestBuildPiArgvUsesTextModeWithoutSessionByDefault(t *testing.T) {
 	argv := BuildPiArgv("claude-test", "high", "", "")
 	if len(argv) != 6 {

--- a/internal/sessionapi/manifest.go
+++ b/internal/sessionapi/manifest.go
@@ -94,12 +94,21 @@ type ScopedToken struct {
 
 type SessionConfig struct {
 	Model           string         `json:"model,omitempty"`
+	Generator       *RoleConfig    `json:"generator,omitempty"`
+	Verifier        *RoleConfig    `json:"verifier,omitempty"`
 	Until           int            `json:"until,omitempty"`
 	UntilSeconds    int            `json:"until_seconds,omitempty"`
 	MaxCostUSD      *float64       `json:"max_cost_usd,omitempty"`
 	AgentTimeoutSec int            `json:"agent_timeout_sec,omitempty"`
 	Thinking        string         `json:"thinking,omitempty"`
 	Extra           map[string]any `json:"-"`
+}
+
+// RoleConfig optionally overrides the shared model configuration for one PVG role.
+// Empty fields inherit their value from SessionConfig.Model/Thinking.
+type RoleConfig struct {
+	Model    string `json:"model,omitempty"`
+	Thinking string `json:"thinking,omitempty"`
 }
 
 // InitialManifest is the typed input for creating a session.json before any
@@ -308,6 +317,12 @@ func (c SessionConfig) MarshalJSON() ([]byte, error) {
 	if c.Model != "" {
 		m["model"] = c.Model
 	}
+	if c.Generator != nil {
+		m["generator"] = c.Generator
+	}
+	if c.Verifier != nil {
+		m["verifier"] = c.Verifier
+	}
 	if c.Until > 0 {
 		m["until"] = c.Until
 	}
@@ -337,6 +352,18 @@ func (c *SessionConfig) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("config.model: %w", err)
 		}
 		delete(raw, "model")
+	}
+	if value, ok := raw["generator"]; ok {
+		if err := json.Unmarshal(value, &c.Generator); err != nil {
+			return fmt.Errorf("config.generator: %w", err)
+		}
+		delete(raw, "generator")
+	}
+	if value, ok := raw["verifier"]; ok {
+		if err := json.Unmarshal(value, &c.Verifier); err != nil {
+			return fmt.Errorf("config.verifier: %w", err)
+		}
+		delete(raw, "verifier")
 	}
 	if value, ok := raw["until"]; ok {
 		if err := json.Unmarshal(value, &c.Until); err != nil {

--- a/internal/sessionapi/types_test.go
+++ b/internal/sessionapi/types_test.go
@@ -42,3 +42,26 @@ func TestSessionConfigPreservesUnknownFields(t *testing.T) {
 		t.Fatalf("future_knob was not preserved: %#v", m["future_knob"])
 	}
 }
+
+func TestSessionConfigRoundTripsOptionalRoleConfig(t *testing.T) {
+	cfg := sessionapi.SessionConfig{
+		Model:     "shared/model",
+		Thinking:  "medium",
+		Generator: &sessionapi.RoleConfig{Model: "generator/model", Thinking: "high"},
+		Verifier:  &sessionapi.RoleConfig{Model: "verifier/model", Thinking: "low"},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded sessionapi.SessionConfig
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Generator == nil || *decoded.Generator != *cfg.Generator {
+		t.Fatalf("generator: got %#v", decoded.Generator)
+	}
+	if decoded.Verifier == nil || *decoded.Verifier != *cfg.Verifier {
+		t.Fatalf("verifier: got %#v", decoded.Verifier)
+	}
+}


### PR DESCRIPTION
## Summary

- add optional generator/verifier model and thinking overrides for local runs
- persist role overrides in the session manifest and resolve them per PVG turn
- keep `--model` and `--thinking` as field-by-field fallbacks, preserving existing behavior

## Interface

```bash
telos run SPEC.md \
  --generator-model openai-codex/gpt-5.5 --generator-thinking high \
  --verifier-model anthropic/claude-sonnet-4 --verifier-thinking medium
```

Equivalent `TELOS_GENERATOR_*` and `TELOS_VERIFIER_*` environment variables are supported. Model values retain the existing `<provider>/<model-id>` format. Per-role overrides are intentionally local-only in this change; cloud launches reject them instead of silently ignoring them.

## Compatibility

The role blocks are optional. Existing manifests and CLI invocations are unchanged, and each omitted role field inherits the shared model/thinking value.

## Test plan

- `go test ./...`