### PR TITLE
fix(cli): persist context handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ Cloud commands run in the configured personal, team, or platform context.
 Use `telos config` to show the active context and `telos config --context
 @your-org` to switch it. Omit the context configuration to use your personal
 context; `telos config --context personal` clears a stored organization
-selection. `TELOS_CONTEXT` overrides the stored context for a single command
-or process:
+selection. The stored configuration keeps the user-facing handle as
+`context: "@your-org"`; the CLI resolves its internal organization ID when
+sending requests. `TELOS_CONTEXT` overrides the stored context for a single
+command or process:
 
 ```bash
 TELOS_CONTEXT=@your-org telos list --cloud

--- a/cmd/telos/config.go
+++ b/cmd/telos/config.go
@@ -70,7 +70,7 @@ func setContext(stored *config.Config, value string) {
 		stored.Context = ""
 		contextName = "personal"
 	} else {
-		stored.Context = organization.ID
+		stored.Context = contextName
 	}
 	if err := config.SaveConfig(stored); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/telos/config_test.go
+++ b/cmd/telos/config_test.go
@@ -35,11 +35,45 @@ func TestCmdConfigSetsContextAndPreservesLogin(t *testing.T) {
 		t.Fatalf("output = %q", out)
 	}
 	stored := config.LoadStoredConfig()
-	if stored.Context != "org_telos" {
+	if stored.Context != "@telos" {
 		t.Fatalf("context = %q", stored.Context)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "@telos") ||
+		strings.Contains(string(data), "org_telos") {
+		t.Fatalf("stored config is not handle-based:\n%s", data)
 	}
 	if stored.APIEndpoint != server.URL || stored.AuthToken != "test-token" {
 		t.Fatalf("login config changed: %#v", stored)
+	}
+}
+
+func TestCmdConfigNormalizesOrganizationIDToHandle(t *testing.T) {
+	server := accountBootstrapServer(t)
+	defer server.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.ConfigPathEnv, configPath)
+	t.Setenv(config.APIEndpointEnv, "")
+	t.Setenv(config.AuthTokenEnv, "")
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{
+		APIEndpoint: server.URL,
+		AuthToken:   "test-token",
+		Context:     "org_telos",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	captureStdout(t, func() {
+		cmdConfig([]string{"--context", "org_telos"})
+	})
+
+	if got := config.LoadStoredConfig().Context; got != "@telos" {
+		t.Fatalf("context = %q", got)
 	}
 }
 
@@ -75,7 +109,7 @@ func TestCmdConfigUsesStoredLoginForContextResolution(t *testing.T) {
 	})
 
 	stored := config.LoadStoredConfig()
-	if stored.Context != "org_telos" {
+	if stored.Context != "@telos" {
 		t.Fatalf("context = %q", stored.Context)
 	}
 	if stored.APIEndpoint != storedServer.URL || stored.AuthToken != "test-token" {


### PR DESCRIPTION
store the user facing @<handle> names vs resolved internal ids