### PR TITLE
Emit and honor starred skill locks in apply packages

### DIFF
--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -125,6 +125,26 @@ func TestPrintPlanPreviewCloud(t *testing.T) {
 	}
 }
 
+func TestPrintPlanPreviewStarsRequiredVerifierSkills(t *testing.T) {
+	verifyEngineering := &spec.Skill{Name: "verify-engineering"}
+	compiled := &spec.CompiledEnvironment{
+		Environment: &spec.EnvironmentSpec{Name: "gitea"},
+		ContentHash: "8a8f0c21",
+		Skills: []*spec.Skill{
+			verifyEngineering,
+			{Name: "verify-quality"},
+		},
+		RequiredVerifierSkills: []*spec.Skill{verifyEngineering},
+	}
+
+	var out bytes.Buffer
+	printPlanPreview(&out, compiled, "./SPEC.md", "local", "root")
+	text := out.String()
+	if !strings.Contains(text, "Skills    verify-engineering*, verify-quality") {
+		t.Fatalf("plan output missing starred skill marker:\n%s", text)
+	}
+}
+
 func TestReorderInterspersedFlagsDashDash(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.Bool("json", false, "")

--- a/cmd/telos/plan.go
+++ b/cmd/telos/plan.go
@@ -70,6 +70,9 @@ func cmdPlan(args []string) {
 			"namespace":    compiled.Namespace,
 			"lineage":      compiled.Lineage,
 			"skills":       skillNames(compiled.Skills),
+			"required_verifier_skills": skillNames(
+				compiled.RequiredVerifierSkills,
+			),
 		},
 		"session": map[string]interface{}{
 			"lineage":          sessionLineage,
@@ -108,7 +111,7 @@ func printPlanPreview(
 	}
 	printSummaryField(out, "Hash", compiled.ContentHash)
 	if len(compiled.Skills) > 0 {
-		printSummaryField(out, "Skills", strings.Join(skillNames(compiled.Skills), ", "))
+		printSummaryField(out, "Skills", strings.Join(skillDisplayNames(compiled), ", "))
 	}
 }
 
@@ -116,6 +119,24 @@ func skillNames(skills []*spec.Skill) []string {
 	var names []string
 	for _, s := range skills {
 		names = append(names, s.Name)
+	}
+	return names
+}
+
+// skillDisplayNames marks required verifier skills with the same trailing
+// star the spec frontmatter uses to declare them.
+func skillDisplayNames(compiled *spec.CompiledEnvironment) []string {
+	required := map[string]bool{}
+	for _, s := range compiled.RequiredVerifierSkills {
+		required[s.Name] = true
+	}
+	var names []string
+	for _, s := range compiled.Skills {
+		name := s.Name
+		if required[name] {
+			name += "*"
+		}
+		names = append(names, name)
 	}
 	return names
 }

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -2017,7 +2017,14 @@ func digestApplyPackage(data []byte, manifest *spec.ApplyPackageManifest) string
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		writeSpecDigestPart(h, name)
+		// Mirrors digestPackage: a starred (required-rubric) lock is part of
+		// package identity; the marker fires only when set so pre-starred
+		// digests stay stable.
+		if manifest.Skills[name].Starred {
+			writeSpecDigestPart(h, name+"*")
+		} else {
+			writeSpecDigestPart(h, name)
+		}
 		writeSpecDigestPart(h, manifest.Skills[name].Digest)
 	}
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))

