### PR TITLE
feat(ci): publish master releases automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -16,3 +17,72 @@ jobs:
       - run: go build ./...
       - run: go vet ./...
       - run: go test ./...
+
+  release:
+    name: publish-release
+    needs: test
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: telos-release
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TELOS_GCP_PROJECT: telos-experiments
+      TELOS_RELEASE_BUCKET: telos-runtime-artifacts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_RELEASE_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Resolve immutable release version
+        id: version
+        run: |
+          set -euo pipefail
+          if version="$(git describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null)"; then
+            :
+          else
+            base="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+            version="${base}+master.${GITHUB_SHA:0:12}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish immutable release
+        env:
+          TELOS_ALLOW_UNSIGNED_DARWIN: "1"
+        run: scripts/publish-release.sh "${{ steps.version.outputs.version }}"
+
+      - name: Verify published artifacts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          release="gs://${TELOS_RELEASE_BUCKET}/releases/${VERSION}"
+          verify="$RUNNER_TEMP/release-verify"
+          artifact=telos-linux-amd64
+          mkdir -p "$verify"
+          gcloud storage cp "${release}/SHA256SUMS" "$verify/SHA256SUMS" >/dev/null
+          gcloud storage cp "${release}/${artifact}" "$verify/telos" >/dev/null
+          expected="$(awk -v artifact="$artifact" '$2 == artifact { print $1 }' "$verify/SHA256SUMS")"
+          actual="$(sha256sum "$verify/telos" | awk '{ print $1 }')"
+          test -n "$expected"
+          test "$actual" = "$expected"
+          chmod 0755 "$verify/telos"
+          test "$("$verify/telos" --version)" = "telos $VERSION"
+
+      - name: Promote release
+        run: scripts/promote-release.sh "${{ steps.version.outputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: release
     concurrency:
       group: telos-release
       cancel-in-progress: false
@@ -85,4 +90,10 @@ jobs:
           test "$("$verify/telos" --version)" = "telos $VERSION"
 
       - name: Promote release
