### PR TITLE
sessionapi: expose event_seq with cursor params and SSE resume

### DIFF
--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -51,7 +51,12 @@ func (h *handler) healthz(w http.ResponseWriter, r *http.Request) {
 	if _, ok := h.authorize(w, r, AccessRequest{Action: ActionHealth}); !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+	// capabilities lets never-updated peers detect cursor support without a
+	// version handshake; in-tree health checks only read `ok`.
+	writeJSON(w, http.StatusOK, map[string]string{
+		"ok":           "true",
+		"capabilities": "events_cursor",
+	})
 }
 
 func (h *handler) createSession(w http.ResponseWriter, r *http.Request) {
@@ -254,8 +259,23 @@ func (h *handler) getEvents(w http.ResponseWriter, r *http.Request) {
 	if _, ok := h.authorize(w, r, AccessRequest{Action: ActionReadSession, SessionID: id}); !ok {
 		return
 	}
+	after, err := nonNegativeIntParam(r, "after")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	before, err := nonNegativeIntParam(r, "before")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	tail, err := nonNegativeIntParam(r, "tail")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/event-stream") {
-		h.streamEvents(w, r, id)
+		h.streamEvents(w, r, id, after)
 		return
 	}
 	events, err := h.store.Events(id)
@@ -267,13 +287,61 @@ func (h *handler) getEvents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if events == nil {
-		events = []SessionEvent{}
-	}
-	writeJSON(w, http.StatusOK, SessionEventsResponse{Events: events})
+	writeJSON(w, http.StatusOK, SessionEventsResponse{
+		Events: filterEventsWindow(events, after, before, tail),
+	})
 }
 