--- a/internal/spec/compile.go
+++ b/internal/spec/compile.go
@@ -76,32 +76,6 @@ func compileEnv(envPath string, baseDir string, visited map[string]bool) (*Compi
 
 	packageSkillPaths, packageRequiredPaths, hasPackageManifest := packageManifestSkillPaths(compileBaseDir)
 
-	// Spec text is authoritative for skills it declares: a manifest star only
-	// applies to skills the spec itself does not list, so un-starring an
-	// entry in SPEC.md always wins over a previously recorded lock.
-	if len(packageRequiredPaths) > 0 && len(env.SkillPaths) > 0 {
-		declaredAbs := map[string]bool{}
-		declaredNames := map[string]bool{}
-		for _, path := range env.SkillPaths {
-			if abs, err := filepath.Abs(path); err == nil {
-				declaredAbs[abs] = true
-			}
-			declaredNames[filepath.Base(path)] = true
-		}
-		var filtered []string
-		for _, path := range packageRequiredPaths {
-			abs, err := filepath.Abs(path)
-			if err != nil {
-				continue
-			}
-			if declaredAbs[abs] || declaredNames[filepath.Base(path)] {
-				continue
-			}
-			filtered = append(filtered, path)
-		}
-		packageRequiredPaths = filtered
-	}
-
 	// Resolve skills
 	var declared []*Skill
 	skillPaths := appendMissingPaths(env.SkillPaths, packageSkillPaths)
@@ -111,6 +85,38 @@ func compileEnv(envPath string, baseDir string, visited map[string]bool) (*Compi
 			return nil, err
 		}
 		annotateSkillSourceRefs(declared, env.SkillSourceRefs)
+	}
+
+	// Spec text is authoritative for skills it declares: a manifest star only
+	// applies to skills the spec itself does not list, so un-starring an
+	// entry in SPEC.md always wins over a previously recorded lock. Both
+	// sides are matched by resolved skill name — SKILL.md may declare a name
+	// that differs from its directory, so paths alone cannot be trusted.
+	if len(packageRequiredPaths) > 0 && len(env.SkillPaths) > 0 {
+		specDeclaredAbs := map[string]bool{}
+		for _, path := range env.SkillPaths {
+			if abs, absErr := filepath.Abs(path); absErr == nil {
+				specDeclaredAbs[abs] = true
+			}
+		}
+		specDeclaredNames := map[string]bool{}
+		for _, s := range declared {
+			if abs, absErr := filepath.Abs(s.Path); absErr == nil && specDeclaredAbs[abs] {
+				specDeclaredNames[s.Name] = true
+			}
+		}
+		packageRequired, resolveErr := ResolveSkillsFromPaths(packageRequiredPaths)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		var filtered []string
+		for _, s := range packageRequired {
+			if specDeclaredNames[s.Name] {
+				continue
+			}
+			filtered = append(filtered, s.Path)
+		}
+		packageRequiredPaths = filtered
 	}
 	var required []*Skill
 	requiredPaths := appendMissingPaths(env.RequiredVerifierSkillPaths, packageRequiredPaths)

--- a/internal/spec/compile.go
+++ b/internal/spec/compile.go
@@ -249,7 +249,9 @@ func packageManifestSkillPaths(baseDir string) ([]string, []string, bool) {
 			continue
 		}
 		paths = append(paths, path)
-		if lock.Starred {
+		// A schema-1 starred lock is invalid (see validateApplyPackageFiles):
+		// ignore the flag rather than honor a star old readers would drop.
+		if lock.Starred && manifest.SchemaVersion >= ApplyPackageSchemaVersionStarred {
 			starred = append(starred, path)
 		}
 	}

--- a/internal/spec/compile.go
+++ b/internal/spec/compile.go
@@ -76,6 +76,32 @@ func compileEnv(envPath string, baseDir string, visited map[string]bool) (*Compi
 
 	packageSkillPaths, packageRequiredPaths, hasPackageManifest := packageManifestSkillPaths(compileBaseDir)
 
+	// Spec text is authoritative for skills it declares: a manifest star only
+	// applies to skills the spec itself does not list, so un-starring an
+	// entry in SPEC.md always wins over a previously recorded lock.
+	if len(packageRequiredPaths) > 0 && len(env.SkillPaths) > 0 {
+		declaredAbs := map[string]bool{}
+		declaredNames := map[string]bool{}
+		for _, path := range env.SkillPaths {
+			if abs, err := filepath.Abs(path); err == nil {
+				declaredAbs[abs] = true
+			}
+			declaredNames[filepath.Base(path)] = true
+		}
+		var filtered []string
+		for _, path := range packageRequiredPaths {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				continue
+			}
+			if declaredAbs[abs] || declaredNames[filepath.Base(path)] {
+				continue
+			}
+			filtered = append(filtered, path)
+		}
+		packageRequiredPaths = filtered
+	}
+
 	// Resolve skills
 	var declared []*Skill
 	skillPaths := appendMissingPaths(env.SkillPaths, packageSkillPaths)
@@ -207,7 +233,8 @@ func packageManifestSkillPaths(baseDir string) ([]string, []string, bool) {
 		return nil, nil, false
 	}
 	var paths []string
