### PR TITLE
fix(cli): repair merged package interfaces

### DIFF
--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -140,7 +140,7 @@ func TestPrintPlanPreviewStarsRequiredVerifierSkills(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	printPlanPreview(&out, compiled, "./SPEC.md", "local", "root")
+	printPlanPreview(&out, compiled, "./SPEC.md", "local", "root", nil)
 	text := out.String()
 	if !strings.Contains(text, "Skills    verify-engineering*, verify-quality") {
 		t.Fatalf("plan output missing starred skill marker:\n%s", text)

--- a/internal/spec/package.go
+++ b/internal/spec/package.go
@@ -118,7 +118,7 @@ func ApplyPackageDigest(manifest *ApplyPackageManifest) string {
 	if manifest == nil {
 		return ""
 	}
-	return digestPackage(manifest.Spec.Digest, manifest.Skills)
+	return digestPackage(manifest.SchemaVersion, manifest.Spec.Digest, manifest.Skills)
 }
 
 // ApplyPackageSpec verifies a package's declared contents and returns its root spec.


### PR DESCRIPTION
## Summary

- include manifest schema version when recomputing package digests
- update the starred-skills plan preview test for the merged comparison parameter

## Validation

- `go build ./...`
- `go test ./...`
- `bazel test //...`

This is the focused release blocker discovered after PRs #13, #14, and #15 merged to master.