-func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string) {
+func nonNegativeIntParam(r *http.Request, name string) (int64, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(name))
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("%s must be a non-negative integer", name)
+	}
+	return value, nil
+}
+
+// effectiveSeqs assigns each event its cursor position: the durable
+// event_seq where present, else the 1-based position among parsed events.
+// The ordinal fallback is stable — the evidence file is append-only and
+// malformed lines are skipped deterministically — but only genuine seqs
+// are ever advertised as SSE ids.
+func effectiveSeqs(events []SessionEvent) []int64 {
+	seqs := make([]int64, len(events))
+	for i, event := range events {
+		if event.EventSeq != nil {
+			seqs[i] = *event.EventSeq
+		} else {
+			seqs[i] = int64(i + 1)
+		}
+	}
+	return seqs
+}
+
+// filterEventsWindow applies ?after / ?before / ?tail to the event list.
+// Zero values mean "unset": no lower bound, no upper bound, no length cap.
+func filterEventsWindow(events []SessionEvent, after, before, tail int64) []SessionEvent {
+	seqs := effectiveSeqs(events)
+	filtered := make([]SessionEvent, 0, len(events))
+	for i, event := range events {
+		if after > 0 && seqs[i] <= after {
+			continue
+		}
+		if before > 0 && seqs[i] >= before {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	if tail > 0 && int64(len(filtered)) > tail {
+		filtered = filtered[int64(len(filtered))-tail:]
+	}
+	return filtered
+}
+
+func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string, after int64) {
 	if _, err := h.store.Get(id); err != nil {
 		if errors.Is(err, ErrNotFound) {
 			writeError(w, http.StatusNotFound, err.Error())
@@ -287,6 +355,14 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		writeError(w, http.StatusInternalServerError, "streaming unsupported")
 		return
 	}
+	// Resume: ?after wins over the standard Last-Event-ID reconnect header.
+	if after == 0 {
+		if header := strings.TrimSpace(r.Header.Get("Last-Event-ID")); header != "" {
+			if value, err := strconv.ParseInt(header, 10, 64); err == nil && value > 0 {
+				after = value
+			}
+		}
+	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
@@ -299,13 +375,24 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		if err != nil {
 			return false
 		}
+		seqs := effectiveSeqs(events)
+		// Seqs are monotonic, so once past the cursor this loop is a no-op.
+		for sent < len(events) && after > 0 && seqs[sent] <= after {
+			sent++
+		}
 		for sent < len(events) {
 			data, err := json.Marshal(events[sent])
 			if err != nil {
 				sent++
 				continue
 			}
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			// Only durable seqs are advertised as SSE ids; an ordinal
+			// would resume wrongly on a client that stored it.
+			if seq := events[sent].EventSeq; seq != nil {
+				_, _ = fmt.Fprintf(w, "id: %d\ndata: %s\n\n", *seq, data)
+			} else {
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			}
 			flusher.Flush()
 			sent++
 		}

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -51,12 +51,7 @@ func (h *handler) healthz(w http.ResponseWriter, r *http.Request) {
 	if _, ok := h.authorize(w, r, AccessRequest{Action: ActionHealth}); !ok {
 		return
 	}
-	// capabilities lets never-updated peers detect cursor support without a
-	// version handshake; in-tree health checks only read `ok`.
-	writeJSON(w, http.StatusOK, map[string]string{
-		"ok":           "true",
-		"capabilities": "events_cursor",
-	})
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
 }
 
 func (h *handler) createSession(w http.ResponseWriter, r *http.Request) {
@@ -304,33 +299,20 @@ func nonNegativeIntParam(r *http.Request, name string) (int64, error) {
 	return value, nil
 }
 
-// effectiveSeqs assigns each event its cursor position: the durable
-// event_seq where present, else the 1-based position among parsed events.
-// The ordinal fallback is stable — the evidence file is append-only and
-// malformed lines are skipped deterministically — but only genuine seqs
-// are ever advertised as SSE ids.
-func effectiveSeqs(events []SessionEvent) []int64 {
-	seqs := make([]int64, len(events))
-	for i, event := range events {
-		if event.EventSeq != nil {
-			seqs[i] = *event.EventSeq
-		} else {
-			seqs[i] = int64(i + 1)
-		}
-	}
-	return seqs
-}
-
 // filterEventsWindow applies ?after / ?before / ?tail to the event list.
-// Zero values mean "unset": no lower bound, no upper bound, no length cap.
+// after and before are durable event_seq cursors. Events without a durable
+// sequence are retained, preferring a harmless replay over dropping events.
 func filterEventsWindow(events []SessionEvent, after, before, tail int64) []SessionEvent {
-	seqs := effectiveSeqs(events)
 	filtered := make([]SessionEvent, 0, len(events))
-	for i, event := range events {
-		if after > 0 && seqs[i] <= after {
+	for _, event := range events {
+		if event.EventSeq == nil {
+			filtered = append(filtered, event)
 			continue
 		}
-		if before > 0 && seqs[i] >= before {
+		if after > 0 && *event.EventSeq <= after {
+			continue
+		}
+		if before > 0 && *event.EventSeq >= before {
 			continue
 		}
 		filtered = append(filtered, event)
@@ -355,8 +337,9 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		writeError(w, http.StatusInternalServerError, "streaming unsupported")
 		return
 	}
-	// Resume: ?after wins over the standard Last-Event-ID reconnect header.
-	if after == 0 {
+	// An explicit ?after wins over the standard reconnect header, including
+	// ?after=0.
+	if strings.TrimSpace(r.URL.Query().Get("after")) == "" {
 		if header := strings.TrimSpace(r.Header.Get("Last-Event-ID")); header != "" {
 			if value, err := strconv.ParseInt(header, 10, 64); err == nil && value > 0 {
 				after = value
@@ -375,9 +358,10 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		if err != nil {
 			return false
 		}
-		seqs := effectiveSeqs(events)
-		// Seqs are monotonic, so once past the cursor this loop is a no-op.
-		for sent < len(events) && after > 0 && seqs[sent] <= after {
+		// A legacy or multi-spec stream has no durable cursor. Replay it
+		// instead of treating list position as event identity.
+		for sent < len(events) && after > 0 && events[sent].EventSeq != nil &&
+			*events[sent].EventSeq <= after {
 			sent++
 		}
 		for sent < len(events) {

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -270,6 +270,10 @@ func (h *handler) getEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/event-stream") {
+		if queryParamSet(r, "before") || queryParamSet(r, "tail") {
+			writeError(w, http.StatusBadRequest, "before and tail are not supported for event streams")
+			return
+		}
 		h.streamEvents(w, r, id, after)
 		return
 	}
@@ -283,8 +287,13 @@ func (h *handler) getEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, SessionEventsResponse{
-		Events: filterEventsWindow(events, after, before, tail),
+		Events:       filterEventsWindow(events, after, before, tail),
+		HeadEventSeq: headEventSeq(events),
 	})
+}
+
+func queryParamSet(r *http.Request, name string) bool {
+	return strings.TrimSpace(r.URL.Query().Get(name)) != ""
 }
 
 func nonNegativeIntParam(r *http.Request, name string) (int64, error) {
@@ -321,6 +330,13 @@ func filterEventsWindow(events []SessionEvent, after, before, tail int64) []Sess
 		filtered = filtered[int64(len(filtered))-tail:]
 	}
 	return filtered
+}
+
+func headEventSeq(events []SessionEvent) *int64 {
+	if len(events) == 0 || !durableEventSeqs(events) {
+		return nil
+	}
+	return events[len(events)-1].EventSeq
 }
 
 func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string, after int64) {

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -1711,7 +1711,7 @@ func writeEventsFixture(t *testing.T, root, sessionID, spec string, lines []stri
 	}
 }
 
-func getEventsList(t *testing.T, url string) []sessionapi.SessionEvent {
+func getEventsResponse(t *testing.T, url string) sessionapi.SessionEventsResponse {
 	t.Helper()
 	resp, err := http.Get(url)
 	if err != nil {
@@ -1721,7 +1721,12 @@ func getEventsList(t *testing.T, url string) []sessionapi.SessionEvent {
 	assertEqual(t, "status_code", "200", itoa(resp.StatusCode))
 	var evResp sessionapi.SessionEventsResponse
 	json.NewDecoder(resp.Body).Decode(&evResp)
-	return evResp.Events
+	return evResp
+}
+
+func getEventsList(t *testing.T, url string) []sessionapi.SessionEvent {
+	t.Helper()
+	return getEventsResponse(t, url).Events
 }
 
 func eventNames(events []sessionapi.SessionEvent) string {
@@ -1792,8 +1797,19 @@ func TestEventsTail(t *testing.T) {
 	created := createSession(t, srv.URL, createSessionBody(t, "et"))
 	writeEventsFixture(t, store.Root, created.SessionID, "et", cursorFixtureLines)
 
-	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?tail=2")
-	assertEqual(t, "events", "three,four", eventNames(events))
+	response := getEventsResponse(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?tail=2")
+	assertEqual(t, "events", "three,four", eventNames(response.Events))
+	if response.HeadEventSeq == nil || *response.HeadEventSeq != 4 {
+		t.Fatalf("head_event_seq = %v, want 4", response.HeadEventSeq)
+	}
+
+	caughtUp := getEventsResponse(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=4")
+	if len(caughtUp.Events) != 0 {
+		t.Fatalf("caught-up events = %#v, want empty", caughtUp.Events)
+	}
+	if caughtUp.HeadEventSeq == nil || *caughtUp.HeadEventSeq != 4 {
+		t.Fatalf("caught-up head_event_seq = %v, want 4", caughtUp.HeadEventSeq)
+	}
 }
 
 func TestEventsBeforeTailCombined(t *testing.T) {
@@ -1980,6 +1996,34 @@ func TestEventsSSEResume(t *testing.T) {
 	body = stream("?after=0", "3")
 	if !strings.Contains(body, `"event":"one"`) {
 		t.Fatalf("expected explicit ?after=0 to override Last-Event-ID, got: %s", body)
+	}
+}
+
+func TestEventsSSERejectsSnapshotWindows(t *testing.T) {
+	srv, _ := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "essw"))
+	stopSession(t, srv.URL, created.SessionID)
+
+	for _, query := range []string{"before=2", "tail=10"} {
+		req, err := http.NewRequest(
+			http.MethodGet,
+			srv.URL+"/api/sessions/"+created.SessionID+"/events?"+query,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", query, resp.StatusCode)
+		}
 	}
 }
 

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -1848,6 +1848,83 @@ func TestEventsBadParams(t *testing.T) {
 	}
 }
 
+func TestEventsMixedSeqFileFallsBackToOrdinals(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "emx"))
+	// Seq-less lines ahead of numbered ones: the numbered seqs collide with
+	// the legacy lines' ordinal positions, so none of them are durable.
+	writeEventsFixture(t, store.Root, created.SessionID, "emx", []string{
+		`{"event":"legacy-one"}`,
+		`{"event":"legacy-two"}`,
+		`{"event_seq":1,"event":"new-one"}`,
+		`{"event_seq":2,"event":"new-two"}`,
+	})
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events")
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+	for i, event := range events {
+		if event.EventSeq != nil {
+			t.Fatalf("event %d: expected event_seq stripped, got %d", i, *event.EventSeq)
+		}
+	}
+	// Windows fall back to ordinals over the whole parsed list — monotonic,
+	// so ?after can never skip new events or replay old ones at the seam.
+	filtered := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=2")
+	assertEqual(t, "events", "new-one,new-two", eventNames(filtered))
+}
+
+func TestEventsMultiSpecSeqsNotAdvertised(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	// Two specs, each evidence file numbered independently from 1: the
+	// concatenation is not a usable cursor space, so no seqs may surface.
+	id := "sess_multispec"
+	sessionDir := filepath.Join(store.Root, id)
+	specs := []sessionapi.InitialManifestSpec{}
+	for i, name := range []string{"alpha", "beta"} {
+		specDir := filepath.Join(sessionDir, "specs", name)
+		if err := os.MkdirAll(specDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		evidencePath := filepath.Join(specDir, "evidence.jsonl")
+		lines := `{"event_seq":1,"event":"` + name + `-one"}` + "\n" +
+			`{"event_seq":2,"event":"` + name + `-two"}` + "\n"
+		if err := os.WriteFile(evidencePath, []byte(lines), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		specs = append(specs, sessionapi.InitialManifestSpec{
+			Index:        i,
+			Name:         name,
+			DirName:      name,
+			EvidencePath: &evidencePath,
+		})
+	}
+	m := sessionapi.ManifestFromInitial(sessionapi.InitialManifest{
+		SessionID: id,
+		CreatedAt: "2026-05-18T12:00:00.000Z",
+		SpecName:  "alpha",
+		Specs:     specs,
+	})
+	if err := sessionapi.WriteManifest(filepath.Join(sessionDir, "session.json"), &m); err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+id+"/events")
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+	for i, event := range events {
+		if event.EventSeq != nil {
+			t.Fatalf("event %d: expected event_seq stripped, got %d", i, *event.EventSeq)
+		}
+	}
+}
+
 func TestEventsSSEResume(t *testing.T) {
 	srv, store := newTestServer(t)
 	defer srv.Close()

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -117,6 +117,9 @@ func TestHealthz(t *testing.T) {
 	if body["ok"] != "true" {
 		t.Fatalf("unexpected health body: %#v", body)
 	}
+	if body["capabilities"] != "events_cursor" {
+		t.Fatalf("expected events_cursor capability, got %#v", body)
+	}
 }
 
 func TestCreateSessionPersistsSpecMarkdown(t *testing.T) {
@@ -1643,6 +1646,10 @@ func TestEventsPresent(t *testing.T) {
 	if evResp.Events[0].Data["cost_usd"] != 0.5 {
 		t.Errorf("expected cost_usd=0.5, got %v", evResp.Events[0].Data["cost_usd"])
 	}
+	// Legacy evidence has no event_seq: the projection must not invent one.
+	if evResp.Events[0].EventSeq != nil {
+		t.Errorf("expected nil event_seq, got %v", *evResp.Events[0].EventSeq)
+	}
 
 	assertEqual(t, "event[1].event", "game_end", evResp.Events[1].Event)
 }
@@ -1695,6 +1702,235 @@ func TestEventsSSE(t *testing.T) {
 	}
 	if !strings.Contains(string(body), `data: {"event":"game_end"`) {
 		t.Fatalf("unexpected SSE body: %s", body)
+	}
+}
+
+func writeEventsFixture(t *testing.T, root, sessionID, spec string, lines []string) {
+	t.Helper()
+	path := filepath.Join(root, sessionID, "specs", spec, "evidence.jsonl")
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getEventsList(t *testing.T, url string) []sessionapi.SessionEvent {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	assertEqual(t, "status_code", "200", itoa(resp.StatusCode))
+	var evResp sessionapi.SessionEventsResponse
+	json.NewDecoder(resp.Body).Decode(&evResp)
+	return evResp.Events
+}
+
+func eventNames(events []sessionapi.SessionEvent) string {
+	names := make([]string, 0, len(events))
+	for _, event := range events {
+		names = append(names, event.Event)
+	}
+	return strings.Join(names, ",")
+}
+
+// Fixture for the cursor tests: seq-stamped lines with one malformed line —
+// the window params must count only parsed events.
+var cursorFixtureLines = []string{
+	`{"event_seq":1,"event":"one","ts":"2026-05-21T00:00:01.000Z"}`,
+	`{"event_seq":2,"event":"two"}`,
+	`this line is not json`,
+	`{"event_seq":3,"event":"three"}`,
+	`{"event_seq":4,"event":"four"}`,
+}
+
+func TestEventsSeqAndRoleProjected(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "esr"))
+	writeEventsFixture(t, store.Root, created.SessionID, "esr", []string{
+		`{"event_seq":7,"event":"agent_progress","role":"prover","ts":"2026-05-21T00:00:01.000Z","data":{"text":"hi"}}`,
+	})
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events")
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventSeq == nil || *events[0].EventSeq != 7 {
+		t.Fatalf("expected event_seq=7, got %v", events[0].EventSeq)
+	}
+	if events[0].Role == nil || *events[0].Role != "prover" {
+		t.Fatalf("expected role=prover, got %v", events[0].Role)
+	}
+}
+
+func TestEventsAfter(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "ea"))
+	writeEventsFixture(t, store.Root, created.SessionID, "ea", cursorFixtureLines)
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=2")
+	assertEqual(t, "events", "three,four", eventNames(events))
+}
+
+func TestEventsBefore(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "eb"))
+	writeEventsFixture(t, store.Root, created.SessionID, "eb", cursorFixtureLines)
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?before=3")
+	assertEqual(t, "events", "one,two", eventNames(events))
+}
+
+func TestEventsTail(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "et"))
+	writeEventsFixture(t, store.Root, created.SessionID, "et", cursorFixtureLines)
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?tail=2")
+	assertEqual(t, "events", "three,four", eventNames(events))
+}
+
+func TestEventsBeforeTailCombined(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "ebt"))
+	writeEventsFixture(t, store.Root, created.SessionID, "ebt", cursorFixtureLines)
+
+	// Backward paging: the window before seq 4, newest 2 of it.
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?before=4&tail=2")
+	assertEqual(t, "events", "two,three", eventNames(events))
+}
+
+func TestEventsAfterLegacyOrdinal(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "eal"))
+	// No event_seq anywhere: positions fall back to 1-based ordinals over
+	// parsed events only — the malformed line must not shift them.
+	writeEventsFixture(t, store.Root, created.SessionID, "eal", []string{
+		`{"event":"one"}`,
+		`this line is not json`,
+		`{"event":"two"}`,
+		`{"event":"three"}`,
+	})
+
+	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=1")
+	assertEqual(t, "events", "two,three", eventNames(events))
+	tailed := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?tail=2")
+	assertEqual(t, "events", "two,three", eventNames(tailed))
+}
+
+func TestEventsBadParams(t *testing.T) {
+	srv, _ := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "ebp"))
+	for _, query := range []string{"after=-1", "before=x", "tail=1.5"} {
+		resp, err := http.Get(srv.URL + "/api/sessions/" + created.SessionID + "/events?" + query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", query, resp.StatusCode)
+		}
+	}
+}
+
+func TestEventsSSEResume(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "esse"))
+	writeEventsFixture(t, store.Root, created.SessionID, "esse", cursorFixtureLines)
+	stopSession(t, srv.URL, created.SessionID)
+
+	stream := func(query, lastEventID string) string {
+		t.Helper()
+		req, err := http.NewRequest("GET", srv.URL+"/api/sessions/"+created.SessionID+"/events"+query, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		if lastEventID != "" {
+			req.Header.Set("Last-Event-ID", lastEventID)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		assertEqual(t, "status_code", "200", itoa(resp.StatusCode))
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(body)
+	}
+
+	// ?after resumes past the cursor and frames carry durable ids.
+	body := stream("?after=2", "")
+	if strings.Contains(body, `"event":"two"`) || !strings.Contains(body, `"event":"three"`) {
+		t.Fatalf("expected resume after seq 2, got: %s", body)
+	}
+	if !strings.Contains(body, "id: 3\n") {
+		t.Fatalf("expected id: frames for seq events, got: %s", body)
+	}
+
+	// The standard reconnect header works the same way…
+	body = stream("", "2")
+	if strings.Contains(body, `"event":"two"`) || !strings.Contains(body, `"event":"three"`) {
+		t.Fatalf("expected Last-Event-ID resume, got: %s", body)
+	}
+
+	// …but an explicit ?after wins over it.
+	body = stream("?after=3", "1")
+	if strings.Contains(body, `"event":"three"`) || !strings.Contains(body, `"event":"four"`) {
+		t.Fatalf("expected ?after to win over Last-Event-ID, got: %s", body)
+	}
+}
+
+func TestEventsSSELegacyNoIDFrames(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "esl"))
+	writeEventsFixture(t, store.Root, created.SessionID, "esl", []string{
+		`{"event":"game_end","data":{"game_result":"success"}}`,
+	})
+	stopSession(t, srv.URL, created.SessionID)
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/sessions/"+created.SessionID+"/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `data: {"event":"game_end"`) {
+		t.Fatalf("unexpected SSE body: %s", body)
+	}
+	// Ordinal positions are not durable cursors: never advertise them.
+	if strings.Contains(string(body), "id: ") {
+		t.Fatalf("expected no id frames for legacy events, got: %s", body)
 	}
 }
 

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -117,9 +117,6 @@ func TestHealthz(t *testing.T) {
 	if body["ok"] != "true" {
 		t.Fatalf("unexpected health body: %#v", body)
 	}
-	if body["capabilities"] != "events_cursor" {
-		t.Fatalf("expected events_cursor capability, got %#v", body)
-	}
 }
 
 func TestCreateSessionPersistsSpecMarkdown(t *testing.T) {
@@ -1811,13 +1808,11 @@ func TestEventsBeforeTailCombined(t *testing.T) {
 	assertEqual(t, "events", "two,three", eventNames(events))
 }
 
-func TestEventsAfterLegacyOrdinal(t *testing.T) {
+func TestEventsLegacyCursorReplaysSafely(t *testing.T) {
 	srv, store := newTestServer(t)
 	defer srv.Close()
 
 	created := createSession(t, srv.URL, createSessionBody(t, "eal"))
-	// No event_seq anywhere: positions fall back to 1-based ordinals over
-	// parsed events only — the malformed line must not shift them.
 	writeEventsFixture(t, store.Root, created.SessionID, "eal", []string{
 		`{"event":"one"}`,
 		`this line is not json`,
@@ -1826,7 +1821,7 @@ func TestEventsAfterLegacyOrdinal(t *testing.T) {
 	})
 
 	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=1")
-	assertEqual(t, "events", "two,three", eventNames(events))
+	assertEqual(t, "events", "one,two,three", eventNames(events))
 	tailed := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?tail=2")
 	assertEqual(t, "events", "two,three", eventNames(tailed))
 }
@@ -1848,7 +1843,7 @@ func TestEventsBadParams(t *testing.T) {
 	}
 }
 
-func TestEventsMixedSeqFileFallsBackToOrdinals(t *testing.T) {
+func TestEventsMixedSeqFileReplaysWithoutCursor(t *testing.T) {
 	srv, store := newTestServer(t)
 	defer srv.Close()
 
@@ -1871,10 +1866,8 @@ func TestEventsMixedSeqFileFallsBackToOrdinals(t *testing.T) {
 			t.Fatalf("event %d: expected event_seq stripped, got %d", i, *event.EventSeq)
 		}
 	}
-	// Windows fall back to ordinals over the whole parsed list — monotonic,
-	// so ?after can never skip new events or replay old ones at the seam.
 	filtered := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events?after=2")
-	assertEqual(t, "events", "new-one,new-two", eventNames(filtered))
+	assertEqual(t, "events", "legacy-one,legacy-two,new-one,new-two", eventNames(filtered))
 }
 
 func TestEventsMultiSpecSeqsNotAdvertised(t *testing.T) {
@@ -1923,6 +1916,13 @@ func TestEventsMultiSpecSeqsNotAdvertised(t *testing.T) {
 			t.Fatalf("event %d: expected event_seq stripped, got %d", i, *event.EventSeq)
 		}
 	}
+	filtered := getEventsList(t, srv.URL+"/api/sessions/"+id+"/events?after=2")
+	assertEqual(
+		t,
+		"events",
+		"alpha-one,alpha-two,beta-one,beta-two",
+		eventNames(filtered),
+	)
 }
 
 func TestEventsSSEResume(t *testing.T) {
@@ -1976,9 +1976,14 @@ func TestEventsSSEResume(t *testing.T) {
 	if strings.Contains(body, `"event":"three"`) || !strings.Contains(body, `"event":"four"`) {
 		t.Fatalf("expected ?after to win over Last-Event-ID, got: %s", body)
 	}
+
+	body = stream("?after=0", "3")
+	if !strings.Contains(body, `"event":"one"`) {
+		t.Fatalf("expected explicit ?after=0 to override Last-Event-ID, got: %s", body)
+	}
 }
 
-func TestEventsSSELegacyNoIDFrames(t *testing.T) {
+func TestEventsSSELegacyCursorReplaysWithoutIDFrames(t *testing.T) {
 	srv, store := newTestServer(t)
 	defer srv.Close()
 
@@ -1993,6 +1998,7 @@ func TestEventsSSELegacyNoIDFrames(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Last-Event-ID", "99")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -880,7 +880,38 @@ func (fs *FileStore) Events(id string) ([]SessionEvent, error) {
 		}
 		events = append(events, specEvents...)
 	}
-	return events, nil
+	return normalizeEventSeqs(events), nil
+}
+
+// durableEventSeqs reports whether the projected seqs can serve as
+// session-wide cursors: every event carries one and the sequence strictly
+// increases across the whole list.
+func durableEventSeqs(events []SessionEvent) bool {
+	var last int64
+	for _, event := range events {
+		if event.EventSeq == nil || *event.EventSeq <= last {
+			return false
+		}
+		last = *event.EventSeq
+	}
+	return true
+}
+
+// normalizeEventSeqs strips event_seq from the projection unless it is
+// durable for the whole session. Two real shapes fail the check: evidence
+// mixing seq-less legacy lines with numbered ones, and multi-spec sessions,
+// whose concatenated per-file sequences restart at 1. Advertising either
+// would hand clients a cursor that filters the wrong events — stripping
+// makes the session read as legacy (full replays, ordinal windows), which
+// is always correct.
+func normalizeEventSeqs(events []SessionEvent) []SessionEvent {
+	if durableEventSeqs(events) {
+		return events
+	}
+	for i := range events {
+		events[i].EventSeq = nil
+	}
+	return events
 }
 
 func (fs *FileStore) emitSpecUpdate(event SpecUpdateEvent) {

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -897,13 +897,9 @@ func durableEventSeqs(events []SessionEvent) bool {
 	return true
 }
 
-// normalizeEventSeqs strips event_seq from the projection unless it is
-// durable for the whole session. Two real shapes fail the check: evidence
-// mixing seq-less legacy lines with numbered ones, and multi-spec sessions,
-// whose concatenated per-file sequences restart at 1. Advertising either
-// would hand clients a cursor that filters the wrong events — stripping
-// makes the session read as legacy (full replays, ordinal windows), which
-// is always correct.
+// normalizeEventSeqs strips event_seq unless it is durable for the whole
+// session. Mixed legacy evidence and multi-spec sequences cannot safely
+// resume, so callers replay them without cursor IDs.
 func normalizeEventSeqs(events []SessionEvent) []SessionEvent {
 	if durableEventSeqs(events) {
 		return events

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -1217,9 +1217,12 @@ func readEvidenceFile(path string, spec *ManifestSpec) ([]SessionEvent, error) {
 
 		dataField, _ := raw["data"].(map[string]any)
 		timestamp, _ := raw["ts"].(string)
+		role, _ := raw["role"].(string)
 
 		ev := SessionEvent{
 			Event:       eventName,
+			EventSeq:    eventSeq(raw),
+			Role:        strPtr(role),
 			Timestamp:   strPtr(timestamp),
 			SpecIndex:   spec.Index,
 			SpecName:    strPtr(spec.Name),
@@ -1229,6 +1232,17 @@ func readEvidenceFile(path string, spec *ManifestSpec) ([]SessionEvent, error) {
 		events = append(events, ev)
 	}
 	return events, nil
+}
+
+// eventSeq lifts the evidence writer's sequence number; nil for lines that
+// predate seq-stamping.
+func eventSeq(raw map[string]any) *int64 {
+	value, ok := raw["event_seq"].(float64)
+	if !ok {
+		return nil
+	}
+	seq := int64(value)
+	return &seq
 }
 
 type evidenceSummary struct {

--- a/internal/sessionapi/types.go
+++ b/internal/sessionapi/types.go
@@ -318,7 +318,12 @@ func SessionsFromListItems(items []SessionListItem) []Session {
 
 // SessionEvent represents one evidence event from a session.
 type SessionEvent struct {
-	Event       string         `json:"event"`
+	Event string `json:"event"`
+	// EventSeq is the evidence writer's dense 1-based sequence number —
+	// the durable cursor for pagination and stream resume. Nil for lines
+	// written before seq-stamping existed.
+	EventSeq    *int64         `json:"event_seq,omitempty"`
+	Role        *string        `json:"role,omitempty"`
 	Timestamp   *string        `json:"ts,omitempty"`
 	SessionID   *string        `json:"session_id,omitempty"`
 	SpecIndex   *int           `json:"spec_index,omitempty"`

--- a/internal/sessionapi/types.go
+++ b/internal/sessionapi/types.go
@@ -334,5 +334,6 @@ type SessionEvent struct {
 
 // SessionEventsResponse wraps GET /api/sessions/{id}/events.
 type SessionEventsResponse struct {
-	Events []SessionEvent `json:"events"`
+	Events       []SessionEvent `json:"events"`
+	HeadEventSeq *int64         `json:"head_event_seq,omitempty"`
 }


### PR DESCRIPTION
The evidence writer already stamps every event with a durable, session-wide event_seq. This PR exposes that cursor without inventing identity for legacy evidence.

- SessionEvent exposes event_seq and role.
- JSON events accept after, before, and tail.
- JSON responses include head_event_seq, the durable high-water mark independent of the returned window, so a caught-up or filtered page can advance safely.
- SSE resumes from after or Last-Event-ID and emits id only for durable sequence values. An explicit after query wins, including after=0.
- SSE deliberately rejects before and tail because they are snapshot-window operations, not live-stream semantics.
- Legacy, mixed, and multi-spec evidence never receive synthetic cursor IDs; they safely replay. Old runtimes remain compatible by ignoring query parameters.

Companions: telos-org/cloud#61 and telos-org/web#55.

Validation: go test ./..., go vet ./..., and go build ./... pass. Coverage includes projection, forward/backward/tail windows, durable high-water behavior, malformed input, legacy and mixed evidence, multi-spec rollover, SSE resume/header precedence, unsupported SSE windows, and safe replay without synthetic IDs.