-	for name := range manifest.Skills {
+	var starred []string
+	for name, lock := range manifest.Skills {
 		if !dnsRE.MatchString(name) {
 			continue
 		}
@@ -216,8 +243,11 @@ func packageManifestSkillPaths(baseDir string) ([]string, []string, bool) {
 			continue
 		}
 		paths = append(paths, path)
+		if lock.Starred {
+			starred = append(starred, path)
+		}
 	}
-	return paths, nil, true
+	return paths, starred, true
 }
 
 func isApplyPackageManifest(manifest ApplyPackageManifest) bool {

--- a/internal/spec/compile.go
+++ b/internal/spec/compile.go
@@ -257,7 +257,7 @@ func packageManifestSkillPaths(baseDir string) ([]string, []string, bool) {
 }
 
 func isApplyPackageManifest(manifest ApplyPackageManifest) bool {
-	return manifest.SchemaVersion == ApplyPackageSchemaVersion &&
+	return applyPackageSchemaSupported(manifest.SchemaVersion) &&
 		strings.TrimSpace(manifest.Spec.Digest) != "" &&
 		manifest.Skills != nil
 }

--- a/internal/spec/package.go
+++ b/internal/spec/package.go
@@ -18,6 +18,28 @@ import (
 
 const ApplyPackageSchemaVersion = 1
 
+// ApplyPackageSchemaVersionStarred gates manifests whose skill locks carry the
+// starred (required-rubric) flag. Starred locks change runtime semantics and
+// are folded into the package digest; older runtimes would silently drop the
+// unknown field and mis-derive the digest, so those packages declare a schema
+// version that pre-starred readers reject outright ("unsupported apply
+// package schema_version") — an actionable upgrade signal instead of a
+// baffling digest mismatch on version-pinned deployments.
+const ApplyPackageSchemaVersionStarred = 2
+
+func applyPackageSchemaSupported(version int) bool {
+	return version == ApplyPackageSchemaVersion || version == ApplyPackageSchemaVersionStarred
+}
+
+func applyPackageSchemaVersionFor(skills map[string]ApplyPackageSkillLock) int {
+	for _, lock := range skills {
+		if lock.Starred {
+			return ApplyPackageSchemaVersionStarred
+		}
+	}
+	return ApplyPackageSchemaVersion
+}
+
 // ApplyPackage is an immutable bundle of the root spec and resolved skills.
 type ApplyPackage struct {
 	Digest   string
@@ -149,12 +171,13 @@ func BuildApplyPackageWithSkillRefs(compiled *CompiledEnvironment, skillRefs map
 			requiredNames[skill.Name] = true
 		}
 	}
+	skillLocks := skillLockMap(skillEntries, requiredNames)
 	manifest := ApplyPackageManifest{
-		SchemaVersion: ApplyPackageSchemaVersion,
+		SchemaVersion: applyPackageSchemaVersionFor(skillLocks),
 		Spec:          specEntry,
-		Skills:        skillLockMap(skillEntries, requiredNames),
+		Skills:        skillLocks,
 	}
-	packageDigest := digestPackage(specEntry.Digest, manifest.Skills)
+	packageDigest := digestPackage(manifest.SchemaVersion, specEntry.Digest, manifest.Skills)
 
 	manifestData, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -383,7 +406,7 @@ func validateApplyPackageFilesWithMode(manifest *ApplyPackageManifest, files map
 	if manifest == nil {
 		return fmt.Errorf("apply package missing manifest")
 	}
-	if manifest.SchemaVersion != ApplyPackageSchemaVersion {
+	if !applyPackageSchemaSupported(manifest.SchemaVersion) {
 		return fmt.Errorf("unsupported apply package schema_version %d", manifest.SchemaVersion)
 	}
 	specFile, ok := files["SPEC.md"]
@@ -774,9 +797,9 @@ func relativePathWithin(root string, path string) (string, bool) {
 	return filepath.ToSlash(rel), true
 }
 
-func digestPackage(specDigest string, skills map[string]ApplyPackageSkillLock) string {
+func digestPackage(schemaVersion int, specDigest string, skills map[string]ApplyPackageSkillLock) string {
 	h := sha256.New()
-	writeDigestPart(h, fmt.Sprintf("schema:%d", ApplyPackageSchemaVersion))
+	writeDigestPart(h, fmt.Sprintf("schema:%d", schemaVersion))
 	writeDigestPart(h, "spec:"+specDigest)
 	names := make([]string, 0, len(skills))
 	for name := range skills {

--- a/internal/spec/package.go
+++ b/internal/spec/package.go
@@ -37,8 +37,9 @@ type ApplyPackageSkillEntry struct {
 }
 
 type ApplyPackageSkillLock struct {
-	Digest string `json:"digest"`
-	Ref    string `json:"ref,omitempty"`
+	Digest  string `json:"digest"`
+	Ref     string `json:"ref,omitempty"`
+	Starred bool   `json:"starred,omitempty"`
 }
 
 func (lock *ApplyPackageSkillLock) UnmarshalJSON(data []byte) error {
@@ -46,17 +47,20 @@ func (lock *ApplyPackageSkillLock) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &digest); err == nil {
 		lock.Digest = digest
 		lock.Ref = ""
+		lock.Starred = false
 		return nil
 	}
 	var raw struct {
-		Digest string `json:"digest"`
-		Ref    string `json:"ref"`
+		Digest  string `json:"digest"`
+		Ref     string `json:"ref"`
+		Starred bool   `json:"starred"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	lock.Digest = raw.Digest
 	lock.Ref = raw.Ref
+	lock.Starred = raw.Starred
 	return nil
 }
 
@@ -139,10 +143,16 @@ func BuildApplyPackageWithSkillRefs(compiled *CompiledEnvironment, skillRefs map
 		packageFiles = append(packageFiles, files...)
 	}
 
+	requiredNames := make(map[string]bool, len(compiled.RequiredVerifierSkills))
+	for _, skill := range compiled.RequiredVerifierSkills {
+		if skill != nil {
+			requiredNames[skill.Name] = true
+		}
+	}
 	manifest := ApplyPackageManifest{
 		SchemaVersion: ApplyPackageSchemaVersion,
 		Spec:          specEntry,
-		Skills:        skillLockMap(skillEntries),
+		Skills:        skillLockMap(skillEntries, requiredNames),
 	}
 	packageDigest := digestPackage(specEntry.Digest, manifest.Skills)
 
@@ -715,12 +725,13 @@ func digestSkill(name string, files []ApplyPackageFileEntry) string {
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))
 }
 
-func skillLockMap(skills []ApplyPackageSkillEntry) map[string]ApplyPackageSkillLock {
+func skillLockMap(skills []ApplyPackageSkillEntry, requiredNames map[string]bool) map[string]ApplyPackageSkillLock {
 	out := make(map[string]ApplyPackageSkillLock, len(skills))
 	for _, skill := range skills {
 		out[skill.Name] = ApplyPackageSkillLock{
-			Digest: skill.Digest,
-			Ref:    strings.TrimSpace(skill.Ref),
+			Digest:  skill.Digest,
+			Ref:     strings.TrimSpace(skill.Ref),
+			Starred: requiredNames[skill.Name],
 		}
 	}
 	return out

--- a/internal/spec/package.go
+++ b/internal/spec/package.go
@@ -784,7 +784,15 @@ func digestPackage(specDigest string, skills map[string]ApplyPackageSkillLock) s
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		writeDigestPart(h, name)
+		// Starred marks a required evaluation rubric — runtime semantics, so
+		// it is part of package identity. The marker perturbs the hash only
+		// when set (skill names cannot contain '*'), keeping every previously
+		// published digest stable.
+		if skills[name].Starred {
+			writeDigestPart(h, name+"*")
+		} else {
+			writeDigestPart(h, name)
+		}
 		writeDigestPart(h, skills[name].Digest)
 	}
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))

--- a/internal/spec/package.go
+++ b/internal/spec/package.go
@@ -409,6 +409,20 @@ func validateApplyPackageFilesWithMode(manifest *ApplyPackageManifest, files map
 	if !applyPackageSchemaSupported(manifest.SchemaVersion) {
 		return fmt.Errorf("unsupported apply package schema_version %d", manifest.SchemaVersion)
 	}
+	if manifest.SchemaVersion < ApplyPackageSchemaVersionStarred {
+		for _, lock := range manifest.Skills {
+			if lock.Starred {
+				// Mirrors the Cloud publish rule: a schema-1 starred lock
+				// would be silently dropped (and its digest mis-derived) by
+				// pre-starred readers, so the combination is invalid even for
+				// locally supplied packages that never pass through Cloud.
+				return fmt.Errorf(
+					"starred skill locks require schema_version %d",
+					ApplyPackageSchemaVersionStarred,
+				)
+			}
+		}
+	}
 	specFile, ok := files["SPEC.md"]
 	if !ok {
 		return fmt.Errorf("apply package missing SPEC.md")

--- a/internal/spec/package_test.go
+++ b/internal/spec/package_test.go
@@ -522,7 +522,181 @@ func TestCompileUsesPackageManifestInjectedRequiredSkill(t *testing.T) {
 		t.Fatal("missing manifest-injected verify-quality skill")
 	}
 	if len(compiled.RequiredVerifierSkills) != 0 {
-		t.Fatalf("package manifest should not mark required verifier skills: got %#v", compiled.RequiredVerifierSkills)
+		t.Fatalf("unstarred package manifest locks should not mark required verifier skills: got %#v", compiled.RequiredVerifierSkills)
+	}
+}
+
+func TestBuildApplyPackageMarksStarredSkillLocks(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "SPEC.md")
+	data := []byte("---\nversion: 0.1.0\nname: package-starred\nplatform: cloud\nskills:\n  - alpha*\n  - beta\n---\nBuild the package.\n")
+	if err := os.WriteFile(specPath, data, 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "alpha", map[string]string{
+		"SKILL.md": "---\nname: alpha\n---\nUse alpha.",
+	})
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "beta", map[string]string{
+		"SKILL.md": "---\nname: beta\n---\nUse beta.",
+	})
+
+	compiled, err := CompileEnvironment(specPath)
+	if err != nil {
+		t.Fatalf("CompileEnvironment: %v", err)
+	}
+	pkg, err := BuildApplyPackage(compiled)
+	if err != nil {
+		t.Fatalf("BuildApplyPackage: %v", err)
+	}
+
+	if !pkg.Manifest.Skills["alpha"].Starred {
+		t.Fatalf("starred skill lock not marked: %#v", pkg.Manifest.Skills["alpha"])
+	}
+	if pkg.Manifest.Skills["beta"].Starred {
+		t.Fatalf("unstarred skill lock marked: %#v", pkg.Manifest.Skills["beta"])
+	}
+
+	entries := tarEntries(t, pkg.Bytes)
+	var manifest map[string]any
+	if err := json.Unmarshal(entries["manifest.json"], &manifest); err != nil {
+		t.Fatalf("manifest.json: %v", err)
+	}
+	rawSkills := manifest["skills"].(map[string]any)
+	alpha := rawSkills["alpha"].(map[string]any)
+	if alpha["starred"] != true {
+		t.Fatalf("manifest alpha lock missing starred: %#v", alpha)
+	}
+	beta := rawSkills["beta"].(map[string]any)
+	if _, ok := beta["starred"]; ok {
+		t.Fatalf("unstarred lock should omit starred key: %#v", beta)
+	}
+
+	// The starred flag is provenance metadata, not package identity.
+	flipped := make(map[string]ApplyPackageSkillLock, len(pkg.Manifest.Skills))
+	for name, lock := range pkg.Manifest.Skills {
+		lock.Starred = !lock.Starred
+		flipped[name] = lock
+	}
+	if got := digestPackage(pkg.Manifest.Spec.Digest, flipped); got != pkg.Digest {
+		t.Fatalf("package digest depends on starred flag: %s != %s", got, pkg.Digest)
+	}
+
+	// The push-time rebuild with registry refs keeps the marker.
+	refPkg, err := BuildApplyPackageWithSkillRefs(compiled, map[string]string{
+		"alpha": "@user-abc/alpha:0.1.0",
+		"beta":  "@user-abc/beta:0.1.0",
+	})
+	if err != nil {
+		t.Fatalf("BuildApplyPackageWithSkillRefs: %v", err)
+	}
+	if !refPkg.Manifest.Skills["alpha"].Starred || refPkg.Manifest.Skills["beta"].Starred {
+		t.Fatalf("ref rebuild lost starred markers: %#v", refPkg.Manifest.Skills)
+	}
+}
+
+func TestApplyPackageSkillLockUnmarshalStarred(t *testing.T) {
+	var lock ApplyPackageSkillLock
+	if err := json.Unmarshal([]byte(`{"digest":"sha256:abc","ref":"@a/b:1.0.0","starred":true}`), &lock); err != nil {
+		t.Fatalf("unmarshal starred lock: %v", err)
+	}
+	if !lock.Starred || lock.Digest != "sha256:abc" || lock.Ref != "@a/b:1.0.0" {
+		t.Fatalf("starred lock round-trip: %#v", lock)
+	}
+	if err := json.Unmarshal([]byte(`{"digest":"sha256:abc"}`), &lock); err != nil {
+		t.Fatalf("unmarshal plain lock: %v", err)
+	}
+	if lock.Starred {
+		t.Fatalf("plain lock should not be starred: %#v", lock)
+	}
+	lock.Starred = true
+	if err := json.Unmarshal([]byte(`"sha256:abc"`), &lock); err != nil {
+		t.Fatalf("unmarshal legacy lock: %v", err)
+	}
+	if lock.Starred {
+		t.Fatalf("legacy string lock should reset starred: %#v", lock)
+	}
+}
+
+func TestCompileHonorsPackageManifestStarredSkill(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "SPEC.md")
+	if err := os.WriteFile(
+		specPath,
+		[]byte("---\nversion: 0.1.0\nname: manifest-starred-skill\nplatform: cloud\n---\nUse injected skills.\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "verify-quality", map[string]string{
+		"SKILL.md": "---\nname: verify-quality\n---\nVerify quality.",
+	})
+	manifest := ApplyPackageManifest{
+		SchemaVersion: ApplyPackageSchemaVersion,
+		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
+		Skills: map[string]ApplyPackageSkillLock{
+			"verify-quality": {
+				Digest:  "sha256:skill",
+				Ref:     "@telos/verify-quality:1.0.0",
+				Starred: true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	compiled, err := CompileEnvironmentWithBase(specPath, dir)
+	if err != nil {
+		t.Fatalf("CompileEnvironmentWithBase: %v", err)
+	}
+
+	if len(compiled.RequiredVerifierSkills) != 1 || compiled.RequiredVerifierSkills[0].Name != "verify-quality" {
+		t.Fatalf("starred manifest lock should mark required verifier skill: got %#v", compiled.RequiredVerifierSkills)
+	}
+}
+
+func TestCompileSpecDeclarationOverridesManifestStar(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "SPEC.md")
+	if err := os.WriteFile(
+		specPath,
+		[]byte("---\nversion: 0.1.0\nname: spec-wins-star\nplatform: cloud\nskills:\n  - verify-quality\n---\nSpec declares it unstarred.\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "verify-quality", map[string]string{
+		"SKILL.md": "---\nname: verify-quality\n---\nVerify quality.",
+	})
+	manifest := ApplyPackageManifest{
+		SchemaVersion: ApplyPackageSchemaVersion,
+		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
+		Skills: map[string]ApplyPackageSkillLock{
+			"verify-quality": {
+				Digest:  "sha256:skill",
+				Starred: true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	compiled, err := CompileEnvironmentWithBase(specPath, dir)
+	if err != nil {
+		t.Fatalf("CompileEnvironmentWithBase: %v", err)
+	}
+
+	if len(compiled.RequiredVerifierSkills) != 0 {
+		t.Fatalf("spec-declared unstarred skill must override stale manifest star: got %#v", compiled.RequiredVerifierSkills)
 	}
 }
 

--- a/internal/spec/package_test.go
+++ b/internal/spec/package_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -754,6 +755,93 @@ func TestCompileSpecDeclarationOverridesManifestStarByDeclaredName(t *testing.T)
 
 	if len(compiled.RequiredVerifierSkills) != 0 {
 		t.Fatalf("spec declaration must override the manifest star by resolved name: got %#v", compiled.RequiredVerifierSkills)
+	}
+}
+
+func TestExtractApplyPackageRejectsStarredLockInSchemaV1(t *testing.T) {
+	// A schema-1 manifest carrying a starred lock never passes Cloud, but a
+	// locally supplied package bypasses Cloud entirely — the shared validator
+	// must reject the combination so a current runtime cannot accept a
+	// package that older runtimes would mis-hash.
+	pkg := buildPackageTestPackage(t, "package-v1-starred")
+	entries := tarEntries(t, pkg.Bytes)
+	var manifest map[string]any
+	if err := json.Unmarshal(entries["manifest.json"], &manifest); err != nil {
+		t.Fatalf("manifest.json: %v", err)
+	}
+	if manifest["schema_version"] != float64(ApplyPackageSchemaVersion) {
+		t.Fatalf("fixture should start at schema 1: %#v", manifest["schema_version"])
+	}
+	skills := manifest["skills"].(map[string]any)
+	alpha := skills["alpha"].(map[string]any)
+	alpha["starred"] = true
+	mutated, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries["manifest.json"] = mutated
+	data, err := writePackageTar(packageFilesFromEntries(entries))
+	if err != nil {
+		t.Fatalf("writePackageTar: %v", err)
+	}
+
+	_, err = ExtractApplyPackage(data, t.TempDir())
+	if err == nil {
+		t.Fatal("expected schema-1 starred lock to be rejected")
+	}
+	if !strings.Contains(err.Error(), "starred skill locks require schema_version 2") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompileIgnoresStarredLockInSchemaV1(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "SPEC.md")
+	if err := os.WriteFile(
+		specPath,
+		[]byte("---\nversion: 0.1.0\nname: manifest-v1-starred\nplatform: cloud\n---\nUse injected skills.\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "verify-quality", map[string]string{
+		"SKILL.md": "---\nname: verify-quality\n---\nVerify quality.",
+	})
+	manifest := ApplyPackageManifest{
+		SchemaVersion: ApplyPackageSchemaVersion,
+		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
+		Skills: map[string]ApplyPackageSkillLock{
+			"verify-quality": {
+				Digest:  "sha256:skill",
+				Starred: true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	compiled, err := CompileEnvironmentWithBase(specPath, dir)
+	if err != nil {
+		t.Fatalf("CompileEnvironmentWithBase: %v", err)
+	}
+
+	// The invalid schema-1 star is ignored, but the skill itself still loads.
+	if len(compiled.RequiredVerifierSkills) != 0 {
+		t.Fatalf("schema-1 starred lock must not mark required verifier skills: got %#v", compiled.RequiredVerifierSkills)
+	}
+	var found bool
+	for _, skill := range compiled.Skills {
+		if skill.Name == "verify-quality" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("manifest-injected skill missing from compile")
 	}
 }
 

--- a/internal/spec/package_test.go
+++ b/internal/spec/package_test.go
@@ -571,14 +571,19 @@ func TestBuildApplyPackageMarksStarredSkillLocks(t *testing.T) {
 		t.Fatalf("unstarred lock should omit starred key: %#v", beta)
 	}
 
-	// The starred flag is provenance metadata, not package identity.
+	// Starred changes runtime semantics, so it is part of package identity:
+	// flipping a flag must change the digest, while identical locks digest
+	// deterministically.
+	if got := digestPackage(pkg.Manifest.Spec.Digest, pkg.Manifest.Skills); got != pkg.Digest {
+		t.Fatalf("digest not deterministic for identical locks: %s != %s", got, pkg.Digest)
+	}
 	flipped := make(map[string]ApplyPackageSkillLock, len(pkg.Manifest.Skills))
 	for name, lock := range pkg.Manifest.Skills {
 		lock.Starred = !lock.Starred
 		flipped[name] = lock
 	}
-	if got := digestPackage(pkg.Manifest.Spec.Digest, flipped); got != pkg.Digest {
-		t.Fatalf("package digest depends on starred flag: %s != %s", got, pkg.Digest)
+	if got := digestPackage(pkg.Manifest.Spec.Digest, flipped); got == pkg.Digest {
+		t.Fatalf("package digest must include the starred flag: %s", got)
 	}
 
 	// The push-time rebuild with registry refs keeps the marker.
@@ -697,6 +702,53 @@ func TestCompileSpecDeclarationOverridesManifestStar(t *testing.T) {
 
 	if len(compiled.RequiredVerifierSkills) != 0 {
 		t.Fatalf("spec-declared unstarred skill must override stale manifest star: got %#v", compiled.RequiredVerifierSkills)
+	}
+}
+
+func TestCompileSpecDeclarationOverridesManifestStarByDeclaredName(t *testing.T) {
+	// The spec declares the skill through a directory whose name differs from
+	// the SKILL.md-declared name; the stale manifest star is keyed by the
+	// declared name. The override must match on resolved names, not paths.
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "SPEC.md")
+	if err := os.WriteFile(
+		specPath,
+		[]byte("---\nversion: 0.1.0\nname: spec-wins-star-alias\nplatform: cloud\nskills:\n  - local-review\n---\nDeclared unstarred under an alias directory.\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "local-review", map[string]string{
+		"SKILL.md": "---\nname: verify-security\n---\nReview security.",
+	})
+	writePackageTestSkill(t, filepath.Join(dir, "skills"), "verify-security", map[string]string{
+		"SKILL.md": "---\nname: verify-security\n---\nReview security.",
+	})
+	manifest := ApplyPackageManifest{
+		SchemaVersion: ApplyPackageSchemaVersion,
+		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
+		Skills: map[string]ApplyPackageSkillLock{
+			"verify-security": {
+				Digest:  "sha256:skill",
+				Starred: true,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	compiled, err := CompileEnvironmentWithBase(specPath, dir)
+	if err != nil {
+		t.Fatalf("CompileEnvironmentWithBase: %v", err)
+	}
+
+	if len(compiled.RequiredVerifierSkills) != 0 {
+		t.Fatalf("spec declaration must override the manifest star by resolved name: got %#v", compiled.RequiredVerifierSkills)
 	}
 }
 

--- a/internal/spec/package_test.go
+++ b/internal/spec/package_test.go
@@ -555,6 +555,11 @@ func TestBuildApplyPackageMarksStarredSkillLocks(t *testing.T) {
 	if pkg.Manifest.Skills["beta"].Starred {
 		t.Fatalf("unstarred skill lock marked: %#v", pkg.Manifest.Skills["beta"])
 	}
+	// Starred packages declare the gated schema version so pre-starred
+	// runtimes reject them explicitly instead of mis-deriving the digest.
+	if pkg.Manifest.SchemaVersion != ApplyPackageSchemaVersionStarred {
+		t.Fatalf("starred package schema_version: got %d", pkg.Manifest.SchemaVersion)
+	}
 
 	entries := tarEntries(t, pkg.Bytes)
 	var manifest map[string]any
@@ -574,7 +579,7 @@ func TestBuildApplyPackageMarksStarredSkillLocks(t *testing.T) {
 	// Starred changes runtime semantics, so it is part of package identity:
 	// flipping a flag must change the digest, while identical locks digest
 	// deterministically.
-	if got := digestPackage(pkg.Manifest.Spec.Digest, pkg.Manifest.Skills); got != pkg.Digest {
+	if got := digestPackage(pkg.Manifest.SchemaVersion, pkg.Manifest.Spec.Digest, pkg.Manifest.Skills); got != pkg.Digest {
 		t.Fatalf("digest not deterministic for identical locks: %s != %s", got, pkg.Digest)
 	}
 	flipped := make(map[string]ApplyPackageSkillLock, len(pkg.Manifest.Skills))
@@ -582,7 +587,7 @@ func TestBuildApplyPackageMarksStarredSkillLocks(t *testing.T) {
 		lock.Starred = !lock.Starred
 		flipped[name] = lock
 	}
-	if got := digestPackage(pkg.Manifest.Spec.Digest, flipped); got == pkg.Digest {
+	if got := digestPackage(pkg.Manifest.SchemaVersion, pkg.Manifest.Spec.Digest, flipped); got == pkg.Digest {
 		t.Fatalf("package digest must include the starred flag: %s", got)
 	}
 
@@ -636,7 +641,7 @@ func TestCompileHonorsPackageManifestStarredSkill(t *testing.T) {
 		"SKILL.md": "---\nname: verify-quality\n---\nVerify quality.",
 	})
 	manifest := ApplyPackageManifest{
-		SchemaVersion: ApplyPackageSchemaVersion,
+		SchemaVersion: ApplyPackageSchemaVersionStarred,
 		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
 		Skills: map[string]ApplyPackageSkillLock{
 			"verify-quality": {
@@ -678,7 +683,7 @@ func TestCompileSpecDeclarationOverridesManifestStar(t *testing.T) {
 		"SKILL.md": "---\nname: verify-quality\n---\nVerify quality.",
 	})
 	manifest := ApplyPackageManifest{
-		SchemaVersion: ApplyPackageSchemaVersion,
+		SchemaVersion: ApplyPackageSchemaVersionStarred,
 		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
 		Skills: map[string]ApplyPackageSkillLock{
 			"verify-quality": {
@@ -725,7 +730,7 @@ func TestCompileSpecDeclarationOverridesManifestStarByDeclaredName(t *testing.T)
 		"SKILL.md": "---\nname: verify-security\n---\nReview security.",
 	})
 	manifest := ApplyPackageManifest{
-		SchemaVersion: ApplyPackageSchemaVersion,
+		SchemaVersion: ApplyPackageSchemaVersionStarred,
 		Spec:          ApplyPackageSpecEntry{Digest: "sha256:spec"},
 		Skills: map[string]ApplyPackageSkillLock{
 			"verify-security": {


### PR DESCRIPTION
## Summary

Starred skills (`verify-slo*` = required evaluation rubric) were dropped from the structured package manifest and transported only as opaque SPEC.md text. This PR makes the star real data end to end:

- **Emit**: `ApplyPackageSkillLock` gains `Starred bool` (`starred,omitempty`); `BuildApplyPackageWithSkillRefs` marks locks from `compiled.RequiredVerifierSkills`. The custom `UnmarshalJSON` decodes the field too — without that, every read-back path would silently lose it.
- **Honor**: `packageManifestSkillPaths` now returns starred lock paths (previously hardcoded nil), so a manifest star compiles into `RequiredVerifierSkills` and reaches the rubric prompt sections. Divergence rule: **spec text wins for skills it declares** — the filter runs after skill resolution and matches resolved `Skill.Name` on both sides (SKILL.md may declare a name that differs from its directory), so un-starring an entry in SPEC.md always takes effect even against a stale lock. Manifest stars apply only to manifest-injected skills.
- **Show**: `telos plan` renders `name*` in the Skills line and adds `required_verifier_skills` to the JSON output (the existing `skills` key is unchanged for machine consumers).

### Identity & versioning

`starred` changes runtime semantics, so it is **part of package identity**: `digestPackage` and the runtime re-derivation (`digestApplyPackage`) hash a starred lock's name as `name*`. And because an older, version-pinned telosd would silently drop the unknown field and mis-derive the digest, **manifests carrying any starred lock declare `schema_version: 2`** — pre-starred readers hard-reject unknown schema versions ("unsupported apply package schema_version"), turning the mixed-rollout failure into an explicit upgrade signal. Unstarred packages keep schema 1 and hash byte-identically to before, so every published digest is stable; new readers accept both versions.

**Rollout order is a hard requirement**: cloud (telos-org/cloud#58) must deploy before a starred-emitting CLI ships, and starred packages can only run on runtimes carrying this change — an older pinned runtime rejects them with the explicit schema error. Unstarred flows are unaffected in every direction.

Companion PRs: telos-org/cloud#58 (validation + digest + schema gate) and telos-org/web#51 (display/toggle + client digest + schema emission).

## Test plan

- `TestBuildApplyPackageMarksStarredSkillLocks` — starred lock emitted (+ omitted when false), `schema_version: 2` declared, digest folds the flag (inequality on flip, determinism on identity), push-time ref rebuild keeps markers
- `TestApplyPackageSkillLockUnmarshalStarred` — dict round-trip; legacy string form resets to false
- `TestCompileHonorsPackageManifestStarredSkill` / `TestCompileSpecDeclarationOverridesManifestStar` / `TestCompileSpecDeclarationOverridesManifestStarByDeclaredName` — manifest star injects a required skill; spec declaration overrides a stale star, including when the directory name differs from the SKILL.md-declared name
- `TestCompileUsesPackageManifestInjectedRequiredSkill` still passes unchanged (un-starred locks inject nothing)
- `TestPrintPlanPreviewStarsRequiredVerifierSkills` — `name*` in plan output
- `go test ./...`, `gofmt`, `go vet` clean; smoke-tested `go run ./cmd/telos plan` against a starred spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdzKyZpnZiHVrjmueey8ow