### PR TITLE
feat(cli): add cloud context configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,20 @@ controller session that keeps reconciling desired state.
 
 ```bash
 telos login
+telos config --context @your-org
 telos apply SPEC.md
 telos list --cloud
+```
+
+Cloud commands run in the configured personal, team, or platform context.
+Use `telos config` to show the active context and `telos config --context
+@your-org` to switch it. Omit the context configuration to use your personal
+context; `telos config --context personal` clears a stored organization
+selection. `TELOS_CONTEXT` overrides the stored context for a single command
+or process:
+
+```bash
+TELOS_CONTEXT=@your-org telos list --cloud
 ```
 
 Hosted deployments pin their effective model when they are created. Override

--- a/cmd/telos/config.go
+++ b/cmd/telos/config.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/telos-org/telos/internal/cloud"
+	"github.com/telos-org/telos/internal/config"
+)
+
+func cmdConfig(args []string) {
+	fs := flag.NewFlagSet("config", flag.ExitOnError)
+	contextValue := fs.String(
+		"context",
+		"",
+		"Cloud context as @handle, organization ID, or personal",
+	)
+	parseFlags(fs, args)
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: telos config [--context @handle]")
+		os.Exit(2)
+	}
+
+	effective := config.LoadConfig()
+	if flagNameSet(fs, "context") {
+		setContext(effective, *contextValue)
+		return
+	}
+	printConfig(effective)
+}
+
+func setContext(effective *config.Config, value string) {
+	if strings.TrimSpace(value) == "" {
+		fmt.Fprintln(
+			os.Stderr,
+			"error: --context requires @handle, organization ID, or personal",
+		)
+		os.Exit(2)
+	}
+	client, err := configClient(effective)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	organization, err := client.ResolveContext(value)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	stored := config.LoadStoredConfig()
+	if strings.TrimSpace(value) == "personal" {
+		stored.Context = ""
+	} else {
+		stored.Context = organization.ID
+	}
+	if err := config.SaveConfig(stored); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("context set to %s\n", organization.ContextName())
+	if os.Getenv(config.ContextEnv) != "" {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: %s still overrides the stored context\n",
+			config.ContextEnv,
+		)
+	}
+}
+
+func printConfig(cfg *config.Config) {
+	endpoint := cfg.APIEndpoint
+	if endpoint == "" {
+		endpoint = cloud.DefaultAPIEndpoint
+	}
+	contextName := strings.TrimSpace(cfg.Context)
+	if contextName == "" {
+		contextName = "personal"
+	}
+	if cfg.AuthToken != "" {
+		if client, err := configClient(cfg); err == nil {
+			if organization, err := client.ResolveContext(cfg.Context); err == nil {
+				contextName = organization.ContextName()
+			}
+		}
+	}
+
+	authenticated := "no"
+	if cfg.AuthToken != "" {
+		authenticated = "yes"
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(w, "Endpoint\t%s\n", endpoint)
+	fmt.Fprintf(w, "Authenticated\t%s\n", authenticated)
+	fmt.Fprintf(w, "Context\t%s\n", contextName)
+	_ = w.Flush()
+}
+
+func configClient(cfg *config.Config) (*cloud.Client, error) {
+	if cfg.AuthToken == "" {
+		return nil, fmt.Errorf("not logged in; run `telos login` first")
+	}
+	endpoint := cfg.APIEndpoint
+	if endpoint == "" {
+		endpoint = cloud.DefaultAPIEndpoint
+	}
+	return cloud.NewClient(endpoint, cfg.AuthToken), nil
+}

--- a/cmd/telos/config.go
+++ b/cmd/telos/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -24,15 +25,23 @@ func cmdConfig(args []string) {
 		os.Exit(2)
 	}
 
-	effective := config.LoadConfig()
 	if flagNameSet(fs, "context") {
-		setContext(effective, *contextValue)
+		for _, name := range []string{config.APIEndpointEnv, config.AuthTokenEnv} {
+			if os.Getenv(name) != "" {
+				fmt.Fprintf(
+					os.Stderr,
+					"warning: %s is ignored when updating stored context\n",
+					name,
+				)
+			}
+		}
+		setContext(config.LoadStoredConfig(), *contextValue)
 		return
 	}
-	printConfig(effective)
+	printConfig(config.LoadConfig())
 }
 
-func setContext(effective *config.Config, value string) {
+func setContext(stored *config.Config, value string) {
 	if strings.TrimSpace(value) == "" {
 		fmt.Fprintln(
 			os.Stderr,
@@ -40,20 +49,26 @@ func setContext(effective *config.Config, value string) {
 		)
 		os.Exit(2)
 	}
-	client, err := configClient(effective)
+	client, err := configClient(stored)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	organization, err := client.ResolveContext(value)
+	account, err := client.AccountBootstrap()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	organization, err := account.ResolveContext(value)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	stored := config.LoadStoredConfig()
-	if strings.TrimSpace(value) == "personal" {
+	contextName := organization.ContextName()
+	if organization.ID == account.PersonalOrgID {
 		stored.Context = ""
+		contextName = "personal"
 	} else {
 		stored.Context = organization.ID
 	}
@@ -61,7 +76,7 @@ func setContext(effective *config.Config, value string) {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("context set to %s\n", organization.ContextName())
+	fmt.Printf("context set to %s\n", contextName)
 	if os.Getenv(config.ContextEnv) != "" {
 		fmt.Fprintf(
 			os.Stderr,
@@ -80,22 +95,42 @@ func printConfig(cfg *config.Config) {
 	if contextName == "" {
 		contextName = "personal"
 	}
+	authentication := "not configured"
+	var statusError error
 	if cfg.AuthToken != "" {
-		if client, err := configClient(cfg); err == nil {
-			if organization, err := client.ResolveContext(cfg.Context); err == nil {
-				contextName = organization.ContextName()
+		authentication = "unavailable"
+		client, err := configClient(cfg)
+		if err != nil {
+			statusError = err
+		} else {
+			account, err := client.AccountBootstrap()
+			if err != nil {
+				statusError = err
+				if cloud.IsStatus(err, http.StatusUnauthorized) ||
+					cloud.IsStatus(err, http.StatusForbidden) {
+					authentication = "invalid"
+				}
+			} else {
+				authentication = "valid"
+				organization, err := account.ResolveContext(cfg.Context)
+				if err != nil {
+					statusError = err
+				} else if organization.ID == account.PersonalOrgID {
+					contextName = "personal"
+				} else {
+					contextName = organization.ContextName()
+				}
 			}
 		}
 	}
 
-	authenticated := "no"
-	if cfg.AuthToken != "" {
-		authenticated = "yes"
-	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintf(w, "Endpoint\t%s\n", endpoint)
-	fmt.Fprintf(w, "Authenticated\t%s\n", authenticated)
+	fmt.Fprintf(w, "Authentication\t%s\n", authentication)
 	fmt.Fprintf(w, "Context\t%s\n", contextName)
+	if statusError != nil {
+		fmt.Fprintf(w, "Error\t%v\n", statusError)
+	}
 	_ = w.Flush()
 }
 

--- a/cmd/telos/config_test.go
+++ b/cmd/telos/config_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/telos-org/telos/internal/config"
+)
+
+func TestCmdConfigSetsContextAndPreservesLogin(t *testing.T) {
+	server := accountBootstrapServer(t)
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	t.Setenv(config.APIEndpointEnv, "")
+	t.Setenv(config.AuthTokenEnv, "")
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: server.URL,
+		AuthToken:   "test-token",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdConfig([]string{"--context", "@telos"})
+	})
+	if !strings.Contains(out, "context set to @telos") {
+		t.Fatalf("output = %q", out)
+	}
+	stored := config.LoadStoredConfig()
+	if stored.Context != "org_telos" {
+		t.Fatalf("context = %q", stored.Context)
+	}
+	if stored.APIEndpoint != server.URL || stored.AuthToken != "test-token" {
+		t.Fatalf("login config changed: %#v", stored)
+	}
+}
+
+func TestCmdConfigShowsResolvedContextWithoutToken(t *testing.T) {
+	server := accountBootstrapServer(t)
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	t.Setenv(config.APIEndpointEnv, "")
+	t.Setenv(config.AuthTokenEnv, "")
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: server.URL,
+		AuthToken:   "test-token",
+		Context:     "org_telos",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdConfig(nil)
+	})
+	for _, want := range []string{server.URL, "Authenticated", "yes", "Context", "@telos"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q does not contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "test-token") {
+		t.Fatalf("output leaked auth token: %q", out)
+	}
+}
+
+func TestCmdConfigClearsContextForPersonalDefault(t *testing.T) {
+	server := accountBootstrapServer(t)
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	t.Setenv(config.APIEndpointEnv, "")
+	t.Setenv(config.AuthTokenEnv, "")
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: server.URL,
+		AuthToken:   "test-token",
+		Context:     "org_telos",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	captureStdout(t, func() {
+		cmdConfig([]string{"--context", "personal"})
+	})
+	if got := config.LoadStoredConfig().Context; got != "" {
+		t.Fatalf("context = %q, want personal default", got)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "context:") {
+		t.Fatalf("personal config should omit context key:\n%s", data)
+	}
+}
+
+func TestCmdConfigShowsUnauthenticatedLocalValues(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	t.Setenv(config.APIEndpointEnv, "")
+	t.Setenv(config.AuthTokenEnv, "")
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{Context: "org_telos"}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdConfig(nil)
+	})
+	for _, want := range []string{"https://api.usetelos.ai", "no", "org_telos"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output %q does not contain %q", out, want)
+		}
+	}
+}
+
+func accountBootstrapServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/account/bootstrap" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"personal_org_id": "org_personal",
+			"organizations": [
+				{"id":"org_personal","handle":"grohan","display_name":"Rohan","kind":"personal","role":"owner","default_publish_scope":"grohan"},
+				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner","default_publish_scope":"telos"}
+			]
+		}`))
+	}))
+}

--- a/cmd/telos/config_test.go
+++ b/cmd/telos/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -42,7 +43,47 @@ func TestCmdConfigSetsContextAndPreservesLogin(t *testing.T) {
 	}
 }
 
-func TestCmdConfigShowsResolvedContextWithoutToken(t *testing.T) {
+func TestCmdConfigUsesStoredLoginForContextResolution(t *testing.T) {
+	storedServer := accountBootstrapServer(t)
+	defer storedServer.Close()
+
+	environmentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"personal_org_id": "org_environment_personal",
+			"organizations": [
+				{"id":"org_environment","handle":"telos","display_name":"Environment Telos","kind":"platform","role":"owner"}
+			]
+		}`))
+	}))
+	defer environmentServer.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: storedServer.URL,
+		AuthToken:   "test-token",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.APIEndpointEnv, environmentServer.URL)
+	t.Setenv(config.AuthTokenEnv, "environment-token")
+	t.Setenv(config.ContextEnv, "")
+
+	captureStdout(t, func() {
+		cmdConfig([]string{"--context", "@telos"})
+	})
+
+	stored := config.LoadStoredConfig()
+	if stored.Context != "org_telos" {
+		t.Fatalf("context = %q", stored.Context)
+	}
+	if stored.APIEndpoint != storedServer.URL || stored.AuthToken != "test-token" {
+		t.Fatalf("login config changed: %#v", stored)
+	}
+}
+
+func TestCmdConfigShowsResolvedContextWithoutExposingToken(t *testing.T) {
 	server := accountBootstrapServer(t)
 	defer server.Close()
 
@@ -62,45 +103,90 @@ func TestCmdConfigShowsResolvedContextWithoutToken(t *testing.T) {
 	out := captureStdout(t, func() {
 		cmdConfig(nil)
 	})
-	for _, want := range []string{server.URL, "Authenticated", "yes", "Context", "@telos"} {
+	for _, want := range []string{server.URL, "Context", "@telos"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output %q does not contain %q", out, want)
 		}
+	}
+	if got := configOutputValue(t, out, "Authentication"); got != "valid" {
+		t.Fatalf("authentication = %q", got)
 	}
 	if strings.Contains(out, "test-token") {
 		t.Fatalf("output leaked auth token: %q", out)
 	}
 }
 
-func TestCmdConfigClearsContextForPersonalDefault(t *testing.T) {
+func TestCmdConfigClearsResolvedPersonalContext(t *testing.T) {
 	server := accountBootstrapServer(t)
 	defer server.Close()
 
-	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	t.Setenv(config.ConfigPathEnv, configPath)
-	t.Setenv(config.APIEndpointEnv, "")
-	t.Setenv(config.AuthTokenEnv, "")
-	t.Setenv(config.ContextEnv, "")
-	if err := config.SaveConfig(&config.Config{
-		APIEndpoint: server.URL,
-		AuthToken:   "test-token",
-		Context:     "org_telos",
-	}); err != nil {
-		t.Fatal(err)
-	}
+	for _, value := range []string{"personal", "@grohan", "org_personal"} {
+		t.Run(value, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			t.Setenv(config.ConfigPathEnv, configPath)
+			t.Setenv(config.APIEndpointEnv, "")
+			t.Setenv(config.AuthTokenEnv, "")
+			t.Setenv(config.ContextEnv, "")
+			if err := config.SaveConfig(&config.Config{
+				APIEndpoint: server.URL,
+				AuthToken:   "test-token",
+				Context:     "org_telos",
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	captureStdout(t, func() {
-		cmdConfig([]string{"--context", "personal"})
-	})
-	if got := config.LoadStoredConfig().Context; got != "" {
-		t.Fatalf("context = %q, want personal default", got)
+			out := captureStdout(t, func() {
+				cmdConfig([]string{"--context", value})
+			})
+			if !strings.Contains(out, "context set to personal") {
+				t.Fatalf("output = %q", out)
+			}
+			if got := config.LoadStoredConfig().Context; got != "" {
+				t.Fatalf("context = %q, want personal default", got)
+			}
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(data), "context:") {
+				t.Fatalf("personal config should omit context key:\n%s", data)
+			}
+		})
 	}
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(data), "context:") {
-		t.Fatalf("personal config should omit context key:\n%s", data)
+}
+
+func TestCmdConfigSurfacesAuthenticationFailure(t *testing.T) {
+	for _, statusCode := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, `{"detail":"token rejected"}`, statusCode)
+			}))
+			defer server.Close()
+
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			t.Setenv(config.ConfigPathEnv, configPath)
+			t.Setenv(config.APIEndpointEnv, "")
+			t.Setenv(config.AuthTokenEnv, "")
+			t.Setenv(config.ContextEnv, "")
+			if err := config.SaveConfig(&config.Config{
+				APIEndpoint: server.URL,
+				AuthToken:   "rejected-token",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			out := captureStdout(t, func() {
+				cmdConfig(nil)
+			})
+			if got := configOutputValue(t, out, "Authentication"); got != "invalid" {
+				t.Fatalf("authentication = %q", got)
+			}
+			for _, want := range []string{"token rejected", fmt.Sprintf("HTTP %d", statusCode)} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("output %q does not contain %q", out, want)
+				}
+			}
+		})
 	}
 }
 
@@ -117,7 +203,7 @@ func TestCmdConfigShowsUnauthenticatedLocalValues(t *testing.T) {
 	out := captureStdout(t, func() {
 		cmdConfig(nil)
 	})
-	for _, want := range []string{"https://api.usetelos.ai", "no", "org_telos"} {
+	for _, want := range []string{"https://api.usetelos.ai", "not configured", "org_telos"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output %q does not contain %q", out, want)
 		}
@@ -137,9 +223,21 @@ func accountBootstrapServer(t *testing.T) *httptest.Server {
 		_, _ = w.Write([]byte(`{
 			"personal_org_id": "org_personal",
 			"organizations": [
-				{"id":"org_personal","handle":"grohan","display_name":"Rohan","kind":"personal","role":"owner","default_publish_scope":"grohan"},
+				{"id":"org_personal","handle":"grohan","display_name":"Rohan","role":"owner","default_publish_scope":"grohan"},
 				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner","default_publish_scope":"telos"}
 			]
 		}`))
 	}))
+}
+
+func configOutputValue(t *testing.T, output, label string) string {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == label {
+			return strings.Join(fields[1:], " ")
+		}
+	}
+	t.Fatalf("output %q has no %s row", output, label)
+	return ""
 }

--- a/cmd/telos/logout.go
+++ b/cmd/telos/logout.go
@@ -15,26 +15,27 @@ func cmdLogout(args []string) {
 	fs := flag.NewFlagSet("logout", flag.ExitOnError)
 	parseFlags(fs, args)
 
-	cfg := config.LoadConfig()
-	if cfg.AuthToken == "" {
+	effective := config.LoadConfig()
+	if effective.AuthToken == "" {
 		fmt.Println("not logged in")
 		return
 	}
 	if os.Getenv(config.AuthTokenEnv) != "" {
 		fmt.Fprintf(os.Stderr, "warning: %s is set; unset it to fully log out\n", config.AuthTokenEnv)
-	} else if tokenID := cloud.APITokenID(cfg.AuthToken); tokenID != "" {
-		endpoint := cfg.APIEndpoint
+	} else if tokenID := cloud.APITokenID(effective.AuthToken); tokenID != "" {
+		endpoint := effective.APIEndpoint
 		if endpoint == "" {
 			endpoint = cloud.DefaultAPIEndpoint
 		}
 		// Best-effort server-side revoke so the credential dies with the login.
-		if err := cloud.NewClient(endpoint, cfg.AuthToken).RevokeAPIToken(tokenID); err != nil {
+		if err := cloud.NewClient(endpoint, effective.AuthToken).RevokeAPIToken(tokenID); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: token not revoked server-side: %v\n", err)
 		}
 	}
 
-	cfg.AuthToken = ""
-	if err := config.SaveConfig(cfg); err != nil {
+	stored := config.LoadStoredConfig()
+	stored.AuthToken = ""
+	if err := config.SaveConfig(stored); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/telos/logout_test.go
+++ b/cmd/telos/logout_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/telos-org/telos/internal/config"
+)
+
+func TestLogoutDoesNotPersistEnvironmentOverrides(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: "https://stored.example.com",
+		AuthToken:   "stored-token",
+		Context:     "org_stored",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(config.APIEndpointEnv, "https://environment.example.com")
+	t.Setenv(config.AuthTokenEnv, "environment-token")
+	t.Setenv(config.ContextEnv, "@environment")
+
+	cmdLogout(nil)
+
+	stored := config.LoadStoredConfig()
+	if stored.AuthToken != "" {
+		t.Fatalf("stored token was not cleared")
+	}
+	if stored.APIEndpoint != "https://stored.example.com" {
+		t.Fatalf("endpoint = %q", stored.APIEndpoint)
+	}
+	if stored.Context != "org_stored" {
+		t.Fatalf("context = %q", stored.Context)
+	}
+}

--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -13,6 +13,7 @@
 //	telos delete SESSION [--json]
 //	telos login [--endpoint URL]
 //	telos logout
+//	telos config [--context @handle]
 //	telos version
 //	telos --version
 package main
@@ -63,6 +64,8 @@ func main() {
 		cmdLogin(os.Args[2:])
 	case "logout":
 		cmdLogout(os.Args[2:])
+	case "config":
+		cmdConfig(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		usage(os.Stderr)
@@ -88,6 +91,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  delete SESSION     Delete a session (local history is preserved)")
 	fmt.Fprintln(out, "  login              Log in to Telos Cloud via the browser")
 	fmt.Fprintln(out, "  logout             Log out and revoke this device's token")
+	fmt.Fprintln(out, "  config             Show or update CLI configuration")
 	fmt.Fprintln(out, "  version            Show version")
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "global flags:")

--- a/internal/cloud/BUILD.bazel
+++ b/internal/cloud/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "cloud",
     srcs = [
+        "account.go",
         "cliauth.go",
         "client.go",
     ],
@@ -17,9 +18,13 @@ go_library(
 go_test(
     name = "cloud_test",
     srcs = [
+        "account_test.go",
         "cliauth_test.go",
         "client_test.go",
     ],
     embed = [":cloud"],
-    deps = ["//internal/sessionapi"],
+    deps = [
+        "//internal/config",
+        "//internal/sessionapi",
+    ],
 )

--- a/internal/cloud/account.go
+++ b/internal/cloud/account.go
@@ -1,0 +1,71 @@
+package cloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type OrganizationRecord struct {
+	ID                  string  `json:"id"`
+	Handle              *string `json:"handle"`
+	DisplayName         string  `json:"display_name"`
+	Kind                string  `json:"kind"`
+	Role                string  `json:"role"`
+	DefaultPublishScope *string `json:"default_publish_scope"`
+}
+
+type AccountBootstrapRecord struct {
+	PersonalOrgID string               `json:"personal_org_id"`
+	Organizations []OrganizationRecord `json:"organizations"`
+}
+
+func (c *Client) AccountBootstrap() (*AccountBootstrapRecord, error) {
+	resp, err := c.do("GET", "/api/account/bootstrap", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+	var account AccountBootstrapRecord
+	if err := json.NewDecoder(resp.Body).Decode(&account); err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (c *Client) ResolveContext(value string) (*OrganizationRecord, error) {
+	account, err := c.AccountBootstrap()
+	if err != nil {
+		return nil, err
+	}
+	return account.ResolveContext(value)
+}
+
+func (account *AccountBootstrapRecord) ResolveContext(value string) (*OrganizationRecord, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "personal" {
+		value = account.PersonalOrgID
+	}
+
+	for i := range account.Organizations {
+		organization := &account.Organizations[i]
+		if organization.ID == value {
+			return organization, nil
+		}
+		if organization.Handle != nil && value == "@"+*organization.Handle {
+			return organization, nil
+		}
+	}
+	return nil, fmt.Errorf("context %q is unavailable to this account", value)
+}
+
+func (organization *OrganizationRecord) ContextName() string {
+	if organization.Handle != nil && *organization.Handle != "" {
+		return "@" + *organization.Handle
+	}
+	return organization.ID
+}

--- a/internal/cloud/account_test.go
+++ b/internal/cloud/account_test.go
@@ -1,0 +1,78 @@
+package cloud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAccountBootstrap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/account/bootstrap" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"personal_org_id": "org_personal",
+			"organizations": [
+				{"id":"org_personal","handle":"grohan","display_name":"Rohan","kind":"personal","role":"owner","default_publish_scope":"grohan"},
+				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner","default_publish_scope":"telos"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	account, err := NewClient(server.URL, "test-token").AccountBootstrap()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.PersonalOrgID != "org_personal" || len(account.Organizations) != 2 {
+		t.Fatalf("account = %#v", account)
+	}
+}
+
+func TestResolveContext(t *testing.T) {
+	personalHandle := "grohan"
+	platformHandle := "telos"
+	account := AccountBootstrapRecord{
+		PersonalOrgID: "org_personal",
+		Organizations: []OrganizationRecord{
+			{ID: "org_personal", Handle: &personalHandle},
+			{ID: "org_telos", Handle: &platformHandle},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		context string
+		want    string
+		wantErr bool
+	}{
+		{name: "implicit personal", want: "org_personal"},
+		{name: "explicit personal", context: "personal", want: "org_personal"},
+		{name: "handle", context: "@telos", want: "org_telos"},
+		{name: "stable id", context: "org_telos", want: "org_telos"},
+		{name: "unknown handle", context: "@missing", wantErr: true},
+		{name: "unrecognized value", context: "telos", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			organization, err := account.ResolveContext(tt.context)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if organization.ID != tt.want {
+				t.Fatalf("organization = %q, want %q", organization.ID, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -170,7 +170,19 @@ func ControlClient() (*Client, error) {
 		return nil, fmt.Errorf("not logged in; run `telos login` first")
 	}
 	client := NewClient(endpoint, token)
-	client.OrgID = cfg.OrgID
+	context := strings.TrimSpace(cfg.Context)
+	if context == "" || context == "personal" {
+		return client, nil
+	}
+	if strings.HasPrefix(context, "org_") {
+		client.OrgID = context
+		return client, nil
+	}
+	organization, err := client.ResolveContext(context)
+	if err != nil {
+		return nil, err
+	}
+	client.OrgID = organization.ID
 	return client, nil
 }
 

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/telos-org/telos/internal/config"
@@ -158,6 +159,12 @@ func NewClient(endpoint, token string) *Client {
 	}
 }
 
+// resolvedContexts memoizes successful handle resolutions for the life of
+// the process, keyed by endpoint, token, and context so distinct identities
+// never share an entry. Failures are not cached so transient errors stay
+// retryable.
+var resolvedContexts sync.Map
+
 // ControlClient returns a client for the configured Telos control plane.
 func ControlClient() (*Client, error) {
 	cfg := config.LoadConfig()
@@ -178,10 +185,16 @@ func ControlClient() (*Client, error) {
 		client.OrgID = context
 		return client, nil
 	}
+	key := client.Endpoint + "\x00" + token + "\x00" + context
+	if orgID, ok := resolvedContexts.Load(key); ok {
+		client.OrgID = orgID.(string)
+		return client, nil
+	}
 	organization, err := client.ResolveContext(context)
 	if err != nil {
 		return nil, err
 	}
+	resolvedContexts.Store(key, organization.ID)
 	client.OrgID = organization.ID
 	return client, nil
 }

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/telos-org/telos/internal/config"
 	"github.com/telos-org/telos/internal/sessionapi"
 )
 
@@ -28,6 +30,49 @@ func TestNormalizeEndpoint(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("NormalizeEndpoint(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
+	}
+}
+
+func TestControlClientResolvesHandleContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/account/bootstrap" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"personal_org_id":"org_personal",
+			"organizations":[
+				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv(config.APIEndpointEnv, srv.URL)
+	t.Setenv(config.AuthTokenEnv, "test-token")
+	t.Setenv(config.ContextEnv, "@telos")
+
+	client, err := ControlClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.OrgID != "org_telos" {
+		t.Fatalf("OrgID = %q", client.OrgID)
+	}
+}
+
+func TestControlClientUsesStableContextWithoutLookup(t *testing.T) {
+	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv(config.APIEndpointEnv, "https://api.example.com")
+	t.Setenv(config.AuthTokenEnv, "test-token")
+	t.Setenv(config.ContextEnv, "org_telos")
+
+	client, err := ControlClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.OrgID != "org_telos" {
+		t.Fatalf("OrgID = %q", client.OrgID)
 	}
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -61,6 +61,38 @@ func TestControlClientResolvesHandleContext(t *testing.T) {
 	}
 }
 
+func TestControlClientCachesHandleResolution(t *testing.T) {
+	bootstraps := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bootstraps++
+		_, _ = w.Write([]byte(`{
+			"personal_org_id":"org_personal",
+			"organizations":[
+				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv(config.APIEndpointEnv, srv.URL)
+	t.Setenv(config.AuthTokenEnv, "test-token")
+	t.Setenv(config.ContextEnv, "@telos")
+
+	for i := 0; i < 2; i++ {
+		client, err := ControlClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if client.OrgID != "org_telos" {
+			t.Fatalf("OrgID = %q", client.OrgID)
+		}
+	}
+	if bootstraps != 1 {
+		t.Fatalf("bootstrap requests = %d, want 1", bootstraps)
+	}
+}
+
 func TestControlClientUsesStableContextWithoutLookup(t *testing.T) {
 	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
 	t.Setenv(config.APIEndpointEnv, "https://api.example.com")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,14 @@ const (
 	ConfigPathEnv  = "TELOS_CONFIG"
 	APIEndpointEnv = "TELOS_API_ENDPOINT"
 	AuthTokenEnv   = "TELOS_AUTH_TOKEN"
-	OrgIDEnv       = "TELOS_ORG_ID"
+	ContextEnv     = "TELOS_CONTEXT"
 )
 
 // Config holds user-facing cloud CLI configuration.
 type Config struct {
 	APIEndpoint string `yaml:"api_endpoint,omitempty"`
 	AuthToken   string `yaml:"auth_token,omitempty"`
-	OrgID       string `yaml:"org_id,omitempty"`
+	Context     string `yaml:"context,omitempty"`
 }
 
 // ConfigPath returns the path to the active config file.
@@ -41,8 +41,8 @@ func LoadStoredConfig() *Config {
 	if at, ok := raw["auth_token"].(string); ok {
 		cfg.AuthToken = at
 	}
-	if orgID, ok := raw["org_id"].(string); ok {
-		cfg.OrgID = orgID
+	if context, ok := raw["context"].(string); ok {
+		cfg.Context = context
 	}
 	return cfg
 }
@@ -56,8 +56,8 @@ func LoadConfig() *Config {
 	if v := os.Getenv(AuthTokenEnv); v != "" {
 		cfg.AuthToken = v
 	}
-	if v := os.Getenv(OrgIDEnv); v != "" {
-		cfg.OrgID = v
+	if v := os.Getenv(ContextEnv); v != "" {
+		cfg.Context = v
 	}
 	return cfg
 }
@@ -75,8 +75,8 @@ func SaveConfig(cfg *Config) error {
 	if cfg.AuthToken != "" {
 		m["auth_token"] = cfg.AuthToken
 	}
-	if cfg.OrgID != "" {
-		m["org_id"] = cfg.OrgID
+	if cfg.Context != "" {
+		m["context"] = cfg.Context
 	}
 	data, err := yaml.Marshal(m)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,11 +9,12 @@ import (
 func TestLoadConfigFromFile(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	os.WriteFile(cfgPath, []byte("api_endpoint: https://test.example.com\nauth_token: secret123\norg_id: org_telos\n"), 0o644)
+	os.WriteFile(cfgPath, []byte("api_endpoint: https://test.example.com\nauth_token: secret123\ncontext: org_telos\n"), 0o644)
 
 	t.Setenv("TELOS_CONFIG", cfgPath)
 	t.Setenv("TELOS_API_ENDPOINT", "")
 	t.Setenv("TELOS_AUTH_TOKEN", "")
+	t.Setenv("TELOS_CONTEXT", "")
 
 	cfg := LoadConfig()
 	if cfg.APIEndpoint != "https://test.example.com" {
@@ -22,20 +23,20 @@ func TestLoadConfigFromFile(t *testing.T) {
 	if cfg.AuthToken != "secret123" {
 		t.Errorf("token: got %q", cfg.AuthToken)
 	}
-	if cfg.OrgID != "org_telos" {
-		t.Errorf("org id: got %q", cfg.OrgID)
+	if cfg.Context != "org_telos" {
+		t.Errorf("context: got %q", cfg.Context)
 	}
 }
 
 func TestLoadConfigEnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	os.WriteFile(cfgPath, []byte("api_endpoint: https://file.example.com\nauth_token: file-token\norg_id: org_file\n"), 0o644)
+	os.WriteFile(cfgPath, []byte("api_endpoint: https://file.example.com\nauth_token: file-token\ncontext: org_file\n"), 0o644)
 
 	t.Setenv("TELOS_CONFIG", cfgPath)
 	t.Setenv("TELOS_API_ENDPOINT", "https://env.example.com")
 	t.Setenv("TELOS_AUTH_TOKEN", "env-token")
-	t.Setenv("TELOS_ORG_ID", "org_env")
+	t.Setenv("TELOS_CONTEXT", "@env")
 
 	cfg := LoadConfig()
 	if cfg.APIEndpoint != "https://env.example.com" {
@@ -44,20 +45,20 @@ func TestLoadConfigEnvOverride(t *testing.T) {
 	if cfg.AuthToken != "env-token" {
 		t.Errorf("token: got %q (should be env override)", cfg.AuthToken)
 	}
-	if cfg.OrgID != "org_env" {
-		t.Errorf("org id: got %q (should be env override)", cfg.OrgID)
+	if cfg.Context != "@env" {
+		t.Errorf("context: got %q (should be env override)", cfg.Context)
 	}
 }
 
 func TestLoadStoredConfigIgnoresEnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
-	os.WriteFile(cfgPath, []byte("api_endpoint: https://file.example.com\nauth_token: file-token\norg_id: org_file\n"), 0o644)
+	os.WriteFile(cfgPath, []byte("api_endpoint: https://file.example.com\nauth_token: file-token\ncontext: org_file\n"), 0o644)
 
 	t.Setenv("TELOS_CONFIG", cfgPath)
 	t.Setenv("TELOS_API_ENDPOINT", "https://env.example.com")
 	t.Setenv("TELOS_AUTH_TOKEN", "env-token")
-	t.Setenv("TELOS_ORG_ID", "org_env")
+	t.Setenv("TELOS_CONTEXT", "@env")
 
 	cfg := LoadStoredConfig()
 	if cfg.APIEndpoint != "https://file.example.com" {
@@ -66,8 +67,8 @@ func TestLoadStoredConfigIgnoresEnvOverride(t *testing.T) {
 	if cfg.AuthToken != "file-token" {
 		t.Errorf("token: got %q", cfg.AuthToken)
 	}
-	if cfg.OrgID != "org_file" {
-		t.Errorf("org id: got %q", cfg.OrgID)
+	if cfg.Context != "org_file" {
+		t.Errorf("context: got %q", cfg.Context)
 	}
 }
 
@@ -75,10 +76,23 @@ func TestLoadConfigMissing(t *testing.T) {
 	t.Setenv("TELOS_CONFIG", filepath.Join(t.TempDir(), "nonexistent.yaml"))
 	t.Setenv("TELOS_API_ENDPOINT", "")
 	t.Setenv("TELOS_AUTH_TOKEN", "")
+	t.Setenv("TELOS_CONTEXT", "")
 
 	cfg := LoadConfig()
 	if cfg.APIEndpoint != "" {
 		t.Errorf("expected empty endpoint, got %q", cfg.APIEndpoint)
+	}
+}
+
+func TestLoadConfigIgnoresRemovedOrganizationNames(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	os.WriteFile(cfgPath, []byte("org_id: org_legacy\n"), 0o644)
+	t.Setenv("TELOS_CONFIG", cfgPath)
+	t.Setenv("TELOS_CONTEXT", "")
+	t.Setenv("TELOS_ORG_ID", "org_env_legacy")
+
+	if got := LoadConfig().Context; got != "" {
+		t.Fatalf("removed organization config unexpectedly selected %q", got)
 	}
 }
 
@@ -88,11 +102,12 @@ func TestSaveAndLoadConfig(t *testing.T) {
 	t.Setenv("TELOS_CONFIG", cfgPath)
 	t.Setenv("TELOS_API_ENDPOINT", "")
 	t.Setenv("TELOS_AUTH_TOKEN", "")
+	t.Setenv("TELOS_CONTEXT", "")
 
 	err := SaveConfig(&Config{
 		APIEndpoint: "https://saved.example.com",
 		AuthToken:   "saved-token",
-		OrgID:       "org_saved",
+		Context:     "org_saved",
 	})
 	if err != nil {
 		t.Fatalf("SaveConfig: %v", err)
@@ -105,8 +120,8 @@ func TestSaveAndLoadConfig(t *testing.T) {
 	if cfg.AuthToken != "saved-token" {
 		t.Errorf("token: got %q", cfg.AuthToken)
 	}
-	if cfg.OrgID != "org_saved" {
-		t.Errorf("org id: got %q", cfg.OrgID)
+	if cfg.Context != "org_saved" {
+		t.Errorf("context: got %q", cfg.Context)
 	}
 }
 
@@ -114,6 +129,7 @@ func TestIsConfigured(t *testing.T) {
 	t.Setenv("TELOS_CONFIG", filepath.Join(t.TempDir(), "nonexistent.yaml"))
 	t.Setenv("TELOS_API_ENDPOINT", "")
 	t.Setenv("TELOS_AUTH_TOKEN", "")
+	t.Setenv("TELOS_CONTEXT", "")
 
 	if IsConfigured() {
 		t.Error("should not be configured with no file or env")


### PR DESCRIPTION
## Summary

- replace the user-facing org_id and TELOS_ORG_ID configuration with context and TELOS_CONTEXT
- add a flat telos config --context interface that resolves organization handles and stores stable IDs
- keep personal context implicit and remove the context key when personal is selected
- preserve the wire-level X-Telos-Org-Id header and avoid persisting environment overrides during logout

## Validation

- go test ./...
- go vet ./...
- bazel test //...
- read-only production smoke: TELOS_CONTEXT=@telos telos list --cloud