### PR TITLE
feat: improve logs presentation

### DIFF
--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -23,36 +22,75 @@ import (
 func cmdLogs(args []string) {
 	fs := flag.NewFlagSet("logs", flag.ExitOnError)
 	follow := fs.Bool("f", false, "Follow logs")
-	verbose := fs.Bool("verbose", false, "Show verbose log events")
+	verbose := fs.Bool("verbose", false, "Include detailed human-readable activity")
+	jsonOutput := fs.Bool("json", false, "Print newline-delimited JSON events")
+	raw := fs.Bool("raw", false, "Print the raw transcript or evidence events")
+	tail := fs.Int("tail", defaultLogTail, "Show the most recent N activity rows")
+	all := fs.Bool("all", false, "Show all activity rows")
 	parseFlags(fs, args)
 
 	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "usage: telos logs [-f] [--verbose] SESSION")
+		fmt.Fprintln(os.Stderr, "usage: telos logs [-f] [--verbose|--json|--raw] [--tail N|--all] SESSION")
+		os.Exit(1)
+	}
+	if enabledFlagCount(*verbose, *jsonOutput, *raw) > 1 {
+		fmt.Fprintln(os.Stderr, "error: --verbose, --json, and --raw are mutually exclusive")
+		os.Exit(1)
+	}
+	if *tail < 1 && !*all {
+		fmt.Fprintln(os.Stderr, "error: --tail must be greater than zero")
 		os.Exit(1)
 	}
 	sessionID := fs.Arg(0)
+	options := logViewOptions{Verbose: *verbose, Tail: *tail, All: *all}
 
 	if *follow {
-		if !localSessionExists(sessionID) {
-			if _, found, err := getCloudSessionIfConfigured(sessionID); err != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				os.Exit(1)
-			} else if found {
-				followCloudSessionLogs(sessionID, *verbose)
-				return
+		if session, err := getSessionFromAnywhere(sessionID); err == nil {
+			if *raw {
+				followTranscriptLogs(sessionID, true)
+			} else {
+				followSessionLogs(session, options, *jsonOutput)
 			}
+			return
 		}
-		followLogs(sessionID, *verbose)
+		if session, found, err := getCloudSessionIfConfigured(sessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		} else if found {
+			followCloudSessionLogs(session, options, *jsonOutput || *raw)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", localSessionNotFoundError(sessionID))
+		os.Exit(1)
+	}
+
+	if session, err := getSessionFromAnywhere(sessionID); err == nil {
+		if *raw {
+			text, transcriptErr := getTranscriptFromAnywhere(sessionID)
+			if transcriptErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", transcriptErr)
+				os.Exit(1)
+			}
+			printLogs(os.Stdout, text, true)
+			return
+		}
+		events, eventsErr := getEventsFromAnywhere(sessionID)
+		if eventsErr != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
+			os.Exit(1)
+		}
+		if *jsonOutput {
+			if eventsErr := printJSONLogEvents(os.Stdout, selectLogEvents(events, options)); eventsErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
+				os.Exit(1)
+			}
+			return
+		}
+		printStructuredLogs(os.Stdout, localLogHeader(session), events, options)
 		return
 	}
 
-	text, err := getTranscriptFromAnywhere(sessionID)
-	if err == nil {
-		printLogs(os.Stdout, text, *verbose)
-		return
-	}
-
-	if _, found, cloudErr := getCloudSessionIfConfigured(sessionID); cloudErr != nil {
+	if session, found, cloudErr := getCloudSessionIfConfigured(sessionID); cloudErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", cloudErr)
 		os.Exit(1)
 	} else if found {
@@ -66,28 +104,60 @@ func cmdLogs(args []string) {
 			fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
 			os.Exit(1)
 		}
-		printCloudSessionLogEvents(os.Stdout, events, *verbose)
+		if *jsonOutput || *raw {
+			outputEvents := events
+			if *jsonOutput {
+				outputEvents = selectLogEvents(events, options)
+			}
+			if eventsErr := printJSONLogEvents(os.Stdout, outputEvents); eventsErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
+				os.Exit(1)
+			}
+			return
+		}
+		printStructuredLogs(os.Stdout, cloudLogHeader(session), events, options)
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	fmt.Fprintf(os.Stderr, "error: %v\n", localSessionNotFoundError(sessionID))
 	os.Exit(1)
 }
 
