### PR TITLE
Exit logs -f cleanly when a followed deployment is deleted

### DIFF
--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"sort"
@@ -119,6 +120,11 @@ func streamCloudSessionLogs(
 
 		session, err := control.GetSession(sessionID)
 		if err != nil {
+			if cloud.IsStatus(err, http.StatusNotFound) {
+				// The control plane hard-deletes deployments once teardown
+				// completes; a session vanishing mid-follow means it finished.
+				return nil
+			}
 			return err
 		}
 		if cloudSessionStateTerminal(session.State) {

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -1330,6 +1330,28 @@ func TestFollowCloudSessionLogsStreamsEvents(t *testing.T) {
 	}
 }
 
+func TestFollowCloudSessionLogsExitsCleanWhenSessionDeleted(t *testing.T) {
+	// The control plane hard-deletes deployments once teardown completes:
+	// both /logs and the session GET 404. The follow loop should treat that
+	// as a clean end of the session, not an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	err := streamCloudSessionLogs(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		&out,
+		func(time.Duration) {},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("streamCloudSessionLogs after delete: %v", err)
+	}
+}
+
 func TestRootLookupReturnsClusterAPIError(t *testing.T) {
 	t.Setenv("TELOS_RUNTIME", "")
 	cluster := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Companion to telos-org/cloud#54 (deployments are hard-deleted once teardown is confirmed): when the `/logs` stream 404s and the fallback `GetSession` also 404s, `streamCloudSessionLogs` now returns cleanly instead of exiting 1 with `error: HTTP 404` — a deployment vanishing mid-follow means it finished tearing down.
- No behavior change for any other error: non-404 failures still propagate, and terminal states (`healthy`/`failed`/`deleted`) behave as before.

## Test plan
- New `TestFollowCloudSessionLogsExitsCleanWhenSessionDeleted`: httptest server 404s both endpoints; the follow loop returns nil.
- `go test ./cmd/telos/` fully passing; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuXHz74qFpfdXmstjSnR7u