-        run: scripts/promote-release.sh "${{ steps.version.outputs.version }}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch origin master
+          test "$(git rev-parse origin/master)" = "$GITHUB_SHA"
+          scripts/promote-release.sh "$VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      TELOS_GCP_PROJECT: telos-experiments
       TELOS_RELEASE_BUCKET: telos-runtime-artifacts
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -163,3 +163,7 @@ Release builds use Bazel:
 bazel test //...
 scripts/publish-release.sh
 ```
+
+A protected `master` merge publishes a commit-addressed release, verifies its
+Linux artifact and checksum, and then promotes the `latest` manifest. Versioned
+objects are immutable; a partially failed publication is safe to retry.

--- a/README.md
+++ b/README.md
@@ -167,3 +167,6 @@ scripts/publish-release.sh
 A protected `master` merge publishes a commit-addressed release, verifies its
 Linux artifact and checksum, and then promotes the `latest` manifest. Versioned
 objects are immutable; a partially failed publication is safe to retry.
+Early-alpha macOS artifacts are intentionally unsigned. macOS users may need to
+approve the downloaded binary explicitly until signing and notarization become
+worth the operational dependency.

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 version="${1:?usage: scripts/promote-release.sh VERSION}"
 bucket="${TELOS_RELEASE_BUCKET:-telos-runtime-artifacts}"
-project="${TELOS_GCP_PROJECT:?set TELOS_GCP_PROJECT to the GCP project that owns the release bucket}"
 source="gs://${bucket}/releases/${version}"
 target="gs://${bucket}/releases/latest"
 

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:?usage: scripts/promote-release.sh VERSION}"
+bucket="${TELOS_RELEASE_BUCKET:-telos-runtime-artifacts}"
+project="${TELOS_GCP_PROJECT:?set TELOS_GCP_PROJECT to the GCP project that owns the release bucket}"
+source="gs://${bucket}/releases/${version}"
+target="gs://${bucket}/releases/latest"
+
+gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null
+
+verify_dir="$(mktemp -d)"
+trap 'rm -rf "${verify_dir}"' EXIT
+gcloud storage cp "${source}/manifest.json" "${verify_dir}/manifest.json" >/dev/null
+published_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "${verify_dir}/manifest.json")"
+if [[ "${published_version}" != "${version}" ]]; then
+  echo "promote-release: manifest contains ${published_version}, expected ${version}" >&2
+  exit 1
+fi
+
+# Consumers resolve the immutable version from manifest.json. Publish that
+# manifest last so latest always names a complete, verified release.
+for artifact in \
+  telos-darwin-amd64 \
+  telos-darwin-arm64 \
+  telos-linux-amd64 \
+  telos-linux-arm64 \
+  telosd-darwin-amd64 \
+  telosd-darwin-arm64 \
+  telosd-linux-amd64 \
+  telosd-linux-arm64 \
+  SHA256SUMS \
+  install.sh
+do
+  gcloud storage cp "${source}/${artifact}" "${target}/${artifact}" \
+    --cache-control="no-cache,max-age=0"
+done
+gcloud storage cp "${source}/manifest.json" "${target}/manifest.json" \
+  --cache-control="no-cache,max-age=0"
+
+echo "promoted ${version} to https://usetelos.ai/releases/latest/manifest.json"

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -7,8 +7,6 @@ project="${TELOS_GCP_PROJECT:?set TELOS_GCP_PROJECT to the GCP project that owns
 source="gs://${bucket}/releases/${version}"
 target="gs://${bucket}/releases/latest"
 
-gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null
-
 verify_dir="$(mktemp -d)"
 trap 'rm -rf "${verify_dir}"' EXIT
 gcloud storage cp "${source}/manifest.json" "${verify_dir}/manifest.json" >/dev/null

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -22,8 +22,6 @@ EOF
   exit 1
 fi
 
-gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null
-
 remote="gs://${bucket}/releases/${version}"
 verify_dir="$(mktemp -d)"
 trap 'rm -rf "${verify_dir}"' EXIT

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -17,7 +17,7 @@ if [[ ! -f "${dist}/.darwin-signed" && "${TELOS_ALLOW_UNSIGNED_DARWIN:-}" != "1"
   cat >&2 <<EOF
 publish-release: refusing to publish unsigned Darwin artifacts.
 Set TELOS_DARWIN_CODESIGN_IDENTITY to a Developer ID Application identity and rebuild.
-For an explicit internal-only override, set TELOS_ALLOW_UNSIGNED_DARWIN=1.
+For an explicit unsigned-publication override, set TELOS_ALLOW_UNSIGNED_DARWIN=1.
 EOF
   exit 1
 fi
@@ -25,19 +25,40 @@ fi
 gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null
 
 remote="gs://${bucket}/releases/${version}"
-if gcloud storage objects describe "${remote}/manifest.json" >/dev/null 2>&1; then
-  verify_dir="$(mktemp -d)"
-  trap 'rm -rf "${verify_dir}"' EXIT
-  gcloud storage cp "${remote}/SHA256SUMS" "${verify_dir}/SHA256SUMS" >/dev/null
-  cmp "${dist}/SHA256SUMS" "${verify_dir}/SHA256SUMS" >/dev/null || {
-    echo "publish-release: ${version} already exists with different artifacts" >&2
-    exit 1
-  }
-  echo "publish-release: ${version} already exists with matching checksums"
-else
-  gcloud storage cp "${dist}/"* "${remote}/" \
+verify_dir="$(mktemp -d)"
+trap 'rm -rf "${verify_dir}"' EXIT
+
+publish_immutable() {
+  local artifact="$1"
+  if gcloud storage objects describe "${remote}/${artifact}" >/dev/null 2>&1; then
+    gcloud storage cp "${remote}/${artifact}" "${verify_dir}/${artifact}" >/dev/null
+    cmp "${dist}/${artifact}" "${verify_dir}/${artifact}" >/dev/null || {
+      echo "publish-release: ${version}/${artifact} already differs" >&2
+      exit 1
+    }
+    return
+  fi
+  gcloud storage cp "${dist}/${artifact}" "${remote}/${artifact}" \
     --cache-control="public,max-age=31536000,immutable" \
     --if-generation-match=0
-fi
+}
+
+# The manifest is the release commit point. Upload it only after every artifact
+# exists and matches, making a partially failed publication safe to retry.
+for artifact in \
+  telos-darwin-amd64 \
+  telos-darwin-arm64 \
+  telos-linux-amd64 \
+  telos-linux-arm64 \
+  telosd-darwin-amd64 \
+  telosd-darwin-arm64 \
+  telosd-linux-amd64 \
+  telosd-linux-arm64 \
+  SHA256SUMS \
+  install.sh
+do
+  publish_immutable "${artifact}"
+done
+publish_immutable manifest.json
 
 echo "${remote}/manifest.json"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -5,7 +5,6 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 version="${1:-}"
 bucket="${TELOS_RELEASE_BUCKET:-telos-runtime-artifacts}"
 project="${TELOS_GCP_PROJECT:?set TELOS_GCP_PROJECT to the GCP project that owns the release bucket}"
-location="${TELOS_GCS_LOCATION:-us-west1}"
 
 if [[ -z "${version}" ]]; then
   dist="$("${repo_root}/scripts/build-release.sh")"
@@ -23,30 +22,22 @@ EOF
   exit 1
 fi
 
-if ! gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null 2>&1; then
-  gcloud storage buckets create "gs://${bucket}" \
-    --project "${project}" \
-    --location "${location}" \
-    --uniform-bucket-level-access
+gcloud storage buckets describe "gs://${bucket}" --project "${project}" >/dev/null
+
+remote="gs://${bucket}/releases/${version}"
+if gcloud storage objects describe "${remote}/manifest.json" >/dev/null 2>&1; then
+  verify_dir="$(mktemp -d)"
+  trap 'rm -rf "${verify_dir}"' EXIT
+  gcloud storage cp "${remote}/SHA256SUMS" "${verify_dir}/SHA256SUMS" >/dev/null
+  cmp "${dist}/SHA256SUMS" "${verify_dir}/SHA256SUMS" >/dev/null || {
+    echo "publish-release: ${version} already exists with different artifacts" >&2
+    exit 1
+  }
+  echo "publish-release: ${version} already exists with matching checksums"
+else
+  gcloud storage cp "${dist}/"* "${remote}/" \
+    --cache-control="public,max-age=31536000,immutable" \
+    --if-generation-match=0
 fi
 
-gcloud storage cp "${dist}/"* "gs://${bucket}/releases/${version}/" \
-  --cache-control="public,max-age=31536000,immutable"
-
-gcloud storage cp "${dist}/telos-"* "gs://${bucket}/releases/latest/" \
-  --cache-control="no-cache,max-age=0"
-gcloud storage cp "${dist}/telosd-"* "gs://${bucket}/releases/latest/" \
-  --cache-control="no-cache,max-age=0"
-gcloud storage cp "${dist}/SHA256SUMS" "gs://${bucket}/releases/latest/SHA256SUMS" \
-  --cache-control="no-cache,max-age=0"
-gcloud storage cp "${dist}/manifest.json" "gs://${bucket}/releases/latest/manifest.json" \
-  --cache-control="no-cache,max-age=0"
-gcloud storage cp "${dist}/install.sh" "gs://${bucket}/releases/latest/install.sh" \
-  --cache-control="no-cache,max-age=0"
-
-gcloud storage buckets add-iam-policy-binding "gs://${bucket}" \
-  --member=allUsers \
-  --role=roles/storage.objectViewer \
-  --project "${project}" >/dev/null
-
-echo "https://usetelos.ai/releases/${version}/manifest.json"
+echo "${remote}/manifest.json"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 version="${1:-}"
 bucket="${TELOS_RELEASE_BUCKET:-telos-runtime-artifacts}"
-project="${TELOS_GCP_PROJECT:?set TELOS_GCP_PROJECT to the GCP project that owns the release bucket}"
 
 if [[ -z "${version}" ]]; then
   dist="$("${repo_root}/scripts/build-release.sh")"


### PR DESCRIPTION
## Summary

- publish immutable, commit-addressed Telos CLI and runtime releases from protected master
- make versioned publication retry-safe with create-only objects and a manifest-last commit point
- verify the published Linux artifact, checksum, and stamped version before promoting `latest`
- guard promotion against stale master runs and use a least-privilege WIF release identity
- intentionally publish unsigned macOS artifacts during early alpha; signing and notarization are a later product dependency

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `bazel test //...`
- shell syntax validation
- retry harness: partial publication repaired on retry, complete publication idempotent