-func followLogs(sessionID string, verbose bool) {
-	if err := followTranscript(sessionID, os.Stdout, time.Sleep, verbose); err != nil {
+func enabledFlagCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+func followTranscriptLogs(sessionID string, raw bool) {
+	if err := followTranscript(sessionID, os.Stdout, time.Sleep, raw); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func followCloudSessionLogs(sessionID string, verbose bool) {
+func followSessionLogs(session *sessionapi.Session, options logViewOptions, jsonOutput bool) {
+	if err := pollSessionLogs(session, os.Stdout, time.Sleep, options, jsonOutput); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func followCloudSessionLogs(session *cloud.SessionRecord, options logViewOptions, jsonOutput bool) {
 	control, err := cloud.ControlClient()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	if err := streamCloudSessionLogs(control, sessionID, os.Stdout, time.Sleep, verbose); err != nil {
+	if !jsonOutput {
+		printStructuredLogs(os.Stdout, cloudLogHeader(session), nil, options)
+		fmt.Fprintln(os.Stdout)
+	}
+	if err := streamCloudSessionLogs(control, session.ID, os.Stdout, time.Sleep, options.Verbose, jsonOutput); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -99,12 +169,15 @@ func streamCloudSessionLogs(
 	out io.Writer,
 	sleep func(time.Duration),
 	verbose bool,
+	jsonOutput bool,
 ) error {
-	var lastProgressCount int
 	for {
 		streamErr := control.StreamSessionLogs(context.Background(), sessionID, func(event sessionapi.SessionEvent) error {
-			printed := printCloudSessionLogEvent(out, event, verbose, &lastProgressCount)
-			if printed {
+			printed, err := printStreamingLogEvent(out, event, verbose, jsonOutput)
+			if err != nil {
+				return err
+			}
+			if printed && !jsonOutput {
 				_, _ = fmt.Fprintln(out)
 			}
 			return nil
@@ -132,6 +205,75 @@ func streamCloudSessionLogs(
 		}
 		sleep(2 * time.Second)
 	}
+}
+
+func pollSessionLogs(
+	session *sessionapi.Session,
+	out io.Writer,
+	sleep func(time.Duration),
+	options logViewOptions,
+	jsonOutput bool,
+) error {
+	events, err := getEventsFromAnywhere(session.SessionID)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		if err := printJSONLogEvents(out, selectLogEvents(events, options)); err != nil {
+			return err
+		}
+	} else {
+		printStructuredLogs(out, localLogHeader(session), events, options)
+	}
+	seen := len(events)
+	if session.Status.IsTerminal() {
+		return nil
+	}
+
+	for {
+		sleep(2 * time.Second)
+		events, err = getEventsFromAnywhere(session.SessionID)
+		if err != nil {
+			return err
+		}
+		for _, event := range events[minimum(seen, len(events)):] {
+			if _, err := printStreamingLogEvent(out, event, options.Verbose, jsonOutput); err != nil {
+				return err
+			}
+		}
+		seen = len(events)
+		session, err = getSessionFromAnywhere(session.SessionID)
+		if err != nil {
+			return err
+		}
+		if session.Status.IsTerminal() {
+			return nil
+		}
+	}
+}
+
+func printStreamingLogEvent(
+	out io.Writer,
+	event sessionapi.SessionEvent,
+	verbose bool,
+	jsonOutput bool,
+) (bool, error) {
+	if jsonOutput {
+		return true, printJSONLogEvents(out, []sessionapi.SessionEvent{event})
+	}
+	row, ok := renderedLogRowFromEvent(event, verbose)
+	if !ok {
+		return false, nil
+	}
+	printRenderedLogRow(out, row)
+	return true, nil
+}
+
+func minimum(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
 }
 
 func cloudSessionStateTerminal(state string) bool {
@@ -207,96 +349,6 @@ func printLogs(out io.Writer, transcript string, raw bool) {
 		return
 	}
 	printLogBlocks(out, blocks, 0)
-}
-
-func printCloudSessionLogEvents(out io.Writer, events []sessionapi.SessionEvent, verbose bool) {
-	progressCount := 0
-	printed := false
-	for _, event := range events {
-		if printed {
-			fmt.Fprintln(out)
-		}
-		if printCloudSessionLogEvent(out, event, verbose, &progressCount) {
-			printed = true
-		}
-	}
-	if !printed {
-		fmt.Fprintln(out, "no session log entries")
-	}
-}
-
-func printCloudSessionLogEvent(out io.Writer, event sessionapi.SessionEvent, verbose bool, progressCount *int) bool {
-	if verbose {
-		data, err := json.Marshal(event)
-		if err != nil {
-			return false
-		}
-		fmt.Fprintln(out, string(data))
-		return true
-	}
-	switch event.Event {
-	case "agent_progress":
-		kind, _ := event.Data["kind"].(string)
-		text, _ := event.Data["text"].(string)
-		if strings.TrimSpace(text) == "" {
-			return false
-		}
-		block := logBlock{kind: kind, text: strings.TrimSpace(text)}
-		*progressCount = printLogBlocks(out, []logBlock{block}, *progressCount)
-		return true
-	case "agent_complete":
-		status, _ := event.Data["status"].(string)
-		model, _ := event.Data["model"].(string)
-		turns, hasTurns := numericEventValue(event.Data["num_turns"])
-		if status == "" && model == "" && !hasTurns {
-			return false
-		}
-		fmt.Fprintf(out, "Agent complete: %s", orDash(status))
-		if model != "" {
-			fmt.Fprintf(out, " model=%s", model)
-		}
-		if hasTurns {
-			fmt.Fprintf(out, " turns=%d", turns)
-		}
-		fmt.Fprintln(out)
-		return true
-	case "agent_failure_recoverable":
-		errText, _ := event.Data["error"].(string)
-		if strings.TrimSpace(errText) == "" {
-			return false
-		}
-		current, hasCurrent := numericEventValue(event.Data["consecutive_failures"])
-		maxFailures, hasMax := numericEventValue(event.Data["max_failures"])
-		fmt.Fprintf(out, "Recoverable failure: %s", strings.TrimSpace(errText))
-		if hasCurrent && hasMax {
-			fmt.Fprintf(out, " (%d/%d)", current, maxFailures)
-		}
-		fmt.Fprintln(out)
-		return true
-	case "game_end":
-		if result, _ := event.Data["game_result"].(string); result != "" {
-			fmt.Fprintf(out, "Completed: %s%s\n", result, eventErrorSuffix(event))
-			return true
-		}
-		if reason, _ := event.Data["completion_reason"].(string); reason != "" {
-			fmt.Fprintf(out, "Completed: %s%s\n", reason, eventErrorSuffix(event))
-			return true
-		}
-	}
-	if message, _ := event.Data["message"].(string); strings.TrimSpace(message) != "" {
-		fmt.Fprintln(out, strings.TrimSpace(message))
-		return true
-	}
-	return false
-}
-
-func eventErrorSuffix(event sessionapi.SessionEvent) string {
-	errText, _ := event.Data["error"].(string)
-	errText = strings.TrimSpace(errText)
-	if errText == "" {
-		return ""
-	}
-	return " (" + errText + ")"
 }
 
 func numericEventValue(value any) (int, bool) {

--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -198,7 +198,6 @@ func followCloudSessionLogs(session *cloud.SessionRecord, options logViewOptions
 		printStructuredLogs(os.Stdout, cloudLogHeader(session), page.Events, options)
 		fmt.Fprintln(os.Stdout)
 	}
-	resume := runtimeResumeCursor(page.RuntimeCursor)
 	if err := streamCloudSessionLogsAfter(
 		control,
 		session.ID,
@@ -206,7 +205,7 @@ func followCloudSessionLogs(session *cloud.SessionRecord, options logViewOptions
 		time.Sleep,
 		options.Verbose,
 		jsonOutput,
-		resume,
+		page.RuntimeCursor,
 		cloudLogHeader(session),
 		page.Events,
 	); err != nil {
@@ -235,7 +234,8 @@ func followCloudRawSessionLogs(session *cloud.SessionRecord) {
 		session.ID,
 		os.Stdout,
 		time.Sleep,
-		runtimeResumeCursor(page.RuntimeCursor),
+		page.RuntimeCursor,
+		page.RawEvents,
 	); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -276,8 +276,15 @@ func streamCloudSessionLogsAfter(
 ) error {
 	events := append([]sessionapi.SessionEvent(nil), initialEvents...)
 	currentStatus := deriveOverallLogStatus(header, events)
+	replayCounts := map[string]int(nil)
+	if afterRuntime == nil {
+		replayCounts = sessionEventReplayCounts(initialEvents)
+	}
 	for {
 		streamErr := control.StreamSessionLogsAfter(context.Background(), sessionID, afterRuntime, func(event sessionapi.SessionEvent) error {
+			if consumeSessionEventReplay(replayCounts, event) {
+				return nil
+			}
 			printed, err := printStreamingLogEvent(out, event, verbose, jsonOutput)
 			if err != nil {
 				return err
@@ -327,13 +334,21 @@ func streamCloudRawSessionLogs(
 	out io.Writer,
 	sleep func(time.Duration),
 	afterRuntime *int64,
+	initialEvents []json.RawMessage,
 ) error {
+	replayCounts := map[string]int(nil)
+	if afterRuntime == nil {
+		replayCounts = rawEventReplayCounts(initialEvents)
+	}
 	for {
 		streamErr := control.StreamRawSessionLogsAfter(
 			context.Background(),
 			sessionID,
 			afterRuntime,
 			func(event json.RawMessage) error {
+				if consumeRawEventReplay(replayCounts, event) {
+					return nil
+				}
 				return printRawJSONLogEvents(out, []json.RawMessage{event})
 			},
 		)
@@ -425,14 +440,6 @@ func printStatusTransition(out io.Writer, timestamp string, status overallLogSta
 	})
 }
 
-func runtimeResumeCursor(cursor *int64) *int64 {
-	if cursor != nil {
-		return cursor
-	}
-	zero := int64(0)
-	return &zero
-}
-
 func printRawJSONLogEvents(out io.Writer, events []json.RawMessage) error {
 	for _, event := range events {
 		if !json.Valid(event) {
@@ -446,6 +453,74 @@ func printRawJSONLogEvents(out io.Writer, events []json.RawMessage) error {
 		}
 	}
 	return nil
+}
+
+func sessionEventReplayCounts(events []sessionapi.SessionEvent) map[string]int {
+	counts := make(map[string]int, len(events))
+	for _, event := range events {
+		key, ok := sessionEventReplayKey(event)
+		if ok {
+			counts[key]++
+		}
+	}
+	return counts
+}
+
+func consumeSessionEventReplay(counts map[string]int, event sessionapi.SessionEvent) bool {
+	if len(counts) == 0 {
+		return false
+	}
+	key, ok := sessionEventReplayKey(event)
+	if !ok || counts[key] == 0 {
+		return false
+	}
+	if counts[key] == 1 {
+		delete(counts, key)
+	} else {
+		counts[key]--
+	}
+	return true
+}
+
+func sessionEventReplayKey(event sessionapi.SessionEvent) (string, bool) {
+	data, err := json.Marshal(event)
+	return string(data), err == nil
+}
+
+func rawEventReplayCounts(events []json.RawMessage) map[string]int {
+	counts := make(map[string]int, len(events))
+	for _, event := range events {
+		key, ok := rawEventReplayKey(event)
+		if ok {
+			counts[key]++
+		}
+	}
+	return counts
+}
+
+func consumeRawEventReplay(counts map[string]int, event json.RawMessage) bool {
+	if len(counts) == 0 {
+		return false
+	}
+	key, ok := rawEventReplayKey(event)
+	if !ok || counts[key] == 0 {
+		return false
+	}
+	if counts[key] == 1 {
+		delete(counts, key)
+	} else {
+		counts[key]--
+	}
+	return true
+}
+
+func rawEventReplayKey(event json.RawMessage) (string, bool) {
+	var value any
+	if err := json.Unmarshal(event, &value); err != nil {
+		return "", false
+	}
+	data, err := json.Marshal(value)
+	return string(data), err == nil
 }
 
 func legacyTranscriptFallback(

--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -57,7 +58,11 @@ func cmdLogs(args []string) {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		} else if found {
-			followCloudSessionLogs(session, options, *jsonOutput || *raw)
+			if *raw {
+				followCloudRawSessionLogs(session)
+			} else {
+				followCloudSessionLogs(session, options, *jsonOutput)
+			}
 			return
 		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", localSessionNotFoundError(sessionID))
@@ -75,7 +80,20 @@ func cmdLogs(args []string) {
 			return
 		}
 		events, eventsErr := getEventsFromAnywhere(sessionID)
+		if !*jsonOutput {
+			if transcript, ok := legacyTranscriptFallback(sessionID, events, eventsErr); ok {
+				printLogs(os.Stdout, transcript, false)
+				return
+			}
+		}
 		if eventsErr != nil {
+			if *jsonOutput && transcriptNotReady(eventsErr) {
+				fmt.Fprintln(
+					os.Stderr,
+					"error: structured events are unavailable for this older session; omit --json for readable logs or use --raw for the transcript",
+				)
+				os.Exit(1)
+			}
 			fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
 			os.Exit(1)
 		}
@@ -99,23 +117,26 @@ func cmdLogs(args []string) {
 			fmt.Fprintf(os.Stderr, "error: %v\n", controlErr)
 			os.Exit(1)
 		}
-		events, eventsErr := control.GetSessionLogs(sessionID)
+		page, eventsErr := control.GetSessionLogPage(sessionID)
 		if eventsErr != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
 			os.Exit(1)
 		}
-		if *jsonOutput || *raw {
-			outputEvents := events
-			if *jsonOutput {
-				outputEvents = selectLogEvents(events, options)
-			}
-			if eventsErr := printJSONLogEvents(os.Stdout, outputEvents); eventsErr != nil {
+		if *raw {
+			if eventsErr := printRawJSONLogEvents(os.Stdout, page.RawEvents); eventsErr != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
 				os.Exit(1)
 			}
 			return
 		}
-		printStructuredLogs(os.Stdout, cloudLogHeader(session), events, options)
+		if *jsonOutput {
+			if eventsErr := printJSONLogEvents(os.Stdout, selectLogEvents(page.Events, options)); eventsErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", eventsErr)
+				os.Exit(1)
+			}
+			return
+		}
+		printStructuredLogs(os.Stdout, cloudLogHeader(session), page.Events, options)
 		return
 	}
 
@@ -141,6 +162,16 @@ func followTranscriptLogs(sessionID string, raw bool) {
 }
 
 func followSessionLogs(session *sessionapi.Session, options logViewOptions, jsonOutput bool) {
+	if !jsonOutput {
+		events, eventsErr := getEventsFromAnywhere(session.SessionID)
+		if _, ok := legacyTranscriptFallback(session.SessionID, events, eventsErr); ok {
+			if err := followTranscript(session.SessionID, os.Stdout, time.Sleep, false); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+	}
 	if err := pollSessionLogs(session, os.Stdout, time.Sleep, options, jsonOutput); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -153,11 +184,59 @@ func followCloudSessionLogs(session *cloud.SessionRecord, options logViewOptions
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	if !jsonOutput {
-		printStructuredLogs(os.Stdout, cloudLogHeader(session), nil, options)
+	page, err := control.GetSessionLogPage(session.ID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if jsonOutput {
+		if err := printJSONLogEvents(os.Stdout, selectLogEvents(page.Events, options)); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		printStructuredLogs(os.Stdout, cloudLogHeader(session), page.Events, options)
 		fmt.Fprintln(os.Stdout)
 	}
-	if err := streamCloudSessionLogs(control, session.ID, os.Stdout, time.Sleep, options.Verbose, jsonOutput); err != nil {
+	resume := runtimeResumeCursor(page.RuntimeCursor)
+	if err := streamCloudSessionLogsAfter(
+		control,
+		session.ID,
+		os.Stdout,
+		time.Sleep,
+		options.Verbose,
+		jsonOutput,
+		resume,
+		cloudLogHeader(session),
+		page.Events,
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func followCloudRawSessionLogs(session *cloud.SessionRecord) {
+	control, err := cloud.ControlClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	page, err := control.GetSessionLogPage(session.ID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := printRawJSONLogEvents(os.Stdout, page.RawEvents); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := streamCloudRawSessionLogs(
+		control,
+		session.ID,
+		os.Stdout,
+		time.Sleep,
+		runtimeResumeCursor(page.RuntimeCursor),
+	); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -171,14 +250,49 @@ func streamCloudSessionLogs(
 	verbose bool,
 	jsonOutput bool,
 ) error {
+	return streamCloudSessionLogsAfter(
+		control,
+		sessionID,
+		out,
+		sleep,
+		verbose,
+		jsonOutput,
+		nil,
+		logHeader{},
+		nil,
+	)
+}
+
+func streamCloudSessionLogsAfter(
+	control *cloud.Client,
+	sessionID string,
+	out io.Writer,
+	sleep func(time.Duration),
+	verbose bool,
+	jsonOutput bool,
+	afterRuntime *int64,
+	header logHeader,
+	initialEvents []sessionapi.SessionEvent,
+) error {
+	events := append([]sessionapi.SessionEvent(nil), initialEvents...)
+	currentStatus := deriveOverallLogStatus(header, events)
 	for {
-		streamErr := control.StreamSessionLogs(context.Background(), sessionID, func(event sessionapi.SessionEvent) error {
+		streamErr := control.StreamSessionLogsAfter(context.Background(), sessionID, afterRuntime, func(event sessionapi.SessionEvent) error {
 			printed, err := printStreamingLogEvent(out, event, verbose, jsonOutput)
 			if err != nil {
 				return err
 			}
 			if printed && !jsonOutput {
 				_, _ = fmt.Fprintln(out)
+			}
+			events = append(events, event)
+			if !jsonOutput && header.SessionID != "" {
+				nextStatus := deriveOverallLogStatus(header, events)
+				if nextStatus.Label != currentStatus.Label {
+					printStatusTransition(out, eventTimestamp(event), nextStatus)
+					_, _ = fmt.Fprintln(out)
+				}
+				currentStatus = nextStatus
 			}
 			return nil
 		})
@@ -196,6 +310,43 @@ func streamCloudSessionLogs(
 			if cloud.IsStatus(err, http.StatusNotFound) {
 				// The control plane hard-deletes deployments once teardown
 				// completes; a session vanishing mid-follow means it finished.
+				return nil
+			}
+			return err
+		}
+		if cloudSessionStateTerminal(session.State) {
+			return streamErr
+		}
+		sleep(2 * time.Second)
+	}
+}
+
+func streamCloudRawSessionLogs(
+	control *cloud.Client,
+	sessionID string,
+	out io.Writer,
+	sleep func(time.Duration),
+	afterRuntime *int64,
+) error {
+	for {
+		streamErr := control.StreamRawSessionLogsAfter(
+			context.Background(),
+			sessionID,
+			afterRuntime,
+			func(event json.RawMessage) error {
+				return printRawJSONLogEvents(out, []json.RawMessage{event})
+			},
+		)
+		if streamErr == nil {
+			return nil
+		}
+		if !transcriptNotReady(streamErr) {
+			return streamErr
+		}
+
+		session, err := control.GetSession(sessionID)
+		if err != nil {
+			if cloud.IsStatus(err, http.StatusNotFound) {
 				return nil
 			}
 			return err
@@ -225,6 +376,7 @@ func pollSessionLogs(
 	} else {
 		printStructuredLogs(out, localLogHeader(session), events, options)
 	}
+	currentStatus := deriveOverallLogStatus(localLogHeader(session), events)
 	seen := len(events)
 	if session.Status.IsTerminal() {
 		return nil
@@ -246,10 +398,69 @@ func pollSessionLogs(
 		if err != nil {
 			return err
 		}
+		if !jsonOutput {
+			nextStatus := deriveOverallLogStatus(localLogHeader(session), events)
+			if nextStatus.Label != currentStatus.Label {
+				timestamp := ""
+				if len(events) > 0 {
+					timestamp = eventTimestamp(events[len(events)-1])
+				}
+				printStatusTransition(out, timestamp, nextStatus)
+			}
+			currentStatus = nextStatus
+		}
 		if session.Status.IsTerminal() {
 			return nil
 		}
 	}
+}
+
+func printStatusTransition(out io.Writer, timestamp string, status overallLogStatus) {
+	printRenderedLogRow(out, renderedLogRow{
+		Timestamp: timestamp,
+		Phase:     "STATUS",
+		Summary:   status.Label,
+		Detail:    status.Reason,
+		Count:     1,
+	})
+}
+
+func runtimeResumeCursor(cursor *int64) *int64 {
+	if cursor != nil {
+		return cursor
+	}
+	zero := int64(0)
+	return &zero
+}
+
+func printRawJSONLogEvents(out io.Writer, events []json.RawMessage) error {
+	for _, event := range events {
+		if !json.Valid(event) {
+			return errors.New("raw session log event is invalid JSON")
+		}
+		if _, err := out.Write(event); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func legacyTranscriptFallback(
+	sessionID string,
+	events []sessionapi.SessionEvent,
+	eventsErr error,
+) (string, bool) {
+	if eventsErr == nil && len(events) > 0 {
+		return "", false
+	}
+	transcript, err := getTranscriptFromAnywhere(sessionID)
+	if err != nil || len(logBlocks(transcript)) == 0 {
+		return "", false
+	}
+	return transcript, true
 }
 
 func printStreamingLogEvent(

--- a/cmd/telos/logs_view.go
+++ b/cmd/telos/logs_view.go
@@ -1,0 +1,635 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/telos-org/telos/internal/cloud"
+	"github.com/telos-org/telos/internal/sessionapi"
+)
+
+const defaultLogTail = 50
+
+type logViewOptions struct {
+	Verbose bool
+	Tail    int
+	All     bool
+}
+
+type logHeader struct {
+	Name       string
+	State      string
+	PackageRef string
+	SessionID  string
+	UpdatedAt  string
+	Failure    string
+}
+
+type overallLogStatus struct {
+	Label  string
+	Reason string
+}
+
+type renderedLogRow struct {
+	Timestamp string
+	Phase     string
+	Summary   string
+	Detail    string
+	GroupKey  string
+	CountNoun string
+	Count     int
+	Order     int
+}
+
+func cloudLogHeader(session *cloud.SessionRecord) logHeader {
+	failure := ""
+	if session.FailureReason != nil {
+		failure = strings.TrimSpace(*session.FailureReason)
+	}
+	return logHeader{
+		Name:       session.Name,
+		State:      session.State,
+		PackageRef: session.PackageRef,
+		SessionID:  session.ID,
+		UpdatedAt:  session.UpdatedAt,
+		Failure:    failure,
+	}
+}
+
+func localLogHeader(session *sessionapi.Session) logHeader {
+	name := session.SessionID
+	if session.SpecName != nil && strings.TrimSpace(*session.SpecName) != "" {
+		name = strings.TrimSpace(*session.SpecName)
+	}
+	failure := ""
+	if session.Error != nil {
+		failure = strings.TrimSpace(*session.Error)
+	}
+	updatedAt := ""
+	if session.FinishedAt != nil {
+		updatedAt = *session.FinishedAt
+	} else if session.CreatedAt != nil {
+		updatedAt = *session.CreatedAt
+	}
+	return logHeader{
+		Name:      name,
+		State:     string(session.Status),
+		SessionID: session.SessionID,
+		UpdatedAt: updatedAt,
+		Failure:   failure,
+	}
+}
+
+func printStructuredLogs(
+	out io.Writer,
+	header logHeader,
+	events []sessionapi.SessionEvent,
+	options logViewOptions,
+) {
+	status := deriveOverallLogStatus(header, events)
+	fmt.Fprintln(out, strings.ToUpper(header.Name))
+	fmt.Fprintln(out)
+	printSummaryField(out, "Status", status.Label)
+	printSummaryField(out, "Summary", status.Reason)
+	if header.PackageRef != "" {
+		printSummaryField(out, "Spec", header.PackageRef)
+	}
+	if header.UpdatedAt != "" {
+		printSummaryField(out, "Updated", displayLogDate(header.UpdatedAt))
+	}
+	printSummaryField(out, "Session", header.SessionID)
+
+	rows := collapseRepeatedLogRows(renderLogRows(events, options.Verbose))
+	if !options.All && options.Tail > 0 && len(rows) > options.Tail {
+		rows = rows[len(rows)-options.Tail:]
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "ACTIVITY")
+	if len(rows) == 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "No activity yet.")
+		return
+	}
+	fmt.Fprintln(out)
+	for index, row := range rows {
+		if index > 0 {
+			fmt.Fprintln(out)
+		}
+		printRenderedLogRow(out, row)
+	}
+}
+
+func printJSONLogEvents(out io.Writer, events []sessionapi.SessionEvent) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetEscapeHTML(false)
+	for _, event := range events {
+		if err := encoder.Encode(event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func selectLogEvents(
+	events []sessionapi.SessionEvent,
+	options logViewOptions,
+) []sessionapi.SessionEvent {
+	if options.All || options.Tail >= len(events) {
+		return events
+	}
+	return events[len(events)-options.Tail:]
+}
+
+func deriveOverallLogStatus(
+	header logHeader,
+	events []sessionapi.SessionEvent,
+) overallLogStatus {
+	switch strings.ToLower(strings.TrimSpace(header.State)) {
+	case "deleted", "stopped":
+		return overallLogStatus{Label: "Stopped", Reason: firstNonEmpty(header.Failure, "This session was stopped.")}
+	case "failed", "error", "errored", "stale":
+		return overallLogStatus{Label: "Failed", Reason: firstNonEmpty(header.Failure, "The session could not complete.")}
+	case "pending", "provisioning", "deploying":
+		return overallLogStatus{Label: "Starting", Reason: "Preparing the deployment and runtime."}
+	}
+
+	reset := -1
+	latestConcede := -1
+	latestContinue := -1
+	latestFailure := -1
+	latestWork := -1
+	latestWorkText := ""
+	latestNotice := -1
+	latestNoticeText := ""
+	for index, event := range events {
+		switch event.Event {
+		case "external_update", "deployment.update_accepted", "deployment.update_dispatched":
+			reset = index
+			latestConcede = -1
+			latestContinue = -1
+			latestFailure = -1
+			latestWork = -1
+			latestWorkText = ""
+			latestNotice = -1
+			latestNoticeText = ""
+		case "agent_complete":
+			status := strings.ToUpper(eventDataString(event, "status"))
+			role := eventRole(event)
+			if status == "CONCEDE" && role == "verifier" {
+				latestConcede = index
+			} else if status == "CONTINUE" && role == "verifier" {
+				latestContinue = index
+			}
+		case "game_end":
+			result := strings.ToLower(eventDataString(event, "game_result"))
+			if result == "success" {
+				latestConcede = index
+			} else if result == "failure" {
+				latestFailure = index
+			}
+		case "budget_exceeded", "game_error":
+			latestFailure = index
+		case "agent_failure_recoverable":
+			latestNotice = index
+			notice := strings.TrimSuffix(
+				friendlyAgentError(eventDataString(event, "error")),
+				", retrying",
+			)
+			latestNoticeText = notice + "; retrying."
+		case "game_start", "agent_progress":
+			latestWork = index
+			if event.Event == "agent_progress" {
+				text := eventDataString(event, "text")
+				if text != "" && !isMinorLogAction(text) {
+					latestWorkText = text
+				}
+			}
+		}
+	}
+
+	if latestConcede > reset && latestConcede > latestContinue {
+		return overallLogStatus{
+			Label:  "Ready",
+			Reason: "Current spec accepted; latest verification completed successfully.",
+		}
+	}
+	if latestFailure > reset && latestFailure > latestWork {
+		failure := eventFailure(events[latestFailure])
+		return overallLogStatus{
+			Label:  "Needs attention",
+			Reason: firstNonEmpty(failure, "Progress stopped on an evaluation error."),
+		}
+	}
+	if latestNotice > reset && latestNotice > latestWork {
+		return overallLogStatus{Label: "Working", Reason: latestNoticeText}
+	}
+	return overallLogStatus{
+		Label:  "Working",
+		Reason: firstNonEmpty(conciseLogText(latestWorkText, 120), "Implementing or verifying the current spec."),
+	}
+}
+
+func renderLogRows(events []sessionapi.SessionEvent, verbose bool) []renderedLogRow {
+	rows := make([]renderedLogRow, 0, len(events))
+	for index, event := range events {
+		row, ok := renderedLogRowFromEvent(event, verbose)
+		if !ok {
+			continue
+		}
+		row.Order = index
+		if row.Count == 0 {
+			row.Count = 1
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func renderedLogRowFromEvent(
+	event sessionapi.SessionEvent,
+	verbose bool,
+) (renderedLogRow, bool) {
+	row := renderedLogRow{Timestamp: eventTimestamp(event), Phase: "SYSTEM"}
+	role := eventRole(event)
+
+	switch event.Event {
+	case "agent_progress":
+		text := eventDataString(event, "text")
+		if text == "" || (!verbose && isMinorLogAction(text)) {
+			return renderedLogRow{}, false
+		}
+		row.Phase = progressPhase(role, text)
+		row.Summary, row.Detail = splitLogText(text)
+		return row, true
+	case "agent_complete":
+		status := strings.ToUpper(eventDataString(event, "status"))
+		if status == "" {
+			return renderedLogRow{}, false
+		}
+		row.Phase = progressPhase(role, "")
+		switch {
+		case status == "CONCEDE":
+			row.Summary = "Current spec accepted"
+		case role == "verifier":
+			row.Summary = "Verification requested another iteration"
+		case verbose:
+			row.Summary = "Implementation turn completed"
+		default:
+			return renderedLogRow{}, false
+		}
+		row.Detail = agentLogDetail(event)
+		return row, true
+	case "agent_failure_recoverable":
+		errorText := eventDataString(event, "error")
+		if errorText == "" {
+			return renderedLogRow{}, false
+		}
+		row.Phase = "RETRY"
+		row.Summary = friendlyAgentError(errorText)
+		row.Detail = errorText
+		if current, ok := numericEventValue(event.Data["consecutive_failures"]); ok {
+			if maxFailures, hasMax := numericEventValue(event.Data["max_failures"]); hasMax {
+				row.Detail += fmt.Sprintf(" · attempt %d of %d", current, maxFailures)
+			}
+		}
+		row.GroupKey = "retry:" + normalizedErrorKey(errorText)
+		row.CountNoun = "retries"
+		return row, true
+	case "game_end":
+		row.Phase = "VERIFY"
+		result := strings.ToLower(eventDataString(event, "game_result"))
+		reason := eventDataString(event, "completion_reason")
+		switch result {
+		case "success":
+			row.Summary = "Current spec accepted"
+			if reason != "" && reason != "success" {
+				row.Detail = humanizeLogToken(reason)
+			}
+		case "failure":
+			row.Summary = "Evaluation cycle interrupted"
+			row.Detail = firstNonEmpty(eventDataString(event, "error"), humanizeLogToken(reason))
+			row.GroupKey = "cycle:" + normalizedErrorKey(row.Detail)
+			row.CountNoun = "cycles"
+		case "stopped":
+			row.Summary = "Evaluation stopped"
+			row.Detail = eventDataString(event, "error")
+		default:
+			row.Summary = "Evaluation cycle completed"
+			row.Detail = humanizeLogToken(reason)
+		}
+		return row, true
+	case "budget_exceeded":
+		row.Phase = "SYSTEM"
+		row.Summary = "Budget requires attention"
+		row.Detail = eventDataString(event, "error")
+		return row, true
+	case "game_error":
+		row.Phase = "SYSTEM"
+		row.Summary = "Evaluation error"
+		row.Detail = eventDataString(event, "error")
+		return row, true
+	case "external_update":
+		row.Phase = "SPEC"
+		row.Summary = firstNonEmpty(eventDataString(event, "message"), "Spec updated")
+		return row, true
+	case "game_start":
+		if !verbose {
+			return renderedLogRow{}, false
+		}
+		row.Phase = "VERIFY"
+		row.Summary = "Evaluation cycle started"
+		return row, true
+	case "round_start":
+		if !verbose {
+			return renderedLogRow{}, false
+		}
+		row.Phase = progressPhase(role, "")
+		row.Summary = sentenceCase(firstNonEmpty(role, "Agent")) + " round started"
+		return row, true
+	case "workspace_checkpoint":
+		if !verbose {
+			return renderedLogRow{}, false
+		}
+		row.Phase = "SYSTEM"
+		row.Summary = "Workspace checkpoint saved"
+		if size, ok := numericEventValue(event.Data["bytes"]); ok {
+			row.Detail = formatLogBytes(int64(size))
+		}
+		return row, true
+	}
+
+	message := eventDataString(event, "message")
+	if strings.HasPrefix(event.Event, "deployment.") {
+		row.Phase = "DEPLOY"
+	} else if strings.HasPrefix(event.Event, "runtime.") || strings.HasPrefix(event.Event, "provisioning.") {
+		row.Phase = "START"
+	} else if !verbose {
+		return renderedLogRow{}, false
+	}
+	if message != "" {
+		row.Summary = sentenceCase(message)
+	} else {
+		row.Summary = humanizeLogToken(event.Event)
+	}
+	if row.Summary == "" {
+		return renderedLogRow{}, false
+	}
+	return row, true
+}
+
+func collapseRepeatedLogRows(rows []renderedLogRow) []renderedLogRow {
+	grouped := make(map[string]int)
+	result := make([]renderedLogRow, 0, len(rows))
+	for _, row := range rows {
+		if row.GroupKey == "" {
+			result = append(result, row)
+			continue
+		}
+		index, found := grouped[row.GroupKey]
+		if !found {
+			grouped[row.GroupKey] = len(result)
+			result = append(result, row)
+			continue
+		}
+		current := result[index]
+		if !withinIncidentWindow(current.Timestamp, row.Timestamp) {
+			grouped[row.GroupKey] = len(result)
+			row.GroupKey += ":" + strconv.Itoa(row.Order)
+			result = append(result, row)
+			continue
+		}
+		current.Count += row.Count
+		current.Timestamp = row.Timestamp
+		current.Order = row.Order
+		current.Detail = row.Detail
+		result[index] = current
+	}
+	sort.SliceStable(result, func(i, j int) bool { return result[i].Order < result[j].Order })
+	return result
+}
+
+func printRenderedLogRow(out io.Writer, row renderedLogRow) {
+	timestamp := displayLogTime(row.Timestamp)
+	summary := row.Summary
+	if row.Count > 1 {
+		noun := firstNonEmpty(row.CountNoun, "events")
+		summary += fmt.Sprintf(" · %d %s", row.Count, noun)
+	}
+	fmt.Fprintf(out, "%-8s  %-7s  %s\n", timestamp, row.Phase, summary)
+	if strings.TrimSpace(row.Detail) != "" {
+		fmt.Fprintf(out, "%-8s  %-7s  %s\n", "", "", conciseLogText(row.Detail, 220))
+	}
+}
+
+func eventTimestamp(event sessionapi.SessionEvent) string {
+	if event.Timestamp == nil {
+		return ""
+	}
+	return strings.TrimSpace(*event.Timestamp)
+}
+
+func eventRole(event sessionapi.SessionEvent) string {
+	if event.Role == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(*event.Role))
+}
+
+func eventDataString(event sessionapi.SessionEvent, key string) string {
+	value, _ := event.Data[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func progressPhase(role string, text string) string {
+	if role == "verifier" {
+		return "VERIFY"
+	}
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "test") || strings.Contains(lower, "probe") || strings.Contains(lower, "check") {
+		return "TEST"
+	}
+	return "BUILD"
+}
+
+func isMinorLogAction(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	for _, prefix := range []string{
+		"Reading ",
+		"Editing ",
+		"Creating ",
+		"Writing ",
+		"Updating ",
+		"Deleting ",
+		"Running shell command",
+		"Running kubectl",
+		"Running Node build step",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func agentLogDetail(event sessionapi.SessionEvent) string {
+	parts := []string{}
+	if turns, ok := numericEventValue(event.Data["num_turns"]); ok && turns > 0 {
+		parts = append(parts, fmt.Sprintf("%d turns", turns))
+	}
+	if model := eventDataString(event, "model"); model != "" {
+		parts = append(parts, model)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func eventFailure(event sessionapi.SessionEvent) string {
+	if errorText := eventDataString(event, "error"); errorText != "" {
+		return errorText
+	}
+	if reason := eventDataString(event, "completion_reason"); reason != "" {
+		return humanizeLogToken(reason)
+	}
+	return ""
+}
+
+func friendlyAgentError(errorText string) string {
+	lower := strings.ToLower(errorText)
+	switch {
+	case strings.HasPrefix(lower, "502"), strings.Contains(lower, "no healthy upstream"), strings.Contains(lower, "public routes unavailable"):
+		return "Model provider unavailable"
+	case strings.HasPrefix(lower, "429"):
+		return "Model provider at capacity"
+	case strings.Contains(lower, "socket connection was closed"):
+		return "Agent connection interrupted"
+	case lower == "agent_no_output":
+		return "Agent returned no output"
+	default:
+		return "Agent error, retrying"
+	}
+}
+
+func normalizedErrorKey(value string) string {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.HasPrefix(lower, "502"):
+		return "provider-502"
+	case strings.Contains(lower, "public routes unavailable"):
+		return "provider-public-routes"
+	case strings.Contains(lower, "no healthy upstream"):
+		return "provider-upstream"
+	case strings.HasPrefix(lower, "429"):
+		return "provider-capacity"
+	case lower == "agent_no_output", strings.Contains(lower, "agent_no_output"):
+		return "agent-no-output"
+	default:
+		return lower
+	}
+}
+
+func withinIncidentWindow(left string, right string) bool {
+	leftTime, leftErr := time.Parse(time.RFC3339Nano, left)
+	rightTime, rightErr := time.Parse(time.RFC3339Nano, right)
+	if leftErr != nil || rightErr != nil {
+		return true
+	}
+	delta := rightTime.Sub(leftTime)
+	return delta >= 0 && delta <= 90*time.Minute
+}
+
+func splitLogText(value string) (string, string) {
+	normalized := strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if normalized == "" {
+		return "", ""
+	}
+	cut := -1
+	for _, marker := range []string{". ", ": "} {
+		if index := strings.Index(normalized, marker); index > 0 && (cut == -1 || index < cut) {
+			cut = index
+		}
+	}
+	if cut == -1 || cut > 110 {
+		return conciseLogText(normalized, 140), ""
+	}
+	summary := strings.TrimSuffix(normalized[:cut], ".")
+	detailStart := cut + 2
+	if detailStart >= len(normalized) {
+		return summary, ""
+	}
+	return summary, normalized[detailStart:]
+}
+
+func conciseLogText(value string, limit int) string {
+	normalized := strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+	if limit <= 0 || utf8.RuneCountInString(normalized) <= limit {
+		return normalized
+	}
+	runes := []rune(normalized)
+	return strings.TrimSpace(string(runes[:limit-1])) + "…"
+}
+
+func humanizeLogToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return sentenceCase(strings.ReplaceAll(strings.ReplaceAll(value, "_", " "), ".", " "))
+}
+
+func sentenceCase(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+	return string(runes)
+}
+
+func displayLogTime(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return "--:--:--"
+	}
+	return parsed.Format("15:04:05")
+}
+
+func displayLogDate(value string) string {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return value
+	}
+	return parsed.UTC().Format("2006-01-02 15:04:05 UTC")
+}
+
+func formatLogBytes(value int64) string {
+	const (
+		kib = int64(1024)
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case value >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(value)/float64(gib))
+	case value >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(value)/float64(mib))
+	case value >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(value)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", value)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/telos/logs_view.go
+++ b/cmd/telos/logs_view.go
@@ -74,8 +74,6 @@ func localLogHeader(session *sessionapi.Session) logHeader {
 	updatedAt := ""
 	if session.FinishedAt != nil {
 		updatedAt = *session.FinishedAt
-	} else if session.CreatedAt != nil {
-		updatedAt = *session.CreatedAt
 	}
 	return logHeader{
 		Name:      name,
@@ -151,10 +149,19 @@ func deriveOverallLogStatus(
 	events []sessionapi.SessionEvent,
 ) overallLogStatus {
 	switch strings.ToLower(strings.TrimSpace(header.State)) {
-	case "deleted", "stopped":
-		return overallLogStatus{Label: "Stopped", Reason: firstNonEmpty(header.Failure, "This session was stopped.")}
+	case "deleted", "stopped", "deleting":
+		reason := "This session was stopped."
+		if strings.EqualFold(strings.TrimSpace(header.State), "deleting") {
+			reason = "Stopping this deployment."
+		}
+		return overallLogStatus{Label: "Stopped", Reason: firstNonEmpty(header.Failure, reason)}
 	case "failed", "error", "errored", "stale":
 		return overallLogStatus{Label: "Failed", Reason: firstNonEmpty(header.Failure, "The session could not complete.")}
+	}
+	if strings.TrimSpace(header.Failure) != "" {
+		return overallLogStatus{Label: "Needs attention", Reason: strings.TrimSpace(header.Failure)}
+	}
+	switch strings.ToLower(strings.TrimSpace(header.State)) {
 	case "pending", "provisioning", "deploying":
 		return overallLogStatus{Label: "Starting", Reason: "Preparing the deployment and runtime."}
 	}
@@ -169,7 +176,7 @@ func deriveOverallLogStatus(
 	latestNoticeText := ""
 	for index, event := range events {
 		switch event.Event {
-		case "external_update", "deployment.update_accepted", "deployment.update_dispatched":
+		case "external_update", "deployment.update_accepted":
 			reset = index
 			latestConcede = -1
 			latestContinue = -1
@@ -185,12 +192,20 @@ func deriveOverallLogStatus(
 				latestConcede = index
 			} else if status == "CONTINUE" && role == "verifier" {
 				latestContinue = index
+				latestWork = index
+				latestWorkText = "Verification requested another iteration."
+			} else {
+				latestWork = index
+				latestWorkText = "Implementation turn completed; verification is next."
 			}
 		case "game_end":
 			result := strings.ToLower(eventDataString(event, "game_result"))
+			if result == "" {
+				result = strings.ToLower(eventDataString(event, "result"))
+			}
 			if result == "success" {
 				latestConcede = index
-			} else if result == "failure" {
+			} else if result == "failure" || result == "stopped" {
 				latestFailure = index
 			}
 		case "budget_exceeded", "game_error":
@@ -210,16 +225,20 @@ func deriveOverallLogStatus(
 					latestWorkText = text
 				}
 			}
+		default:
+			if isTerminalLogFailureEvent(event.Event) {
+				latestFailure = index
+			}
 		}
 	}
 
-	if latestConcede > reset && latestConcede > latestContinue {
+	if latestConcede > reset && latestConcede > latestContinue && latestConcede > latestFailure {
 		return overallLogStatus{
 			Label:  "Ready",
 			Reason: "Current spec accepted; latest verification completed successfully.",
 		}
 	}
-	if latestFailure > reset && latestFailure > latestWork {
+	if latestFailure > reset && latestFailure > latestConcede && latestFailure > latestWork {
 		failure := eventFailure(events[latestFailure])
 		return overallLogStatus{
 			Label:  "Needs attention",
@@ -274,7 +293,7 @@ func renderedLogRowFromEvent(
 		}
 		row.Phase = progressPhase(role, "")
 		switch {
-		case status == "CONCEDE":
+		case status == "CONCEDE" && role == "verifier":
 			row.Summary = "Current spec accepted"
 		case role == "verifier":
 			row.Summary = "Verification requested another iteration"
@@ -304,6 +323,9 @@ func renderedLogRowFromEvent(
 	case "game_end":
 		row.Phase = "VERIFY"
 		result := strings.ToLower(eventDataString(event, "game_result"))
+		if result == "" {
+			result = strings.ToLower(eventDataString(event, "result"))
+		}
 		reason := eventDataString(event, "completion_reason")
 		switch result {
 		case "success":
@@ -446,6 +468,16 @@ func eventDataString(event sessionapi.SessionEvent, key string) string {
 	return strings.TrimSpace(value)
 }
 
+func isTerminalLogFailureEvent(event string) bool {
+	name := strings.ToLower(strings.TrimSpace(event))
+	if name == "agent_failure_recoverable" {
+		return false
+	}
+	return strings.HasSuffix(name, ".failed") ||
+		strings.HasSuffix(name, "_failed") ||
+		strings.HasSuffix(name, ".error")
+}
+
 func progressPhase(role string, text string) string {
 	if role == "verifier" {
 		return "VERIFY"
@@ -492,8 +524,14 @@ func eventFailure(event sessionapi.SessionEvent) string {
 	if errorText := eventDataString(event, "error"); errorText != "" {
 		return errorText
 	}
+	if reason := eventDataString(event, "reason"); reason != "" {
+		return reason
+	}
 	if reason := eventDataString(event, "completion_reason"); reason != "" {
 		return humanizeLogToken(reason)
+	}
+	if message := eventDataString(event, "message"); message != "" {
+		return message
 	}
 	return ""
 }

--- a/cmd/telos/logs_view_test.go
+++ b/cmd/telos/logs_view_test.go
@@ -22,6 +22,16 @@ func TestDeriveOverallLogStatus(t *testing.T) {
 			want:   "Starting",
 		},
 		{
+			name:   "starting failure needs attention",
+			header: logHeader{State: "deploying", Failure: "managed session update failed"},
+			want:   "Needs attention",
+		},
+		{
+			name:   "deleting is stopping instead of working",
+			header: logHeader{State: "deleting"},
+			want:   "Stopped",
+		},
+		{
 			name:   "failed lifecycle wins",
 			header: logHeader{State: "failed", Failure: "runtime unavailable"},
 			events: []sessionapi.SessionEvent{{Event: "game_end", Data: map[string]any{"game_result": "success"}}},
@@ -48,6 +58,42 @@ func TestDeriveOverallLogStatus(t *testing.T) {
 				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Checking service health"}},
 			},
 			want: "Ready",
+		},
+		{
+			name:   "failure after acceptance needs attention",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+				{Event: "game_end", Data: map[string]any{"game_result": "failure", "error": "tests failed"}},
+			},
+			want: "Needs attention",
+		},
+		{
+			name:   "work after a failure resumes working",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+				{Event: "game_error", Data: map[string]any{"error": "tests failed"}},
+				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Fixing the failing tests"}},
+			},
+			want: "Working",
+		},
+		{
+			name:   "acceptance after a failure is ready",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "game_error", Data: map[string]any{"error": "tests failed"}},
+				{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+			},
+			want: "Ready",
+		},
+		{
+			name:   "control plane failure needs attention",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "deployment.update_failed", Data: map[string]any{"reason": "runtime rejected the update"}},
+			},
+			want: "Needs attention",
 		},
 		{
 			name:   "new spec resets acceptance",
@@ -86,6 +132,38 @@ func TestDeriveOverallLogStatus(t *testing.T) {
 				t.Fatalf("status: got %q, want %q (%s)", got.Label, test.want, got.Reason)
 			}
 		})
+	}
+}
+
+func TestRenderedLogRowOnlyTreatsVerifierConcedeAsAcceptance(t *testing.T) {
+	verifier := "verifier"
+	prover := "prover"
+
+	verifierRow, ok := renderedLogRowFromEvent(
+		sessionapi.SessionEvent{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+		false,
+	)
+	if !ok || verifierRow.Summary != "Current spec accepted" {
+		t.Fatalf("verifier completion: got %#v, visible=%v", verifierRow, ok)
+	}
+
+	if proverRow, visible := renderedLogRowFromEvent(
+		sessionapi.SessionEvent{Event: "agent_complete", Role: &prover, Data: map[string]any{"status": "CONCEDE"}},
+		false,
+	); visible {
+		t.Fatalf("prover completion should stay hidden by default: %#v", proverRow)
+	}
+}
+
+func TestDeriveOverallLogStatusUsesLatestCompletionReason(t *testing.T) {
+	verifier := "verifier"
+	status := deriveOverallLogStatus(logHeader{State: "healthy"}, []sessionapi.SessionEvent{
+		{Event: "agent_failure_recoverable", Data: map[string]any{"error": "502 no healthy upstream"}},
+		{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONTINUE"}},
+	})
+
+	if status.Label != "Working" || status.Reason != "Verification requested another iteration." {
+		t.Fatalf("status: got %#v", status)
 	}
 }
 

--- a/cmd/telos/logs_view_test.go
+++ b/cmd/telos/logs_view_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/telos-org/telos/internal/sessionapi"
+)
+
+func TestDeriveOverallLogStatus(t *testing.T) {
+	verifier := "verifier"
+	prover := "prover"
+	tests := []struct {
+		name   string
+		header logHeader
+		events []sessionapi.SessionEvent
+		want   string
+	}{
+		{
+			name:   "starting follows lifecycle",
+			header: logHeader{State: "provisioning"},
+			want:   "Starting",
+		},
+		{
+			name:   "failed lifecycle wins",
+			header: logHeader{State: "failed", Failure: "runtime unavailable"},
+			events: []sessionapi.SessionEvent{{Event: "game_end", Data: map[string]any{"game_result": "success"}}},
+			want:   "Failed",
+		},
+		{
+			name:   "verifier acceptance is ready",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}}},
+			want:   "Ready",
+		},
+		{
+			name:   "prover concede is not ready",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{{Event: "agent_complete", Role: &prover, Data: map[string]any{"status": "CONCEDE"}}},
+			want:   "Working",
+		},
+		{
+			name:   "routine work does not revoke acceptance",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+				{Event: "game_start", Data: map[string]any{}},
+				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Checking service health"}},
+			},
+			want: "Ready",
+		},
+		{
+			name:   "new spec resets acceptance",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_complete", Role: &verifier, Data: map[string]any{"status": "CONCEDE"}},
+				{Event: "external_update", Data: map[string]any{"message": "Spec updated"}},
+				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Implementing the new spec"}},
+			},
+			want: "Working",
+		},
+		{
+			name:   "stopped evaluation needs attention",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Running tests"}},
+				{Event: "game_end", Data: map[string]any{"game_result": "failure", "error": "tests failed"}},
+			},
+			want: "Needs attention",
+		},
+		{
+			name:   "recoverable provider incident stays working",
+			header: logHeader{State: "healthy"},
+			events: []sessionapi.SessionEvent{
+				{Event: "agent_progress", Role: &prover, Data: map[string]any{"text": "Implementing the API"}},
+				{Event: "agent_failure_recoverable", Data: map[string]any{"error": "502 no healthy upstream"}},
+			},
+			want: "Working",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveOverallLogStatus(test.header, test.events)
+			if got.Label != test.want {
+				t.Fatalf("status: got %q, want %q (%s)", got.Label, test.want, got.Reason)
+			}
+		})
+	}
+}
+
+func TestCollapseRepeatedLogRowsGroupsIncidentWindows(t *testing.T) {
+	rows := []renderedLogRow{
+		{Timestamp: "2026-07-01T00:00:00Z", Summary: "Model provider unavailable", GroupKey: "retry:502", CountNoun: "retries", Count: 1, Order: 0},
+		{Timestamp: "2026-07-01T00:20:00Z", Summary: "Model provider unavailable", GroupKey: "retry:502", CountNoun: "retries", Count: 1, Order: 1},
+		{Timestamp: "2026-07-01T01:00:00Z", Summary: "Model provider unavailable", GroupKey: "retry:502", CountNoun: "retries", Count: 1, Order: 2},
+		{Timestamp: "2026-07-01T03:00:00Z", Summary: "Model provider unavailable", GroupKey: "retry:502", CountNoun: "retries", Count: 1, Order: 3},
+		{Timestamp: "2026-07-01T03:15:00Z", Summary: "Model provider unavailable", GroupKey: "retry:502", CountNoun: "retries", Count: 1, Order: 4},
+	}
+
+	got := collapseRepeatedLogRows(rows)
+	if len(got) != 2 {
+		t.Fatalf("incidents: got %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Count != 3 || got[1].Count != 2 {
+		t.Fatalf("incident counts: got %d and %d", got[0].Count, got[1].Count)
+	}
+}
+
+func TestPrintStructuredLogsCollapsesRetries(t *testing.T) {
+	ts1 := "2026-07-01T00:00:00Z"
+	ts2 := "2026-07-01T00:10:00Z"
+	ts3 := "2026-07-01T00:20:00Z"
+	events := []sessionapi.SessionEvent{
+		{Event: "agent_failure_recoverable", Timestamp: &ts1, Data: map[string]any{"error": "502 no healthy upstream"}},
+		{Event: "agent_failure_recoverable", Timestamp: &ts2, Data: map[string]any{"error": "502 no healthy upstream"}},
+		{Event: "agent_failure_recoverable", Timestamp: &ts3, Data: map[string]any{"error": "502 no healthy upstream"}},
+	}
+
+	var output strings.Builder
+	printStructuredLogs(&output, logHeader{Name: "breachpoint", State: "healthy", SessionID: "sess_456"}, events, logViewOptions{Tail: defaultLogTail})
+	text := output.String()
+	if !strings.Contains(text, "Model provider unavailable · 3 retries") {
+		t.Fatalf("collapsed retry missing:\n%s", text)
+	}
+	if count := strings.Count(text, "RETRY"); count != 1 {
+		t.Fatalf("retry activity rendered %d times:\n%s", count, text)
+	}
+}

--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -10,7 +10,7 @@
 //	telos list [--limit N] [--wide] [--local] [--cloud] [--json]
 //	telos get SESSION [--output PATH]
 //	telos describe SESSION [--json]
-//	telos logs [-f] [--verbose] SESSION
+//	telos logs [-f] [--verbose|--json|--raw] [--tail N|--all] SESSION
 //	telos delete SESSION [--json]
 //	telos pull PACKAGE [--output PATH]
 //	telos login [--endpoint URL]
@@ -94,7 +94,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  list               List sessions")
 	fmt.Fprintln(out, "  get SESSION        Download a session's package")
 	fmt.Fprintln(out, "  describe SESSION   Show session details")
-	fmt.Fprintln(out, "  logs SESSION       Show session progress")
+	fmt.Fprintln(out, "  logs SESSION       Show status and recent activity")
 	fmt.Fprintln(out, "  delete SESSION     Delete a session (local history is preserved)")
 	fmt.Fprintln(out, "  pull PACKAGE       Download a registry package")
 	fmt.Fprintln(out, "  login              Log in to Telos Cloud via the browser")

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -1187,6 +1187,56 @@ func TestFollowTranscriptSurfacesRootTranscriptError(t *testing.T) {
 	}
 }
 
+func TestLegacyTranscriptFallbackUsesLocalTranscriptOnlySession(t *testing.T) {
+	root := t.TempDir()
+	configureLocalOnlyTest(t)
+	t.Setenv("TELOS_SESSION_DIR", root)
+	s := store()
+	markdown := "---\nversion: 0.1.0\nname: legacy-logs\nplatform: local\n---\n# Legacy Logs\n"
+	session, err := s.Create(sessionapi.SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(session.Specs) == 0 || session.Specs[0].TranscriptPath == nil {
+		t.Fatalf("missing transcript path: %#v", session.Specs)
+	}
+	transcript := "# Transcript\n\n<progress_update>Recovered legacy activity</progress_update>\n"
+	if err := os.WriteFile(*session.Specs[0].TranscriptPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	events, eventsErr := getEventsFromAnywhere(session.SessionID)
+	got, ok := legacyTranscriptFallback(session.SessionID, events, eventsErr)
+	if !ok || got != transcript {
+		t.Fatalf("fallback: ok=%v, got %q, events=%#v, err=%v", ok, got, events, eventsErr)
+	}
+}
+
+func TestLegacyTranscriptFallbackUsesOlderRootRuntime(t *testing.T) {
+	t.Setenv("TELOS_RUNTIME", "")
+	cluster := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/sessions/sess_legacy/events":
+			http.NotFound(w, r)
+		case "/api/sessions/sess_legacy/transcript":
+			_, _ = w.Write([]byte("<progress_update>Recovered root activity</progress_update>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cluster.Close()
+	t.Setenv("TELOS_SESSION_DIR", filepath.Join(t.TempDir(), "sessions"))
+	t.Setenv("TELOS_API_TOKEN", "scoped-token")
+	t.Setenv("TELOS_SESSION_ID", "sess_parent")
+	t.Setenv("TELOS_API_ENDPOINT", cluster.URL)
+
+	events, eventsErr := getEventsFromAnywhere("sess_legacy")
+	transcript, ok := legacyTranscriptFallback("sess_legacy", events, eventsErr)
+	if !ok || !strings.Contains(transcript, "Recovered root activity") {
+		t.Fatalf("fallback: ok=%v, transcript=%q, events=%#v, err=%v", ok, transcript, events, eventsErr)
+	}
+}
+
 func TestPrintLogsDefaultsToProtocolBlocks(t *testing.T) {
 	transcript := `# Transcript
 
@@ -1385,6 +1435,49 @@ func TestFollowCloudSessionLogsStreamsEvents(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "BUILD    ready") {
 		t.Fatalf("follow output missing progress:\n%s", out.String())
+	}
+}
+
+func TestFollowCloudSessionLogsResumesAndPrintsStatusChange(t *testing.T) {
+	verifier := "verifier"
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_123/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"event\":\"agent_complete\",\"event_seq\":8,\"role\":\"verifier\",\"data\":{\"status\":\"CONCEDE\"}}\n\n"))
+	}))
+	defer srv.Close()
+
+	after := int64(7)
+	initial := []sessionapi.SessionEvent{
+		{Event: "agent_progress", EventSeq: &after, Role: &verifier, Data: map[string]any{"text": "Checking the result"}},
+	}
+	var out bytes.Buffer
+	err := streamCloudSessionLogsAfter(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		&out,
+		func(time.Duration) {},
+		false,
+		false,
+		&after,
+		logHeader{Name: "pegfall", State: "healthy", SessionID: "sess_123"},
+		initial,
+	)
+	if err != nil {
+		t.Fatalf("streamCloudSessionLogsAfter: %v", err)
+	}
+	if query != "after_rt=7" {
+		t.Fatalf("resume query: got %q", query)
+	}
+	for _, want := range []string{"Current spec accepted", "STATUS   Ready"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("follow output missing %q:\n%s", want, out.String())
+		}
 	}
 }
 

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -1273,45 +1273,80 @@ func TestPrintLogsVerboseShowsTranscript(t *testing.T) {
 	}
 }
 
-func TestPrintCloudSessionLogsDefaultsToAgentProgress(t *testing.T) {
+func TestPrintStructuredLogsShowsStatusAndSignificantActivity(t *testing.T) {
+	ts1 := "2026-07-01T00:00:00Z"
+	ts2 := "2026-07-01T00:01:00Z"
+	ts3 := "2026-07-01T00:02:00Z"
+	verifier := "verifier"
 	events := []sessionapi.SessionEvent{
-		{Event: "agent_progress", Data: map[string]any{"kind": "progress_update", "text": "ready"}},
-		{Event: "agent_progress", Data: map[string]any{"kind": "review", "text": "criteria,score\nCorrectness,8/10"}},
-		{Event: "agent_complete", Data: map[string]any{"status": "CONTINUE", "model": "test-model", "num_turns": float64(12)}},
-		{Event: "agent_failure_recoverable", Data: map[string]any{"error": "agent_no_output", "consecutive_failures": float64(1), "max_failures": float64(3)}},
-		{Event: "runtime.prepare.started", Data: map[string]any{"message": "preparing runtime", "stage": "prepare"}},
-		{Event: "game_end", Data: map[string]any{"game_result": "failure", "error": "run_duration_exhausted: exceeded 1800 seconds"}},
+		{Event: "agent_progress", Timestamp: &ts1, Data: map[string]any{"text": "Reading package.json"}},
+		{Event: "agent_progress", Timestamp: &ts1, Data: map[string]any{"text": "Implemented the authentication flow. Added session validation."}},
+		{Event: "agent_progress", Timestamp: &ts2, Role: &verifier, Data: map[string]any{"text": "Running the integration checks"}},
+		{Event: "game_end", Timestamp: &ts3, Data: map[string]any{"game_result": "failure", "error": "run_duration_exhausted: exceeded 1800 seconds"}},
 	}
 
 	var out bytes.Buffer
-	printCloudSessionLogEvents(&out, events, false)
+	printStructuredLogs(&out, logHeader{
+		Name:       "palmfall",
+		State:      "healthy",
+		PackageRef: "@telos/palmfall:1.0.0",
+		SessionID:  "sess_123",
+	}, events, logViewOptions{Tail: defaultLogTail})
 	text := out.String()
 	for _, want := range []string{
-		"#1 ready",
-		"Review\ncriteria,score\nCorrectness,8/10",
-		"Agent complete: CONTINUE model=test-model turns=12",
-		"Recoverable failure: agent_no_output (1/3)",
-		"preparing runtime",
-		"Completed: failure (run_duration_exhausted: exceeded 1800 seconds)",
+		"PALMFALL",
+		"Status    Needs attention",
+		"Summary   run_duration_exhausted: exceeded 1800 seconds",
+		"00:00:00  BUILD    Implemented the authentication flow",
+		"00:01:00  VERIFY   Running the integration checks",
+		"00:02:00  VERIFY   Evaluation cycle interrupted",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("cloud session logs missing %q:\n%s", want, text)
+			t.Fatalf("structured logs missing %q:\n%s", want, text)
+		}
+	}
+	for _, unwanted := range []string{"Reading package.json", "game_end"} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("structured logs unexpectedly include %q:\n%s", unwanted, text)
 		}
 	}
 }
 
-func TestPrintCloudSessionLogsVerboseShowsJSONEvents(t *testing.T) {
+func TestPrintStructuredLogsVerboseIncludesMinorActivity(t *testing.T) {
 	ts := "2026-07-01T00:00:00Z"
 	events := []sessionapi.SessionEvent{
-		{Event: "agent_progress", Timestamp: &ts, Data: map[string]any{"kind": "progress_update", "text": "ready"}},
+		{Event: "agent_progress", Timestamp: &ts, Data: map[string]any{"text": "Reading package.json"}},
 	}
 
 	var out bytes.Buffer
-	printCloudSessionLogEvents(&out, events, true)
+	printStructuredLogs(&out, logHeader{Name: "pegfall", State: "healthy", SessionID: "sess_123"}, events, logViewOptions{
+		Verbose: true,
+		Tail:    defaultLogTail,
+	})
 	text := out.String()
+	if !strings.Contains(text, "00:00:00  BUILD    Reading package.json") {
+		t.Fatalf("verbose logs missing minor activity:\n%s", text)
+	}
+}
+
+func TestPrintJSONLogEventsUsesNDJSON(t *testing.T) {
+	ts := "2026-07-01T00:00:00Z"
+	events := []sessionapi.SessionEvent{
+		{Event: "agent_progress", Timestamp: &ts, Data: map[string]any{"text": "ready"}},
+		{Event: "game_end", Timestamp: &ts, Data: map[string]any{"game_result": "success"}},
+	}
+
+	var out bytes.Buffer
+	if err := printJSONLogEvents(&out, events); err != nil {
+		t.Fatalf("printJSONLogEvents: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("NDJSON lines: got %d\n%s", len(lines), out.String())
+	}
 	for _, want := range []string{`"event":"agent_progress"`, `"ts":"2026-07-01T00:00:00Z"`, `"text":"ready"`} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("verbose cloud session logs missing %q:\n%s", want, text)
+		if !strings.Contains(lines[0], want) {
+			t.Fatalf("JSON logs missing %q:\n%s", want, lines[0])
 		}
 	}
 }
@@ -1340,6 +1375,7 @@ func TestFollowCloudSessionLogsStreamsEvents(t *testing.T) {
 		&out,
 		func(time.Duration) {},
 		false,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("streamCloudSessionLogs: %v", err)
@@ -1347,7 +1383,7 @@ func TestFollowCloudSessionLogsStreamsEvents(t *testing.T) {
 	if logCalls != 1 {
 		t.Fatalf("calls: logs=%d", logCalls)
 	}
-	if !strings.Contains(out.String(), "#1 ready") {
+	if !strings.Contains(out.String(), "BUILD    ready") {
 		t.Fatalf("follow output missing progress:\n%s", out.String())
 	}
 }
@@ -1367,6 +1403,7 @@ func TestFollowCloudSessionLogsExitsCleanWhenSessionDeleted(t *testing.T) {
 		"sess_123",
 		&out,
 		func(time.Duration) {},
+		false,
 		false,
 	)
 	if err != nil {

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -1481,6 +1481,101 @@ func TestFollowCloudSessionLogsResumesAndPrintsStatusChange(t *testing.T) {
 	}
 }
 
+func TestFollowCloudSessionLogsDeduplicatesLegacyReplay(t *testing.T) {
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_legacy/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"event\":\"agent_progress\",\"data\":{\"text\":\"old activity\"}}\n\n" +
+				"data: {\"event\":\"agent_progress\",\"data\":{\"text\":\"old activity\"}}\n\n" +
+				"data: {\"event\":\"agent_progress\",\"data\":{\"text\":\"new activity\"}}\n\n",
+		))
+	}))
+	defer srv.Close()
+
+	initial := []sessionapi.SessionEvent{
+		{Event: "agent_progress", Data: map[string]any{"text": "old activity"}},
+	}
+	var out bytes.Buffer
+	if err := printJSONLogEvents(&out, initial); err != nil {
+		t.Fatalf("print snapshot: %v", err)
+	}
+	if err := streamCloudSessionLogsAfter(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_legacy",
+		&out,
+		func(time.Duration) {},
+		false,
+		true,
+		nil,
+		logHeader{},
+		initial,
+	); err != nil {
+		t.Fatalf("streamCloudSessionLogsAfter: %v", err)
+	}
+	if query != "" {
+		t.Fatalf("legacy stream should not invent a cursor: %q", query)
+	}
+	// One replay is removed, while a genuinely new event with the same payload
+	// still appears after the snapshot's single matching count is consumed.
+	if count := strings.Count(out.String(), `"text":"old activity"`); count != 2 {
+		t.Fatalf("old activity printed %d times:\n%s", count, out.String())
+	}
+	if count := strings.Count(out.String(), `"text":"new activity"`); count != 1 {
+		t.Fatalf("new activity printed %d times:\n%s", count, out.String())
+	}
+}
+
+func TestFollowCloudRawSessionLogsDeduplicatesLegacyReplay(t *testing.T) {
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_legacy/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		query = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"round\":1,\"data\":{\"text\":\"old activity\"},\"event\":\"agent_progress\"}\n\n" +
+				"data: {\"event\":\"agent_progress\",\"round\":1,\"data\":{\"text\":\"old activity\"}}\n\n" +
+				"data: {\"event\":\"agent_progress\",\"round\":2,\"data\":{\"text\":\"new activity\"}}\n\n",
+		))
+	}))
+	defer srv.Close()
+
+	initial := []json.RawMessage{
+		json.RawMessage(`{"event":"agent_progress","round":1,"data":{"text":"old activity"}}`),
+	}
+	var out bytes.Buffer
+	if err := printRawJSONLogEvents(&out, initial); err != nil {
+		t.Fatalf("print raw snapshot: %v", err)
+	}
+	if err := streamCloudRawSessionLogs(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_legacy",
+		&out,
+		func(time.Duration) {},
+		nil,
+		initial,
+	); err != nil {
+		t.Fatalf("streamCloudRawSessionLogs: %v", err)
+	}
+	if query != "" {
+		t.Fatalf("legacy raw stream should not invent a cursor: %q", query)
+	}
+	if count := strings.Count(out.String(), `"text":"old activity"`); count != 2 {
+		t.Fatalf("old raw activity printed %d times:\n%s", count, out.String())
+	}
+	if count := strings.Count(out.String(), `"text":"new activity"`); count != 1 {
+		t.Fatalf("new raw activity printed %d times:\n%s", count, out.String())
+	}
+}
+
 func TestFollowCloudSessionLogsExitsCleanWhenSessionDeleted(t *testing.T) {
 	// The control plane hard-deletes deployments once teardown completes:
 	// both /logs and the session GET 404. The follow loop should treat that

--- a/cmd/telos/session_helpers.go
+++ b/cmd/telos/session_helpers.go
@@ -136,6 +136,24 @@ func getTranscriptFromAnywhere(sessionID string) (string, error) {
 	return "", localSessionNotFoundError(sessionID)
 }
 
+func getEventsFromAnywhere(sessionID string) ([]sessionapi.SessionEvent, error) {
+	s := store()
+	events, err := s.Events(sessionID)
+	if err == nil {
+		return events, nil
+	}
+
+	if ctx, ok := rootSessionContext(); ok {
+		events, err := runtimeclient.New(ctx.endpoint, ctx.token).GetEvents(sessionID)
+		if err == nil {
+			return events, nil
+		}
+		return nil, fmt.Errorf("root event lookup failed: %w", err)
+	}
+
+	return nil, localSessionNotFoundError(sessionID)
+}
+
 func stopSessionAnywhere(sessionID string) (*sessionapi.Session, error) {
 	s := store()
 	var sessionDir string

--- a/cmd/telos/testfake_integration_test.go
+++ b/cmd/telos/testfake_integration_test.go
@@ -94,8 +94,14 @@ func TestCLIWithTestFakeExecutor(t *testing.T) {
 	}
 
 	logsOut := runProcess(t, workspace, env, telosBin, "logs", "--verbose", runResp.SessionID)
-	if !strings.Contains(logsOut, "fake prover wrote hello.txt") || !strings.Contains(logsOut, "fake verifier accepted") {
-		t.Fatalf("verbose logs missing fake turns:\n%s", logsOut)
+	for _, want := range []string{"Status    Ready", "Prover round started", "Current spec accepted"} {
+		if !strings.Contains(logsOut, want) {
+			t.Fatalf("verbose logs missing %q:\n%s", want, logsOut)
+		}
+	}
+	rawLogsOut := runProcess(t, workspace, env, telosBin, "logs", "--raw", runResp.SessionID)
+	if !strings.Contains(rawLogsOut, "fake prover wrote hello.txt") || !strings.Contains(rawLogsOut, "fake verifier accepted") {
+		t.Fatalf("raw logs missing fake turns:\n%s", rawLogsOut)
 	}
 
 	archivePath := filepath.Join(runResp.SessionDir, "specs", "fake-cli", "workspace.tar.gz")

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -88,6 +88,8 @@ type deploymentLogEventsResponse struct {
 
 type deploymentLogEvent struct {
 	Event       string         `json:"event"`
+	EventSeq    *int64         `json:"event_seq,omitempty"`
+	Role        *string        `json:"role,omitempty"`
 	Timestamp   *string        `json:"ts,omitempty"`
 	Time        *string        `json:"time,omitempty"`
 	SessionID   *string        `json:"session_id,omitempty"`
@@ -116,6 +118,8 @@ func (event deploymentLogEvent) asSessionEvent() sessionapi.SessionEvent {
 	}
 	return sessionapi.SessionEvent{
 		Event:       event.Event,
+		EventSeq:    event.EventSeq,
+		Role:        event.Role,
 		Timestamp:   timestamp,
 		SessionID:   event.SessionID,
 		SpecIndex:   event.SpecIndex,

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -83,7 +83,20 @@ type sessionListResponse struct {
 }
 
 type deploymentLogEventsResponse struct {
-	Events []deploymentLogEvent `json:"events"`
+	Events  []json.RawMessage   `json:"events"`
+	Cursors deploymentLogCursor `json:"cursors"`
+}
+
+type deploymentLogCursor struct {
+	Runtime *int64 `json:"rt"`
+}
+
+// SessionLogPage keeps both the normalized events used by the human/JSON
+// views and their original wire records for --raw output.
+type SessionLogPage struct {
+	Events        []sessionapi.SessionEvent
+	RawEvents     []json.RawMessage
+	RuntimeCursor *int64
 }
 
 type deploymentLogEvent struct {
@@ -462,7 +475,15 @@ func (c *Client) DeleteSession(sessionID string) (*SessionRecord, error) {
 }
 
 func (c *Client) GetSessionLogs(sessionID string) ([]sessionapi.SessionEvent, error) {
-	resp, err := c.do("GET", "/api/deployments/"+url.PathEscape(sessionID)+"/logs", nil)
+	page, err := c.GetSessionLogPage(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return page.Events, nil
+}
+
+func (c *Client) GetSessionLogPage(sessionID string) (*SessionLogPage, error) {
+	resp, err := c.do("GET", sessionLogsPath(sessionID, nil), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -475,20 +496,61 @@ func (c *Client) GetSessionLogs(sessionID string) ([]sessionapi.SessionEvent, er
 		return nil, err
 	}
 	events := make([]sessionapi.SessionEvent, 0, len(response.Events))
-	for _, event := range response.Events {
+	for _, raw := range response.Events {
+		var event deploymentLogEvent
+		if err := json.Unmarshal(raw, &event); err != nil {
+			return nil, fmt.Errorf("decode session log event: %w", err)
+		}
 		events = append(events, event.asSessionEvent())
 	}
-	return events, nil
+	return &SessionLogPage{
+		Events:        events,
+		RawEvents:     response.Events,
+		RuntimeCursor: response.Cursors.Runtime,
+	}, nil
 }
 
 func (c *Client) StreamSessionLogs(ctx context.Context, sessionID string, onEvent func(sessionapi.SessionEvent) error) error {
-	return c.streamEvents(ctx, "/api/deployments/"+url.PathEscape(sessionID)+"/logs", func(data []byte) error {
+	return c.StreamSessionLogsAfter(ctx, sessionID, nil, onEvent)
+}
+
+func (c *Client) StreamSessionLogsAfter(
+	ctx context.Context,
+	sessionID string,
+	afterRuntime *int64,
+	onEvent func(sessionapi.SessionEvent) error,
+) error {
+	return c.streamEvents(ctx, sessionLogsPath(sessionID, afterRuntime), func(data []byte) error {
 		var event deploymentLogEvent
 		if err := json.Unmarshal(data, &event); err != nil {
 			return fmt.Errorf("decode session log event: %w", err)
 		}
 		return onEvent(event.asSessionEvent())
 	})
+}
+
+func (c *Client) StreamRawSessionLogsAfter(
+	ctx context.Context,
+	sessionID string,
+	afterRuntime *int64,
+	onEvent func(json.RawMessage) error,
+) error {
+	return c.streamEvents(ctx, sessionLogsPath(sessionID, afterRuntime), func(data []byte) error {
+		if !json.Valid(data) {
+			return errors.New("decode raw session log event: invalid JSON")
+		}
+		return onEvent(append(json.RawMessage(nil), data...))
+	})
+}
+
+func sessionLogsPath(sessionID string, afterRuntime *int64) string {
+	path := "/api/deployments/" + url.PathEscape(sessionID) + "/logs"
+	if afterRuntime == nil {
+		return path
+	}
+	query := url.Values{}
+	query.Set("after_rt", fmt.Sprintf("%d", *afterRuntime))
+	return path + "?" + query.Encode()
 }
 
 // NormalizeEndpoint cleans up an API endpoint URL.

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -498,6 +498,32 @@ func TestClientGetSessionLogs(t *testing.T) {
 	}
 }
 
+func TestClientSessionLogPagePreservesRawEventsAndCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_123/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"events":[{"schema":"telos.evidence.v2","event":"agent_progress","event_id":"evt_7","event_seq":7,"round":3,"data":{"text":"ready"}}],"cursors":{"rt":7,"cp":12,"session":"sess_runtime"}}`))
+	}))
+	defer srv.Close()
+
+	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123")
+	if err != nil {
+		t.Fatalf("GetSessionLogPage: %v", err)
+	}
+	if len(page.Events) != 1 || page.RuntimeCursor == nil || *page.RuntimeCursor != 7 {
+		t.Fatalf("page: got %#v", page)
+	}
+	raw := string(page.RawEvents[0])
+	for _, field := range []string{`"schema":"telos.evidence.v2"`, `"event_id":"evt_7"`, `"round":3`} {
+		if !strings.Contains(raw, field) {
+			t.Fatalf("raw event dropped %s: %s", field, raw)
+		}
+	}
+}
+
 func TestClientStreamSessionLogs(t *testing.T) {
 	var gotOrgID string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -532,6 +558,36 @@ func TestClientStreamSessionLogs(t *testing.T) {
 	}
 	if gotOrgID != "org_telos" {
 		t.Fatalf("org header: got %q", gotOrgID)
+	}
+}
+
+func TestClientStreamRawSessionLogsUsesResumeCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_123/logs" || r.URL.Query().Get("after_rt") != "41" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"event\":\"agent_progress\",\"event_id\":\"evt_42\",\"round\":4}\n\n"))
+	}))
+	defer srv.Close()
+
+	after := int64(41)
+	var events []json.RawMessage
+	err := NewClient(srv.URL, "test-token").StreamRawSessionLogsAfter(
+		context.Background(),
+		"sess_123",
+		&after,
+		func(event json.RawMessage) error {
+			events = append(events, event)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("StreamRawSessionLogsAfter: %v", err)
+	}
+	if len(events) != 1 || !strings.Contains(string(events[0]), `"event_id":"evt_42"`) {
+		t.Fatalf("raw stream events: %s", events)
 	}
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -473,7 +473,7 @@ func TestClientGetSessionLogs(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"events":[` +
-			`{"event":"agent_progress","data":{"kind":"progress_update","text":"ready"}},` +
+			`{"event":"agent_progress","event_seq":7,"role":"verifier","data":{"kind":"progress_update","text":"ready"}},` +
 			`{"event":"runtime.prepare.started","time":"2026-07-04T15:14:52Z","message":"preparing runtime","metadata":{"stage":"prepare"}}` +
 			`]}`))
 	}))
@@ -486,6 +486,9 @@ func TestClientGetSessionLogs(t *testing.T) {
 	}
 	if len(events) != 2 || events[0].Event != "agent_progress" || events[0].Data["text"] != "ready" {
 		t.Fatalf("events: got %#v", events)
+	}
+	if events[0].EventSeq == nil || *events[0].EventSeq != 7 || events[0].Role == nil || *events[0].Role != "verifier" {
+		t.Fatalf("agent event identity: got %#v", events[0])
 	}
 	if events[1].Event != "runtime.prepare.started" || events[1].Data["message"] != "preparing runtime" || events[1].Data["stage"] != "prepare" {
 		t.Fatalf("control event: got %#v", events[1])


### PR DESCRIPTION
## Summary

- replace transcript-first log output with one overall status, reason, and timestamped phase activity
- hide routine file and tool chatter by default while preserving it in human-readable verbose mode
- group repeated incidents and improve evaluation/retry terminology
- add explicit NDJSON, raw, tail, all, and follow behavior
- preserve event sequence and agent role fields from cloud log responses

## User-facing output

The default `telos logs SESSION` view now shows a status summary followed by the latest 50 significant activity rows. `--verbose`, `--json`, `--raw`, `--tail`, and `--all` provide progressively deeper views.

## Testing

- `go test ./...`
