### PR TITLE
Use Bifrost as the hosted model fallback

### DIFF
--- a/internal/telosd/controller_reconciler_test.go
+++ b/internal/telosd/controller_reconciler_test.go
@@ -319,8 +319,8 @@ func TestControllerReconcilerLeavesFileStateRunningWhenWorkerStopFails(t *testin
 
 func assertManagedSessionDefaults(t *testing.T, session *sessionapi.Session) {
 	t.Helper()
-	if got, _ := session.Config["model"].(string); got != fallbackCloudSessionModel {
-		t.Fatalf("model = %q want %q", got, fallbackCloudSessionModel)
+	if got, _ := session.Config["model"].(string); got != legacyCloudSessionModel {
+		t.Fatalf("model = %q want %q", got, legacyCloudSessionModel)
 	}
 	if got, _ := session.Config["thinking"].(string); got != defaultCloudSessionThinking {
 		t.Fatalf("thinking = %q want %q", got, defaultCloudSessionThinking)

--- a/internal/telosd/session_bootstrap.go
+++ b/internal/telosd/session_bootstrap.go
@@ -19,9 +19,11 @@ type cloudBootstrapSession struct {
 }
 
 const (
-	fallbackCloudSessionModel   = "telos-bifrost/standard-agent"
+	legacyCloudSessionModel     = "sail-research/zai-org/GLM-5.2-FP8"
+	bifrostCloudSessionModel    = "telos-bifrost/standard-agent"
 	defaultCloudSessionThinking = "medium"
 	cloudAgentTimeoutEnvVar     = "TELOS_AGENT_TIMEOUT_SEC"
+	cloudBifrostEnabledEnvVar   = "TELOS_BIFROST_ENABLED"
 )
 
 type sessionBootstrapReconciler struct {
@@ -161,7 +163,13 @@ func cloudSessionModel() string {
 	if model := strings.TrimSpace(os.Getenv("TELOS_CLOUD_DEFAULT_MODEL")); model != "" {
 		return model
 	}
-	return fallbackCloudSessionModel
+	// The provider extension and its virtual key are deployed by Cloud. Keep
+	// standalone/older hosted runtimes on the known legacy provider until that
+	// deployment explicitly opts them in.
+	if os.Getenv(cloudBifrostEnabledEnvVar) == "1" {
+		return bifrostCloudSessionModel
+	}
+	return legacyCloudSessionModel
 }
 
 func cloudSessionThinking() string {

--- a/internal/telosd/session_bootstrap.go
+++ b/internal/telosd/session_bootstrap.go
@@ -19,7 +19,7 @@ type cloudBootstrapSession struct {
 }
 
 const (
-	fallbackCloudSessionModel   = "sail-research/zai-org/GLM-5.2-FP8"
+	fallbackCloudSessionModel   = "telos-bifrost/standard-agent"
 	defaultCloudSessionThinking = "medium"
 	cloudAgentTimeoutEnvVar     = "TELOS_AGENT_TIMEOUT_SEC"
 )

--- a/internal/telosd/session_bootstrap.go
+++ b/internal/telosd/session_bootstrap.go
@@ -160,13 +160,20 @@ func (r sessionBootstrapReconciler) packagePathForDigest(digest string) (string,
 }
 
 func cloudSessionModel() string {
+	bifrostEnabled := os.Getenv(cloudBifrostEnabledEnvVar) == "1"
 	if model := strings.TrimSpace(os.Getenv("TELOS_CLOUD_DEFAULT_MODEL")); model != "" {
+		// Cloud persists the resolved model on each deployment. Translate the
+		// former hosted default during a rolling upgrade so a runtime with the
+		// Bifrost extension cannot be pinned to the removed Sail provider.
+		if bifrostEnabled && model == legacyCloudSessionModel {
+			return bifrostCloudSessionModel
+		}
 		return model
 	}
 	// The provider extension and its virtual key are deployed by Cloud. Keep
 	// standalone/older hosted runtimes on the known legacy provider until that
 	// deployment explicitly opts them in.
-	if os.Getenv(cloudBifrostEnabledEnvVar) == "1" {
+	if bifrostEnabled {
 		return bifrostCloudSessionModel
 	}
 	return legacyCloudSessionModel

--- a/internal/telosd/session_bootstrap_test.go
+++ b/internal/telosd/session_bootstrap_test.go
@@ -143,9 +143,17 @@ func TestSessionBootstrapMatchesCloudSessionNameBeforeSpecName(t *testing.T) {
 }
 
 func TestCloudSessionModelUsesEnvOverride(t *testing.T) {
-	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "sail-research/custom")
+	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "telos-bifrost/standard-compaction")
 
-	if got := cloudSessionModel(); got != "sail-research/custom" {
+	if got := cloudSessionModel(); got != "telos-bifrost/standard-compaction" {
+		t.Fatalf("cloudSessionModel = %q", got)
+	}
+}
+
+func TestCloudSessionModelUsesBifrostFallback(t *testing.T) {
+	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "")
+
+	if got := cloudSessionModel(); got != "telos-bifrost/standard-agent" {
 		t.Fatalf("cloudSessionModel = %q", got)
 	}
 }

--- a/internal/telosd/session_bootstrap_test.go
+++ b/internal/telosd/session_bootstrap_test.go
@@ -103,8 +103,8 @@ func TestSessionBootstrapReconcilerCreatesDesiredPackageSession(t *testing.T) {
 	if store.creates[0].CloudSessionName != "auth" {
 		t.Fatalf("CloudSessionName = %q want auth", store.creates[0].CloudSessionName)
 	}
-	if store.creates[0].Model != fallbackCloudSessionModel {
-		t.Fatalf("Model = %q want %q", store.creates[0].Model, fallbackCloudSessionModel)
+	if store.creates[0].Model != legacyCloudSessionModel {
+		t.Fatalf("Model = %q want %q", store.creates[0].Model, legacyCloudSessionModel)
 	}
 	if store.creates[0].AgentTimeoutSec != nil {
 		t.Fatalf("AgentTimeoutSec should not default for controller bootstrap: %v", store.creates[0].AgentTimeoutSec)
@@ -152,8 +152,18 @@ func TestCloudSessionModelUsesEnvOverride(t *testing.T) {
 
 func TestCloudSessionModelUsesBifrostFallback(t *testing.T) {
 	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "")
+	t.Setenv(cloudBifrostEnabledEnvVar, "1")
 
-	if got := cloudSessionModel(); got != "telos-bifrost/standard-agent" {
+	if got := cloudSessionModel(); got != bifrostCloudSessionModel {
+		t.Fatalf("cloudSessionModel = %q", got)
+	}
+}
+
+func TestCloudSessionModelUsesLegacyFallbackWithoutBifrostExtension(t *testing.T) {
+	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "")
+	t.Setenv(cloudBifrostEnabledEnvVar, "")
+
+	if got := cloudSessionModel(); got != legacyCloudSessionModel {
 		t.Fatalf("cloudSessionModel = %q", got)
 	}
 }

--- a/internal/telosd/session_bootstrap_test.go
+++ b/internal/telosd/session_bootstrap_test.go
@@ -159,6 +159,25 @@ func TestCloudSessionModelUsesBifrostFallback(t *testing.T) {
 	}
 }
 
+func TestCloudSessionModelMigratesLegacyOverrideWithBifrost(t *testing.T) {
+	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", legacyCloudSessionModel)
+	t.Setenv(cloudBifrostEnabledEnvVar, "1")
+
+	if got := cloudSessionModel(); got != bifrostCloudSessionModel {
+		t.Fatalf("cloudSessionModel = %q want %q", got, bifrostCloudSessionModel)
+	}
+}
+
+func TestCloudSessionModelPreservesCustomOverrideWithBifrost(t *testing.T) {
+	const customModel = "telos-bifrost/standard-compaction"
+	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", customModel)
+	t.Setenv(cloudBifrostEnabledEnvVar, "1")
+
+	if got := cloudSessionModel(); got != customModel {
+		t.Fatalf("cloudSessionModel = %q want %q", got, customModel)
+	}
+}
+
 func TestCloudSessionModelUsesLegacyFallbackWithoutBifrostExtension(t *testing.T) {
 	t.Setenv("TELOS_CLOUD_DEFAULT_MODEL", "")
 	t.Setenv(cloudBifrostEnabledEnvVar, "")


### PR DESCRIPTION
## Summary

- change the hosted `telosd` session fallback from the direct SailResearch model to `telos-bifrost/standard-agent`
- preserve explicit `TELOS_CLOUD_DEFAULT_MODEL` overrides
- add coverage for the Bifrost fallback

## Deployment contract

This is a coordinated fallback change, not a direct-provider compatibility layer. Existing Cloud releases continue to win through their explicit `TELOS_CLOUD_DEFAULT_MODEL`; the Bifrost fallback is used only when that override is absent. Roll it out with the matching Cloud provider extension, authenticated gateway configuration, and gateway health checks. Rollback must restore the prior Cloud image and runtime manifests together because new runtimes intentionally contain no direct-provider credentials.

## Validation

- `go test ./...`

## Related rollout

The authoritative gateway desired state is in `telos-org/assets#1`; Cloud credential propagation, health/auth smokes, and rollback instructions are in `telos-org/cloud#50`. Do not roll out this PR as a standalone model-routing change.
