### PR TITLE
feat: emit durable epoch finalization events

### DIFF
--- a/internal/cli/BUILD.bazel
+++ b/internal/cli/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/telos-org/telos/internal/cli",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/evidence",
         "//internal/executor",
         "//internal/game",
         "//internal/platform",

--- a/internal/cli/BUILD.bazel
+++ b/internal/cli/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/telos-org/telos/internal/cli",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/evidence",
         "//internal/executor",
         "//internal/game",
         "//internal/platform",

--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/telos-org/telos/internal/evidence"
 	"github.com/telos-org/telos/internal/executor"
 	"github.com/telos-org/telos/internal/game"
 	"github.com/telos-org/telos/internal/platform"
@@ -170,7 +170,10 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if err != nil {
 		return nil, fmt.Errorf("read session manifest: %w", err)
 	}
-	repairedFinalization, err := reconcileFinalizedEpochEvents(sessionDir, manifest)
+	repairedFinalization, err := sessionapi.EmitFinalizedEpochEvents(
+		sessionDir,
+		manifest,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile epoch finalization events: %w", err)
 	}
@@ -218,6 +221,18 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 
 	epochID, err := sessionworker.StartEpoch(sessionDir, manifest)
 	if err != nil {
+		if errors.Is(err, sessionworker.ErrSessionStopped) {
+			if _, eventErr := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
+				return nil, fmt.Errorf(
+					"record stopped epoch finalization: %w",
+					eventErr,
+				)
+			}
+			return &game.PVGResult{
+				GameResult: game.GameStopped,
+				Error:      "stopped by operator",
+			}, nil
+		}
 		return nil, err
 	}
 
@@ -228,10 +243,10 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 		agentExec, err = createAgentExecutor(workspace, cfg)
 		if err != nil {
 			fail := &game.PVGResult{GameResult: game.GameFailure, Error: err.Error()}
-			if finishErr := finishEpoch(sessionDir, manifest, fail); finishErr != nil {
+			if finishErr := finishEpoch(sessionDir, epochID, fail); finishErr != nil {
 				return nil, fmt.Errorf("%w; also failed to finish epoch: %v", err, finishErr)
 			}
-			if eventErr := reconcileFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
+			if _, eventErr := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
 				return nil, fmt.Errorf("%w; also failed to record epoch finalization: %v", err, eventErr)
 			}
 			return nil, err
@@ -253,10 +268,10 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	result := pvg.Run()
 
 	// Close epoch
-	if err := finishEpoch(sessionDir, manifest, result); err != nil {
+	if err := finishEpoch(sessionDir, epochID, result); err != nil {
 		return result, err
 	}
-	if err := reconcileFinalizedEpochEventsFromDisk(sessionDir); err != nil {
+	if _, err := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); err != nil {
 		return result, fmt.Errorf("record epoch finalization: %w", err)
 	}
 	if manifest.SessionKind != sessionapi.KindController {
@@ -309,81 +324,6 @@ func numericMapValue(values map[string]any, key string) int {
 	}
 }
 
-func reconcileFinalizedEpochEventsFromDisk(sessionDir string) error {
-	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
-	if err != nil {
-		return err
-	}
-	_, err = reconcileFinalizedEpochEvents(sessionDir, manifest)
-	return err
-}
-
-func reconcileFinalizedEpochEvents(sessionDir string, manifest *sessionapi.Manifest) (bool, error) {
-	if manifest == nil || len(manifest.Specs) == 0 {
-		return false, nil
-	}
-	evidencePath := manifest.Specs[0].EvidencePath
-	if evidencePath == nil || *evidencePath == "" {
-		return false, nil
-	}
-	repairedLatest := false
-	for i := range manifest.Epochs {
-		epoch := &manifest.Epochs[i]
-		if epoch.FinalizationEventEmitted || epoch.FinalizationKey == "" || epoch.FinishedAt == nil || epoch.Result == nil {
-			continue
-		}
-		writer := evidence.New(manifest.SpecName, *evidencePath, manifest.SessionID, epoch.ID)
-		_, err := writer.LogEpochFinalized(intValue(epoch.RoundCount), evidence.EpochFinalized{
-			EpochID:          epoch.ID,
-			SpecName:         epoch.SpecName,
-			SpecVersion:      epoch.SpecVersion,
-			Revision:         stringValue(epoch.Revision),
-			PackageDigest:    stringValue(epoch.PackageDigest),
-			SpecSHA256:       epoch.SpecSHA256,
-			EpochStartedAt:   epoch.StartedAt,
-			EpochFinishedAt:  *epoch.FinishedAt,
-			Result:           *epoch.Result,
-			GameResult:       gameResultFromEpoch(*epoch.Result),
-			CompletionReason: stringValue(epoch.CompletionReason),
-			VerifierConceded: boolValue(epoch.VerifierConceded),
-			CheckpointSaved:  boolValue(epoch.CheckpointSaved),
-			CheckpointPath:   stringValue(epoch.CheckpointPath),
-			CheckpointBytes:  epoch.CheckpointBytes,
-			FinalizationKey:  epoch.FinalizationKey,
-			Error:            stringValue(epoch.Error),
-		})
-		if err != nil {
-			return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
-		}
-		if err := markFinalizationEventEmitted(
-			sessionDir,
-			epoch.ID,
-			epoch.FinalizationKey,
-		); err != nil {
-			return false, fmt.Errorf("mark epoch %d finalization: %w", epoch.ID, err)
-		}
-		epoch.FinalizationEventEmitted = true
-		if i == len(manifest.Epochs)-1 {
-			repairedLatest = true
-		}
-	}
-	return repairedLatest, nil
-}
-
-func markFinalizationEventEmitted(sessionDir string, epochID int, key string) error {
-	_, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(manifest *sessionapi.Manifest) error {
-		for i := range manifest.Epochs {
-			epoch := &manifest.Epochs[i]
-			if epoch.ID == epochID && epoch.FinalizationKey == key {
-				epoch.FinalizationEventEmitted = true
-				return nil
-			}
-		}
-		return fmt.Errorf("epoch %d finalization identity changed", epochID)
-	})
-	return err
-}
-
 func resultFromEpoch(epoch *sessionapi.Epoch) *game.PVGResult {
 	result := &game.PVGResult{
 		SystemName:              epoch.SpecName,
@@ -404,17 +344,6 @@ func resultFromEpoch(epoch *sessionapi.Epoch) *game.PVGResult {
 		}
 	}
 	return result
-}
-
-func gameResultFromEpoch(result string) string {
-	switch result {
-	case "completed":
-		return string(game.GameSuccess)
-	case "stopped":
-		return string(game.GameStopped)
-	default:
-		return string(game.GameFailure)
-	}
 }
 
 func stringValue(value *string) string {
@@ -729,43 +658,52 @@ func manifestToConfig(manifest *sessionapi.Manifest) LocalRunConfig {
 	return lrc
 }
 
-func finishEpoch(sessionDir string, manifest *sessionapi.Manifest, result *game.PVGResult) error {
+func finishEpoch(sessionDir string, epochID int, result *game.PVGResult) error {
 	_, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(manifest *sessionapi.Manifest) error {
-		if manifest.IsStopped() && result.GameResult != game.GameStopped {
-			return nil
+		var epoch *sessionapi.Epoch
+		for i := range manifest.Epochs {
+			if manifest.Epochs[i].ID == epochID {
+				epoch = &manifest.Epochs[i]
+				break
+			}
 		}
-		last := manifest.LastEpoch()
-		if last == nil {
-			return nil
+		if epoch == nil {
+			return fmt.Errorf("epoch %d not found", epochID)
 		}
+		externallyStopped := epoch.Result != nil && *epoch.Result == "stopped"
 		finishedAt := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-		last.FinishedAt = &finishedAt
-		last.CompletionReason = stringPtr(result.CompletionReason)
-		last.VerifierConceded = boolPtr(result.VerifierConceded)
-		last.RoundCount = intPtr(result.Rounds)
+		epoch.FinishedAt = &finishedAt
+		if !externallyStopped {
+			epoch.CompletionReason = stringPtr(result.CompletionReason)
+			epoch.VerifierConceded = boolPtr(result.VerifierConceded)
+		}
+		epoch.RoundCount = intPtr(result.Rounds)
 		checkpointSaved := result.WorkspaceCheckpointPath != ""
-		last.CheckpointSaved = &checkpointSaved
-		last.CheckpointPath = stringPtr(result.WorkspaceCheckpointPath)
-		last.CheckpointBytes = fileSize(result.WorkspaceCheckpointPath)
+		epoch.CheckpointSaved = &checkpointSaved
+		epoch.CheckpointPath = stringPtr(result.WorkspaceCheckpointPath)
+		epoch.CheckpointBytes = fileSize(result.WorkspaceCheckpointPath)
+		if externallyStopped {
+			return nil
+		}
 
 		switch result.GameResult {
 		case game.GameSuccess:
 			completed := "completed"
-			last.Result = &completed
+			epoch.Result = &completed
 		case game.GameFailure:
 			failed := "failed"
-			last.Result = &failed
+			epoch.Result = &failed
 			if result.Error != "" {
-				last.Error = &result.Error
+				epoch.Error = &result.Error
 			}
 		case game.GameStopped:
 			stopped := "stopped"
-			last.Result = &stopped
+			epoch.Result = &stopped
 			if result.Error != "" {
-				last.Error = &result.Error
+				epoch.Error = &result.Error
 			} else {
 				err := "stopped by operator"
-				last.Error = &err
+				epoch.Error = &err
 			}
 		}
 		return nil

--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/telos-org/telos/internal/evidence"
 	"github.com/telos-org/telos/internal/executor"
 	"github.com/telos-org/telos/internal/game"
 	"github.com/telos-org/telos/internal/platform"
@@ -169,6 +170,15 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if err != nil {
 		return nil, fmt.Errorf("read session manifest: %w", err)
 	}
+	repairedFinalization, err := reconcileFinalizedEpochEvents(sessionDir, manifest)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile epoch finalization events: %w", err)
+	}
+	if repairedFinalization {
+		if epoch := manifest.LastEpoch(); epoch != nil && epoch.FinishedAt != nil {
+			return resultFromEpoch(epoch), nil
+		}
+	}
 	if manifest.IsStopped() {
 		return &game.PVGResult{GameResult: game.GameStopped, Error: "stopped by operator"}, nil
 	}
@@ -181,7 +191,6 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if sessionSpecPath == nil || *sessionSpecPath == "" {
 		return nil, fmt.Errorf("manifest spec missing session_spec_path")
 	}
-
 	// Resolve the session's copied spec against the original spec's directory
 	// so relative `extends` and `skills` paths point at real files on disk
 	// rather than the session's `specs/<name>/` copy.
@@ -189,7 +198,12 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if manifest.SourceSpecPath != nil && *manifest.SourceSpecPath != "" {
 		specBaseDir = filepath.Dir(*manifest.SourceSpecPath)
 	}
-	compiled, err := spec.CompileEnvironmentWithBase(*sessionSpecPath, specBaseDir)
+	compileSpecPath, specBaseDir := boundSpecPaths(
+		manifest,
+		*sessionSpecPath,
+		specBaseDir,
+	)
+	compiled, err := spec.CompileEnvironmentWithBase(compileSpecPath, specBaseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +231,9 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 			if finishErr := finishEpoch(sessionDir, manifest, fail); finishErr != nil {
 				return nil, fmt.Errorf("%w; also failed to finish epoch: %v", err, finishErr)
 			}
+			if eventErr := reconcileFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
+				return nil, fmt.Errorf("%w; also failed to record epoch finalization: %v", err, eventErr)
+			}
 			return nil, err
 		}
 	}
@@ -228,7 +245,7 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 		Verbose:         true,
 		EpochID:         epochID,
 		IsController:    controllerPromptEnabled(manifest),
-		PrimarySpecPath: primarySpecPath(manifest, sessionSpecPath),
+		PrimarySpecPath: compileSpecPath,
 		StopRequested:   func() bool { return sessionStopped(sessionDir) },
 	}
 
@@ -239,6 +256,9 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if err := finishEpoch(sessionDir, manifest, result); err != nil {
 		return result, err
 	}
+	if err := reconcileFinalizedEpochEventsFromDisk(sessionDir); err != nil {
+		return result, fmt.Errorf("record epoch finalization: %w", err)
+	}
 	if manifest.SessionKind != sessionapi.KindController {
 		if err := cleanupSessionWorkspace(sessionDir, result.WorkspaceCheckpointPath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: cleanup session workspace: %v\n", err)
@@ -246,6 +266,173 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	}
 
 	return result, nil
+}
+
+func boundSpecPaths(manifest *sessionapi.Manifest, fallbackPath, fallbackBase string) (string, string) {
+	versionNumber := boundSpecVersion(manifest)
+	if versionNumber == nil {
+		return fallbackPath, fallbackBase
+	}
+	for _, version := range manifest.SpecVersions {
+		if numericMapValue(version, "version") != *versionNumber {
+			continue
+		}
+		if path, _ := version["spec_path"].(string); path != "" {
+			fallbackPath = path
+		}
+		if packageSpec, _ := version["package_spec_path"].(string); packageSpec != "" {
+			fallbackBase = filepath.Dir(packageSpec)
+		}
+		return fallbackPath, fallbackBase
+	}
+	return fallbackPath, fallbackBase
+}
+
+func boundSpecVersion(manifest *sessionapi.Manifest) *int {
+	if manifest == nil {
+		return nil
+	}
+	if open := manifest.OpenEpoch(); open != nil && open.SpecVersion != nil {
+		return open.SpecVersion
+	}
+	return manifest.CurrentSpecVersion
+}
+
+func numericMapValue(values map[string]any, key string) int {
+	switch value := values[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func reconcileFinalizedEpochEventsFromDisk(sessionDir string) error {
+	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		return err
+	}
+	_, err = reconcileFinalizedEpochEvents(sessionDir, manifest)
+	return err
+}
+
+func reconcileFinalizedEpochEvents(sessionDir string, manifest *sessionapi.Manifest) (bool, error) {
+	if manifest == nil || len(manifest.Specs) == 0 {
+		return false, nil
+	}
+	evidencePath := manifest.Specs[0].EvidencePath
+	if evidencePath == nil || *evidencePath == "" {
+		return false, nil
+	}
+	repairedLatest := false
+	for i := range manifest.Epochs {
+		epoch := &manifest.Epochs[i]
+		if epoch.FinalizationEventEmitted || epoch.FinalizationKey == "" || epoch.FinishedAt == nil || epoch.Result == nil {
+			continue
+		}
+		writer := evidence.New(manifest.SpecName, *evidencePath, manifest.SessionID, epoch.ID)
+		_, err := writer.LogEpochFinalized(intValue(epoch.RoundCount), evidence.EpochFinalized{
+			EpochID:          epoch.ID,
+			SpecName:         epoch.SpecName,
+			SpecVersion:      epoch.SpecVersion,
+			Revision:         stringValue(epoch.Revision),
+			PackageDigest:    stringValue(epoch.PackageDigest),
+			SpecSHA256:       epoch.SpecSHA256,
+			EpochStartedAt:   epoch.StartedAt,
+			EpochFinishedAt:  *epoch.FinishedAt,
+			Result:           *epoch.Result,
+			GameResult:       gameResultFromEpoch(*epoch.Result),
+			CompletionReason: stringValue(epoch.CompletionReason),
+			VerifierConceded: boolValue(epoch.VerifierConceded),
+			CheckpointSaved:  boolValue(epoch.CheckpointSaved),
+			CheckpointPath:   stringValue(epoch.CheckpointPath),
+			CheckpointBytes:  epoch.CheckpointBytes,
+			FinalizationKey:  epoch.FinalizationKey,
+			Error:            stringValue(epoch.Error),
+		})
+		if err != nil {
+			return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
+		}
+		if err := markFinalizationEventEmitted(
+			sessionDir,
+			epoch.ID,
+			epoch.FinalizationKey,
+		); err != nil {
+			return false, fmt.Errorf("mark epoch %d finalization: %w", epoch.ID, err)
+		}
+		epoch.FinalizationEventEmitted = true
+		if i == len(manifest.Epochs)-1 {
+			repairedLatest = true
+		}
+	}
+	return repairedLatest, nil
+}
+
+func markFinalizationEventEmitted(sessionDir string, epochID int, key string) error {
+	_, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(manifest *sessionapi.Manifest) error {
+		for i := range manifest.Epochs {
+			epoch := &manifest.Epochs[i]
+			if epoch.ID == epochID && epoch.FinalizationKey == key {
+				epoch.FinalizationEventEmitted = true
+				return nil
+			}
+		}
+		return fmt.Errorf("epoch %d finalization identity changed", epochID)
+	})
+	return err
+}
+
+func resultFromEpoch(epoch *sessionapi.Epoch) *game.PVGResult {
+	result := &game.PVGResult{
+		SystemName:              epoch.SpecName,
+		Rounds:                  intValue(epoch.RoundCount),
+		VerifierConceded:        boolValue(epoch.VerifierConceded),
+		CompletionReason:        stringValue(epoch.CompletionReason),
+		Error:                   stringValue(epoch.Error),
+		WorkspaceCheckpointPath: stringValue(epoch.CheckpointPath),
+	}
+	if epoch.Result != nil {
+		switch *epoch.Result {
+		case "completed":
+			result.GameResult = game.GameSuccess
+		case "stopped":
+			result.GameResult = game.GameStopped
+		default:
+			result.GameResult = game.GameFailure
+		}
+	}
+	return result
+}
+
+func gameResultFromEpoch(result string) string {
+	switch result {
+	case "completed":
+		return string(game.GameSuccess)
+	case "stopped":
+		return string(game.GameStopped)
+	default:
+		return string(game.GameFailure)
+	}
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func intValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
 }
 
 func controllerPromptEnabled(manifest *sessionapi.Manifest) bool {
@@ -330,16 +517,6 @@ func validatePiModel(model string) error {
 		}
 	}
 	return fmt.Errorf("pi model %q is not configured: provider %q exists in ~/.pi/agent/models.json, but model id %q was not found; choose one with `telos run SPEC.md --model <provider>/<model-id>` or set `TELOS_MODEL=<provider>/<model-id>`", model, providerName, modelID)
-}
-
-func primarySpecPath(manifest *sessionapi.Manifest, fallback *string) string {
-	if manifest != nil && manifest.SessionSpecPath != nil && *manifest.SessionSpecPath != "" {
-		return *manifest.SessionSpecPath
-	}
-	if fallback != nil {
-		return *fallback
-	}
-	return ""
 }
 
 func newSessionDir(root string) (string, error) {
@@ -563,6 +740,13 @@ func finishEpoch(sessionDir string, manifest *sessionapi.Manifest, result *game.
 		}
 		finishedAt := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 		last.FinishedAt = &finishedAt
+		last.CompletionReason = stringPtr(result.CompletionReason)
+		last.VerifierConceded = boolPtr(result.VerifierConceded)
+		last.RoundCount = intPtr(result.Rounds)
+		checkpointSaved := result.WorkspaceCheckpointPath != ""
+		last.CheckpointSaved = &checkpointSaved
+		last.CheckpointPath = stringPtr(result.WorkspaceCheckpointPath)
+		last.CheckpointBytes = fileSize(result.WorkspaceCheckpointPath)
 
 		switch result.GameResult {
 		case game.GameSuccess:
@@ -590,6 +774,33 @@ func finishEpoch(sessionDir string, manifest *sessionapi.Manifest, result *game.
 		return fmt.Errorf("finish epoch: %w", err)
 	}
 	return nil
+}
+
+func stringPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func fileSize(path string) *int64 {
+	if path == "" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+	size := info.Size()
+	return &size
 }
 
 func sessionStopped(sessionDir string) bool {

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -939,6 +939,203 @@ func TestRunLocalSessionWithFakeExecutor(t *testing.T) {
 	if sessionAPI.Status != sessionapi.StatusCompleted {
 		t.Errorf("status: got %s", sessionAPI.Status)
 	}
+
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatalf("store.Events: %v", err)
+	}
+	gameEndIndex := -1
+	checkpointIndex := -1
+	finalizedIndex := -1
+	var finalized sessionapi.SessionEvent
+	for i, event := range events {
+		switch event.Event {
+		case "game_end":
+			gameEndIndex = i
+		case "workspace_checkpoint":
+			checkpointIndex = i
+		case "epoch_finalized":
+			finalizedIndex = i
+			finalized = event
+		}
+	}
+	if gameEndIndex < 0 || checkpointIndex <= gameEndIndex || finalizedIndex <= checkpointIndex {
+		t.Fatalf("unexpected lifecycle event order: game_end=%d checkpoint=%d finalized=%d", gameEndIndex, checkpointIndex, finalizedIndex)
+	}
+	if finalized.Schema == nil || *finalized.Schema != "telos.evidence.v2" || finalized.EventID == nil {
+		t.Fatalf("missing durable event identity: %#v", finalized)
+	}
+	if finalized.SessionID == nil || *finalized.SessionID != session.SessionID || finalized.EpochID == nil || *finalized.EpochID != 1 {
+		t.Fatalf("unexpected session/epoch identity: %#v", finalized)
+	}
+	if finalized.Data["result"] != "completed" || finalized.Data["completion_reason"] != "verifier_conceded" || finalized.Data["verifier_conceded"] != true {
+		t.Fatalf("unexpected finalization data: %#v", finalized.Data)
+	}
+	if finalized.Data["checkpoint_saved"] != true || finalized.Data["checkpoint_bytes"] != float64(4) {
+		t.Fatalf("unexpected checkpoint data: %#v", finalized.Data)
+	}
+}
+
+func TestBoundSpecPathsUseImmutableOpenEpochVersion(t *testing.T) {
+	version := 2
+	openVersion := 1
+	manifest := &sessionapi.Manifest{
+		CurrentSpecVersion: &version,
+		Epochs: []sessionapi.Epoch{{
+			ID:          1,
+			SpecVersion: &openVersion,
+		}},
+		SpecVersions: []map[string]any{
+			{
+				"version":           float64(1),
+				"spec_path":         "/revisions/one/SPEC.md",
+				"package_spec_path": "/revisions/one/package/SPEC.md",
+			},
+			{"version": float64(2), "spec_path": "/revisions/two/SPEC.md"},
+		},
+	}
+	path, base := boundSpecPaths(manifest, "/specs/current/SPEC.md", "/current/package")
+	if path != "/revisions/one/SPEC.md" {
+		t.Fatalf("bound spec path: got %q", path)
+	}
+	if base != "/revisions/one/package" {
+		t.Fatalf("bound spec base: got %q", base)
+	}
+}
+
+func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
+	dir := t.TempDir()
+	specPath := writeTestSpec(t, dir)
+	originalDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalDir)
+
+	session, err := CreateLocalSession(specPath, LocalRunConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec := &fakeExecutor{
+		proverResult: game.TurnResult{Role: "prover", Status: game.StatusContinue},
+		verifierResult: game.TurnResult{
+			Role:   "verifier",
+			Status: game.StatusConcede,
+			Logs:   "<status>CONCEDE</status>",
+		},
+	}
+	if _, err := RunLocalSessionWithExecutor(session.SessionDir, exec); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := sessionapi.ReadManifest(manifestPath(session.SessionDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidencePath := *manifest.Specs[0].EvidencePath
+	data, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 0 || !strings.Contains(lines[len(lines)-1], `"event":"epoch_finalized"`) {
+		t.Fatalf("expected final event, got %q", lines)
+	}
+	withoutFinalization := strings.Join(lines[:len(lines)-1], "\n") + "\n"
+	if err := os.WriteFile(evidencePath, []byte(withoutFinalization), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest.LastEpoch().FinalizationEventEmitted = false
+	if err := sessionapi.WriteManifest(manifestPath(session.SessionDir), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	repairExecutor := &fakeExecutor{
+		proverResult:   game.TurnResult{Role: "prover", Status: game.StatusContinue},
+		verifierResult: game.TurnResult{Role: "verifier", Status: game.StatusConcede},
+	}
+	repairedResult, err := RunLocalSessionWithExecutor(session.SessionDir, repairExecutor)
+	if err != nil {
+		t.Fatalf("repair run: %v", err)
+	}
+	if repairedResult.GameResult != game.GameSuccess {
+		t.Fatalf("repaired result: %s", repairedResult.GameResult)
+	}
+	if len(repairExecutor.tasks) != 0 {
+		t.Fatalf("repair must not start another agent cycle: %d tasks", len(repairExecutor.tasks))
+	}
+	manifest, err = sessionapi.ReadManifest(manifestPath(session.SessionDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if appended, err := reconcileFinalizedEpochEvents(session.SessionDir, manifest); err != nil || appended {
+		t.Fatalf("idempotent repair: %v", err)
+	}
+	store := sessionapi.NewFileStore(filepath.Dir(session.SessionDir), sessionapi.RuntimeLocal)
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.Event == "epoch_finalized" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("finalization count: got %d want 1", count)
+	}
+}
+
+func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
+	dir := t.TempDir()
+	evidencePath := filepath.Join(dir, "evidence.jsonl")
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	completed := "completed"
+	manifest := &sessionapi.Manifest{
+		SessionID:   "sess_history",
+		SessionKind: sessionapi.KindController,
+		SpecName:    "service",
+		Specs: []sessionapi.ManifestSpec{{
+			Name:         "service",
+			EvidencePath: &evidencePath,
+		}},
+		Epochs: []sessionapi.Epoch{
+			{
+				ID:              1,
+				StartedAt:       "2026-08-14T11:58:00.000Z",
+				FinishedAt:      &finishedAt,
+				Result:          &completed,
+				FinalizationKey: "sess_history:epoch:00000001:finalized",
+			},
+			{
+				ID:                       2,
+				StartedAt:                "2026-08-14T11:59:00.000Z",
+				FinishedAt:               &finishedAt,
+				Result:                   &completed,
+				FinalizationKey:          "sess_history:epoch:00000002:finalized",
+				FinalizationEventEmitted: true,
+			},
+		},
+	}
+	if err := sessionapi.WriteManifest(manifestPath(dir), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	repairedLatest, err := reconcileFinalizedEpochEvents(dir, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repairedLatest {
+		t.Fatal("repairing a historical epoch must not be treated as repairing the latest epoch")
+	}
+	updated, err := sessionapi.ReadManifest(manifestPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.Epochs[0].FinalizationEventEmitted {
+		t.Fatal("historical epoch finalization marker was not persisted")
+	}
 }
 
 func TestCreateLocalSessionPersistsUntil(t *testing.T) {

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -1068,7 +1068,7 @@ func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if appended, err := reconcileFinalizedEpochEvents(session.SessionDir, manifest); err != nil || appended {
+	if appended, err := sessionapi.EmitFinalizedEpochEvents(session.SessionDir, manifest); err != nil || appended {
 		t.Fatalf("idempotent repair: %v", err)
 	}
 	store := sessionapi.NewFileStore(filepath.Dir(session.SessionDir), sessionapi.RuntimeLocal)
@@ -1122,7 +1122,7 @@ func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repairedLatest, err := reconcileFinalizedEpochEvents(dir, manifest)
+	repairedLatest, err := sessionapi.EmitFinalizedEpochEvents(dir, manifest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1135,6 +1135,64 @@ func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
 	}
 	if !updated.Epochs[0].FinalizationEventEmitted {
 		t.Fatal("historical epoch finalization marker was not persisted")
+	}
+}
+
+func TestFinishEpochMergesCheckpointIntoOriginalLegacyEpoch(t *testing.T) {
+	dir := t.TempDir()
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	stopped := "stopped"
+	checkpointSaved := false
+	manifest := &sessionapi.Manifest{
+		SessionID:   "sess-stop-race",
+		SessionKind: sessionapi.KindController,
+		Epochs: []sessionapi.Epoch{
+			{
+				ID:              1,
+				StartedAt:       "2026-08-14T11:59:00.000Z",
+				FinishedAt:      &finishedAt,
+				Result:          &stopped,
+				CheckpointSaved: &checkpointSaved,
+			},
+			{
+				ID:              2,
+				StartedAt:       finishedAt,
+				FinishedAt:      &finishedAt,
+				Result:          &stopped,
+				CheckpointSaved: &checkpointSaved,
+				FinalizationKey: "sess-stop-race:epoch:00000002:finalized",
+			},
+		},
+	}
+	if err := sessionapi.WriteManifest(manifestPath(dir), manifest); err != nil {
+		t.Fatal(err)
+	}
+	checkpointPath := filepath.Join(dir, "checkpoint.tar")
+	if err := os.WriteFile(checkpointPath, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := finishEpoch(dir, 1, &game.PVGResult{
+		GameResult:              game.GameStopped,
+		Rounds:                  3,
+		WorkspaceCheckpointPath: checkpointPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := sessionapi.ReadManifest(manifestPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := updated.Epochs[0]
+	if legacy.CheckpointSaved == nil || !*legacy.CheckpointSaved || legacy.CheckpointBytes == nil || *legacy.CheckpointBytes != 4 {
+		t.Fatalf("legacy checkpoint metadata was not merged: %#v", legacy)
+	}
+	if legacy.RoundCount == nil || *legacy.RoundCount != 3 {
+		t.Fatalf("legacy round count: %#v", legacy.RoundCount)
+	}
+	synthetic := updated.Epochs[1]
+	if synthetic.CheckpointSaved == nil || *synthetic.CheckpointSaved || synthetic.CheckpointBytes != nil {
+		t.Fatalf("synthetic stop absorbed legacy checkpoint: %#v", synthetic)
 	}
 }
 
@@ -1588,6 +1646,40 @@ func TestRunLocalSessionStopsWhenManifestIsStopped(t *testing.T) {
 	}
 	if sessionAPI.Status != sessionapi.StatusStopped {
 		t.Fatalf("status: got %s", sessionAPI.Status)
+	}
+	manifest, err := sessionapi.ReadManifest(filepath.Join(session.SessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	epoch := manifest.LastEpoch()
+	if epoch == nil || epoch.CheckpointSaved == nil || !*epoch.CheckpointSaved {
+		t.Fatalf("stopped epoch lost checkpoint metadata: %#v", epoch)
+	}
+	if epoch.CheckpointBytes == nil || *epoch.CheckpointBytes != 4 {
+		t.Fatalf("stopped epoch checkpoint bytes: %#v", epoch.CheckpointBytes)
+	}
+	if !epoch.FinalizationEventEmitted {
+		t.Fatal("stopped epoch finalization marker was not persisted")
+	}
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := 0
+	for _, event := range events {
+		if event.Event != "epoch_finalized" {
+			continue
+		}
+		finalized++
+		if event.Data["result"] != "stopped" || event.Data["checkpoint_saved"] != true {
+			t.Fatalf("unexpected stopped finalization: %#v", event.Data)
+		}
+		if event.Data["checkpoint_bytes"] != float64(4) {
+			t.Fatalf("unexpected stopped checkpoint bytes: %#v", event.Data)
+		}
+	}
+	if finalized != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", finalized)
 	}
 }
 

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -1610,6 +1610,14 @@ func TestRunLocalSessionStopsWhenManifestIsStopped(t *testing.T) {
 		t.Fatalf("CreateLocalSession: %v", err)
 	}
 	store := sessionapi.NewFileStore(filepath.Dir(session.SessionDir), sessionapi.RuntimeLocal)
+	owner, err := sessionworker.AcquireOwnership(
+		session.SessionDir,
+		filepath.Join(session.SessionDir, "runner.log"),
+	)
+	if err != nil {
+		t.Fatalf("AcquireOwnership: %v", err)
+	}
+	t.Cleanup(func() { _ = owner.Release() })
 
 	exec := &fakeExecutor{
 		proverResult: game.TurnResult{
@@ -1638,6 +1646,9 @@ func TestRunLocalSessionStopsWhenManifestIsStopped(t *testing.T) {
 	}
 	if result.GameResult != game.GameStopped {
 		t.Fatalf("game result: got %s", result.GameResult)
+	}
+	if err := owner.Release(); err != nil {
+		t.Fatalf("Release ownership: %v", err)
 	}
 
 	sessionAPI, err := store.Get(session.SessionID)

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -2,6 +2,7 @@
 package evidence
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -41,16 +42,24 @@ func New(systemName string, path string, sessionID string, epochID int) *Evidenc
 	}
 }
 
-// Log writes a single evidence event.
+// Log writes a single best-effort evidence event. Lifecycle events that must
+// be durable use log directly and return its error to the session worker.
 func (e *Evidence) Log(event string, roundNum int, role string, data map[string]interface{}) {
+	_, _ = e.log(event, roundNum, role, data, "")
+}
+
+func (e *Evidence) log(event string, roundNum int, role string, data map[string]interface{}, dedupeKey string) (bool, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	lock, err := lockEvidenceFile(e.Path)
 	if err != nil {
-		return
+		return false, err
 	}
 	defer unlockEvidenceFile(lock)
+	if dedupeKey != "" && hasFinalizationKey(e.Path, dedupeKey) {
+		return false, nil
+	}
 
 	if lastSeq := lastEventSeq(e.Path); lastSeq > e.eventSeq {
 		e.eventSeq = lastSeq
@@ -74,15 +83,43 @@ func (e *Evidence) Log(event string, roundNum int, role string, data map[string]
 		record["data"] = map[string]interface{}{}
 	}
 
-	line, _ := json.Marshal(record)
+	line, err := json.Marshal(record)
+	if err != nil {
+		return false, err
+	}
 	f, err := os.OpenFile(e.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return
+		return false, err
 	}
 	defer f.Close()
-	f.Write(line)
-	f.Write([]byte("\n"))
-	f.Sync()
+	line = append(line, '\n')
+	if needsLeadingNewline(e.Path) {
+		line = append([]byte{'\n'}, line...)
+	}
+	if _, err := f.Write(line); err != nil {
+		return false, err
+	}
+	if err := f.Sync(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func needsLeadingNewline(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.Size() == 0 {
+		return false
+	}
+	last := []byte{0}
+	if _, err := f.ReadAt(last, info.Size()-1); err != nil {
+		return false
+	}
+	return last[0] != '\n'
 }
 
 // LogAgent logs an agent completion event.
@@ -123,6 +160,55 @@ func (e *Evidence) LogGameEnd(result string, rounds, proverRounds, verifierRound
 	})
 }
 
+// EpochFinalized is the immutable lifecycle record for one completed worker
+// epoch. Package and spec identity describe the inputs bound when the epoch
+// started, not mutable session state observed after it finished.
+type EpochFinalized struct {
+	EpochID          int
+	SpecName         string
+	SpecVersion      *int
+	Revision         string
+	PackageDigest    string
+	SpecSHA256       string
+	EpochStartedAt   string
+	EpochFinishedAt  string
+	Result           string
+	GameResult       string
+	CompletionReason string
+	VerifierConceded bool
+	CheckpointSaved  bool
+	CheckpointPath   string
+	CheckpointBytes  *int64
+	FinalizationKey  string
+	Error            string
+}
+
+// LogEpochFinalized durably and idempotently appends an epoch_finalized event.
+func (e *Evidence) LogEpochFinalized(roundNum int, finalized EpochFinalized) (bool, error) {
+	data := map[string]interface{}{
+		"epoch_id":          finalized.EpochID,
+		"spec_name":         finalized.SpecName,
+		"spec_version":      finalized.SpecVersion,
+		"revision":          finalized.Revision,
+		"package_digest":    finalized.PackageDigest,
+		"spec_sha256":       finalized.SpecSHA256,
+		"epoch_started_at":  finalized.EpochStartedAt,
+		"epoch_finished_at": finalized.EpochFinishedAt,
+		"result":            finalized.Result,
+		"game_result":       finalized.GameResult,
+		"completion_reason": finalized.CompletionReason,
+		"verifier_conceded": finalized.VerifierConceded,
+		"checkpoint_saved":  finalized.CheckpointSaved,
+		"checkpoint_path":   finalized.CheckpointPath,
+		"finalization_key":  finalized.FinalizationKey,
+		"error":             finalized.Error,
+	}
+	if finalized.CheckpointBytes != nil {
+		data["checkpoint_bytes"] = *finalized.CheckpointBytes
+	}
+	return e.log("epoch_finalized", roundNum, "system", data, finalized.FinalizationKey)
+}
+
 // LogWorkspaceCheckpoint logs a workspace checkpoint event.
 func (e *Evidence) LogWorkspaceCheckpoint(roundNum int, path string) {
 	data := map[string]interface{}{"path": path}
@@ -139,24 +225,69 @@ func (e *Evidence) LogWorkspaceCheckpoint(roundNum int, path string) {
 func (e *Evidence) Close() {}
 
 func lastEventSeq(path string) int {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 0
-	}
-	lines := splitLines(string(data))
-	for i := len(lines) - 1; i >= 0; i-- {
-		if lines[i] == "" {
-			continue
+	seq := 0
+	visitEvidenceLinesReverse(path, func(record map[string]interface{}) bool {
+		value, ok := record["event_seq"].(float64)
+		if !ok {
+			return false
 		}
-		var m map[string]interface{}
-		if json.Unmarshal([]byte(lines[i]), &m) == nil {
-			if seq, ok := m["event_seq"].(float64); ok {
-				return int(seq)
+		seq = int(value)
+		return true
+	})
+	return seq
+}
+
+func hasFinalizationKey(path string, key string) bool {
+	found := false
+	visitEvidenceLinesReverse(path, func(record map[string]interface{}) bool {
+		payload, _ := record["data"].(map[string]interface{})
+		if value, _ := payload["finalization_key"].(string); value == key {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func visitEvidenceLinesReverse(path string, visit func(map[string]interface{}) bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return
+	}
+	const chunkSize int64 = 64 * 1024
+	end := info.Size()
+	var carry []byte
+	for end > 0 {
+		start := max(end-chunkSize, 0)
+		chunk := make([]byte, end-start)
+		if _, err := f.ReadAt(chunk, start); err != nil {
+			return
+		}
+		combined := append(chunk, carry...)
+		lines := bytes.Split(combined, []byte{'\n'})
+		firstComplete := 0
+		if start > 0 {
+			firstComplete = 1
+		}
+		for i := len(lines) - 1; i >= firstComplete; i-- {
+			line := bytes.TrimSpace(lines[i])
+			if len(line) == 0 {
+				continue
+			}
+			var record map[string]interface{}
+			if json.Unmarshal(line, &record) == nil && visit(record) {
+				return
 			}
 		}
-		break
+		carry = append([]byte(nil), lines[0]...)
+		end = start
 	}
-	return 0
 }
 
 func splitLines(s string) []string {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -179,6 +179,82 @@ func TestEvidenceLogGameEnd(t *testing.T) {
 	}
 }
 
+func TestEpochFinalizedIsDurableAndIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	version := 3
+	checkpointBytes := int64(42)
+	finalized := EpochFinalized{
+		EpochID:          7,
+		SpecName:         "controller",
+		SpecVersion:      &version,
+		Revision:         "0.3.0",
+		PackageDigest:    "sha256:package",
+		SpecSHA256:       "sha256:spec",
+		EpochStartedAt:   "2026-08-14T12:00:00.000Z",
+		EpochFinishedAt:  "2026-08-14T12:01:00.000Z",
+		Result:           "completed",
+		GameResult:       "success",
+		CompletionReason: "verifier_conceded",
+		VerifierConceded: true,
+		CheckpointSaved:  true,
+		CheckpointPath:   "/tmp/workspace.tar.gz",
+		CheckpointBytes:  &checkpointBytes,
+		FinalizationKey:  "sess-007:epoch:00000007:finalized",
+	}
+
+	ev := New("controller", path, "sess-007", 7)
+	if appended, err := ev.LogEpochFinalized(2, finalized); err != nil || !appended {
+		t.Fatalf("first append: %v", err)
+	}
+	if appended, err := ev.LogEpochFinalized(2, finalized); err != nil || appended {
+		t.Fatalf("idempotent append: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected one event, got %d", len(lines))
+	}
+	var record map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record["event"] != "epoch_finalized" || int(record["epoch_id"].(float64)) != 7 {
+		t.Fatalf("unexpected event identity: %#v", record)
+	}
+	payload := record["data"].(map[string]interface{})
+	if payload["package_digest"] != "sha256:package" || payload["verifier_conceded"] != true {
+		t.Fatalf("unexpected finalization payload: %#v", payload)
+	}
+}
+
+func TestEvidenceSequenceIgnoresMalformedTrailingLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence.jsonl")
+	if err := os.WriteFile(path, []byte("{\"event_seq\":4,\"event\":\"valid\"}\n{\"event_seq\":"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := New("test-system", path, "sess-008", 1)
+	ev.Log("after-malformed", 1, "system", nil)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	var record map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[len(lines)-2]), &record); err != nil {
+		t.Fatalf("last line: %v", err)
+	}
+	if got := int(record["event_seq"].(float64)); got != 5 {
+		t.Fatalf("event_seq: got %d want 5", got)
+	}
+}
+
 func TestEvidenceNilData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "evidence.jsonl")

--- a/internal/sessionapi/BUILD.bazel
+++ b/internal/sessionapi/BUILD.bazel
@@ -25,3 +25,9 @@ go_test(
         "//internal/spec",
     ],
 )
+
+go_test(
+    name = "sessionapi_store_test",
+    srcs = ["store_test.go"],
+    embed = [":sessionapi"],
+)

--- a/internal/sessionapi/BUILD.bazel
+++ b/internal/sessionapi/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "sessionapi",
     srcs = [
         "auth.go",
+        "finalization.go",
         "manifest.go",
         "server.go",
         "store.go",
@@ -11,7 +12,10 @@ go_library(
     ],
     importpath = "github.com/telos-org/telos/internal/sessionapi",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/spec"],
+    deps = [
+        "//internal/evidence",
+        "//internal/spec",
+    ],
 )
 
 go_test(

--- a/internal/sessionapi/finalization.go
+++ b/internal/sessionapi/finalization.go
@@ -1,0 +1,247 @@
+package sessionapi
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/telos-org/telos/internal/evidence"
+)
+
+// BindEpochFinalizationIdentity snapshots the desired spec identity onto a new
+// epoch before it can run or become terminal. Callers must not use it to rebind
+// an existing epoch: current session state may have advanced since that epoch
+// started.
+func BindEpochFinalizationIdentity(manifest *Manifest, epoch *Epoch) {
+	if manifest == nil || epoch == nil {
+		return
+	}
+	epoch.SpecName = manifest.SpecName
+	epoch.SpecVersion = cloneInt(manifest.CurrentSpecVersion)
+	epoch.Revision = cloneString(manifest.CurrentRevision)
+	epoch.PackageDigest = cloneString(manifest.PackageDigest)
+	epoch.SpecSHA256 = specSHA256ForVersion(
+		manifest.SpecVersions,
+		manifest.CurrentSpecVersion,
+	)
+	epoch.FinalizationKey = fmt.Sprintf(
+		"%s:epoch:%08d:finalized",
+		manifest.SessionID,
+		epoch.ID,
+	)
+	if !containsString(
+		epoch.WorkerCapabilities,
+		CapabilityEpochFinalizedEventsV1,
+	) {
+		epoch.WorkerCapabilities = append(
+			epoch.WorkerCapabilities,
+			CapabilityEpochFinalizedEventsV1,
+		)
+	}
+}
+
+// EmitFinalizedEpochEventsFromDisk drains the durable manifest-to-event outbox
+// on behalf of the epoch owner. The owner calls it only after checkpoint and
+// terminal metadata are fully persisted.
+func EmitFinalizedEpochEventsFromDisk(sessionDir string) (bool, error) {
+	manifest, err := ReadManifest(filepath.Join(sessionDir, "session.json"))
+	if err != nil {
+		return false, err
+	}
+	return EmitFinalizedEpochEvents(sessionDir, manifest)
+}
+
+// EmitFinalizedEpochEvents emits every fully bound terminal epoch that
+// has not yet cleared its durable outbox marker. The bool reports whether the
+// latest epoch was repaired, allowing a restarted worker to return that result
+// without starting another agent cycle.
+func EmitFinalizedEpochEvents(
+	sessionDir string,
+	manifest *Manifest,
+) (bool, error) {
+	if manifest == nil || len(manifest.Specs) == 0 {
+		return false, nil
+	}
+	evidencePath := manifest.Specs[0].EvidencePath
+	if evidencePath == nil || *evidencePath == "" {
+		return false, nil
+	}
+	repairedLatest := false
+	for i := range manifest.Epochs {
+		epoch := &manifest.Epochs[i]
+		if !epochFinalizationPending(epoch) {
+			continue
+		}
+		specName := epoch.SpecName
+		if specName == "" {
+			specName = manifest.SpecName
+		}
+		writer := evidence.New(
+			specName,
+			*evidencePath,
+			manifest.SessionID,
+			epoch.ID,
+		)
+		_, err := writer.LogEpochFinalized(
+			intValue(epoch.RoundCount),
+			evidence.EpochFinalized{
+				EpochID:          epoch.ID,
+				SpecName:         epoch.SpecName,
+				SpecVersion:      epoch.SpecVersion,
+				Revision:         stringValue(epoch.Revision),
+				PackageDigest:    stringValue(epoch.PackageDigest),
+				SpecSHA256:       epoch.SpecSHA256,
+				EpochStartedAt:   epoch.StartedAt,
+				EpochFinishedAt:  *epoch.FinishedAt,
+				Result:           *epoch.Result,
+				GameResult:       epochGameResult(*epoch.Result),
+				CompletionReason: stringValue(epoch.CompletionReason),
+				VerifierConceded: boolValue(epoch.VerifierConceded),
+				CheckpointSaved:  boolValue(epoch.CheckpointSaved),
+				CheckpointPath:   stringValue(epoch.CheckpointPath),
+				CheckpointBytes:  epoch.CheckpointBytes,
+				FinalizationKey:  epoch.FinalizationKey,
+				Error:            stringValue(epoch.Error),
+			},
+		)
+		if err != nil {
+			return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
+		}
+		if err := markFinalizationEventEmitted(
+			sessionDir,
+			epoch.ID,
+			epoch.FinalizationKey,
+		); err != nil {
+			return false, fmt.Errorf("mark epoch %d finalization: %w", epoch.ID, err)
+		}
+		epoch.FinalizationEventEmitted = true
+		if i == len(manifest.Epochs)-1 {
+			repairedLatest = true
+		}
+	}
+	return repairedLatest, nil
+}
+
+// RepairFinalizedEpochEvents drains the outbox only when no worker owns the
+// session. This keeps an API reader or supervisor from publishing terminal
+// evidence before a cooperative worker has persisted its final checkpoint
+// metadata.
+func RepairFinalizedEpochEvents(sessionDir string) (bool, error) {
+	held, err := runnerLockHeld(sessionDir)
+	if err != nil {
+		return false, fmt.Errorf("inspect runner lock: %w", err)
+	}
+	if held {
+		return false, nil
+	}
+	return EmitFinalizedEpochEventsFromDisk(sessionDir)
+}
+
+func epochFinalizationPending(epoch *Epoch) bool {
+	return epoch != nil &&
+		!epoch.FinalizationEventEmitted &&
+		epoch.FinalizationKey != "" &&
+		epoch.FinishedAt != nil &&
+		epoch.Result != nil
+}
+
+func markFinalizationEventEmitted(
+	sessionDir string,
+	epochID int,
+	key string,
+) error {
+	_, err := MutateManifest(
+		filepath.Join(sessionDir, "session.json"),
+		func(manifest *Manifest) error {
+			for i := range manifest.Epochs {
+				epoch := &manifest.Epochs[i]
+				if epoch.ID == epochID && epoch.FinalizationKey == key {
+					epoch.FinalizationEventEmitted = true
+					return nil
+				}
+			}
+			return fmt.Errorf("epoch %d finalization identity changed", epochID)
+		},
+	)
+	return err
+}
+
+func specSHA256ForVersion(
+	versions []map[string]any,
+	version *int,
+) string {
+	if version == nil {
+		return ""
+	}
+	for _, candidate := range versions {
+		if numericMapValue(candidate, "version") == *version {
+			value, _ := candidate["spec_sha256"].(string)
+			return value
+		}
+	}
+	return ""
+}
+
+func numericMapValue(values map[string]any, key string) int {
+	switch value := values[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func containsString(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func epochGameResult(result string) string {
+	switch result {
+	case "completed":
+		return "success"
+	case "stopped":
+		return "stopped"
+	default:
+		return "failure"
+	}
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func intValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}

--- a/internal/sessionapi/manifest.go
+++ b/internal/sessionapi/manifest.go
@@ -64,26 +64,41 @@ type ManifestSpec struct {
 }
 
 type Epoch struct {
-	ID         int     `json:"id"`
-	StartedAt  string  `json:"started_at"`
-	FinishedAt *string `json:"finished_at"`
-	Result     *string `json:"result"`
-	Error      *string `json:"error"`
-	Runner     *Runner `json:"runner"`
+	ID                       int      `json:"id"`
+	StartedAt                string   `json:"started_at"`
+	FinishedAt               *string  `json:"finished_at"`
+	Result                   *string  `json:"result"`
+	Error                    *string  `json:"error"`
+	Runner                   *Runner  `json:"runner"`
+	SpecName                 string   `json:"spec_name,omitempty"`
+	SpecVersion              *int     `json:"spec_version,omitempty"`
+	Revision                 *string  `json:"revision,omitempty"`
+	PackageDigest            *string  `json:"package_digest,omitempty"`
+	SpecSHA256               string   `json:"spec_sha256,omitempty"`
+	CompletionReason         *string  `json:"completion_reason,omitempty"`
+	VerifierConceded         *bool    `json:"verifier_conceded,omitempty"`
+	CheckpointSaved          *bool    `json:"checkpoint_saved,omitempty"`
+	CheckpointPath           *string  `json:"checkpoint_path,omitempty"`
+	CheckpointBytes          *int64   `json:"checkpoint_bytes,omitempty"`
+	RoundCount               *int     `json:"round_count,omitempty"`
+	FinalizationKey          string   `json:"finalization_key,omitempty"`
+	FinalizationEventEmitted bool     `json:"finalization_event_emitted,omitempty"`
+	WorkerCapabilities       []string `json:"worker_capabilities,omitempty"`
 }
 
 type Runner struct {
-	Kind         string  `json:"kind,omitempty"`
-	PID          int     `json:"pid,omitempty"`
-	PGID         int     `json:"pgid,omitempty"`
-	LogPath      string  `json:"log_path,omitempty"`
-	InCluster    bool    `json:"in_cluster"`
-	Hostname     string  `json:"hostname,omitempty"`
-	PodName      string  `json:"pod_name,omitempty"`
-	PodNamespace string  `json:"pod_namespace,omitempty"`
-	StartedAt    string  `json:"started_at,omitempty"`
-	FinishedAt   *string `json:"finished_at,omitempty"`
-	Status       string  `json:"status,omitempty"`
+	Kind               string   `json:"kind,omitempty"`
+	PID                int      `json:"pid,omitempty"`
+	PGID               int      `json:"pgid,omitempty"`
+	LogPath            string   `json:"log_path,omitempty"`
+	InCluster          bool     `json:"in_cluster"`
+	Hostname           string   `json:"hostname,omitempty"`
+	PodName            string   `json:"pod_name,omitempty"`
+	PodNamespace       string   `json:"pod_namespace,omitempty"`
+	StartedAt          string   `json:"started_at,omitempty"`
+	FinishedAt         *string  `json:"finished_at,omitempty"`
+	Status             string   `json:"status,omitempty"`
+	WorkerCapabilities []string `json:"worker_capabilities,omitempty"`
 }
 
 type ScopedToken struct {

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -436,6 +436,12 @@ func terminalFinalizationObserved(session *Session, events []SessionEvent) bool 
 	last := session.Epochs[len(session.Epochs)-1]
 	key, _ := last["finalization_key"].(string)
 	if key == "" {
+		capabilities, _ := last["worker_capabilities"].([]any)
+		for _, capability := range capabilities {
+			if capability == CapabilityEpochFinalizedEventsV1 {
+				return false
+			}
+		}
 		return true
 	}
 	for _, event := range events {

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -412,8 +412,11 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		}
 		session, err := h.store.Get(id)
 		if err == nil && session.Status.IsTerminal() {
-			emitAvailable()
-			return
+			events, eventsErr := h.store.Events(id)
+			if eventsErr != nil || terminalFinalizationObserved(session, events) {
+				emitAvailable()
+				return
+			}
 		}
 		select {
 		case <-r.Context().Done():
@@ -424,6 +427,26 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request, id string
 		case <-poll.C:
 		}
 	}
+}
+
+func terminalFinalizationObserved(session *Session, events []SessionEvent) bool {
+	if session == nil || len(session.Epochs) == 0 {
+		return true
+	}
+	last := session.Epochs[len(session.Epochs)-1]
+	key, _ := last["finalization_key"].(string)
+	if key == "" {
+		return true
+	}
+	for _, event := range events {
+		if event.Event != "epoch_finalized" {
+			continue
+		}
+		if eventKey, _ := event.Data["finalization_key"].(string); eventKey == key {
+			return true
+		}
+	}
+	return false
 }
 
 // --------- JSON helpers ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -110,6 +110,7 @@ func TestHealthz(t *testing.T) {
 		sessionapi.RuntimeIdentity{
 			Version:      "v0.1.3",
 			TelosdDigest: "sha256:" + strings.Repeat("a", 64),
+			Capabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
 		},
 	)
 	srv := httptest.NewServer(mux)
@@ -122,7 +123,7 @@ func TestHealthz(t *testing.T) {
 	defer resp.Body.Close()
 	assertEqual(t, "status_code", "200", itoa(resp.StatusCode))
 
-	var body map[string]string
+	var body map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatal(err)
 	}
@@ -130,10 +131,14 @@ func TestHealthz(t *testing.T) {
 		t.Fatalf("unexpected health body: %#v", body)
 	}
 	if body["runtime_version"] != "v0.1.3" {
-		t.Fatalf("runtime version: got %q", body["runtime_version"])
+		t.Fatalf("runtime version: got %#v", body["runtime_version"])
 	}
 	if body["runtime_telosd_digest"] != "sha256:"+strings.Repeat("a", 64) {
-		t.Fatalf("runtime digest: got %q", body["runtime_telosd_digest"])
+		t.Fatalf("runtime digest: got %#v", body["runtime_telosd_digest"])
+	}
+	capabilities, ok := body["capabilities"].([]any)
+	if !ok || len(capabilities) != 1 || capabilities[0] != sessionapi.CapabilityEpochFinalizedEventsV1 {
+		t.Fatalf("capabilities: got %#v", body["capabilities"])
 	}
 }
 
@@ -1842,13 +1847,13 @@ var cursorFixtureLines = []string{
 	`{"event_seq":4,"event":"four"}`,
 }
 
-func TestEventsSeqAndRoleProjected(t *testing.T) {
+func TestEventsIdentitySeqAndRoleProjected(t *testing.T) {
 	srv, store := newTestServer(t)
 	defer srv.Close()
 
 	created := createSession(t, srv.URL, createSessionBody(t, "esr"))
 	writeEventsFixture(t, store.Root, created.SessionID, "esr", []string{
-		`{"event_seq":7,"event":"agent_progress","role":"prover","ts":"2026-05-21T00:00:01.000Z","data":{"text":"hi"}}`,
+		`{"schema":"telos.evidence.v2","event_id":"sess:event:7","event_seq":7,"session_id":"sess-identity","epoch_id":3,"event":"agent_progress","role":"prover","ts":"2026-05-21T00:00:01.000Z","data":{"text":"hi"}}`,
 	})
 
 	events := getEventsList(t, srv.URL+"/api/sessions/"+created.SessionID+"/events")
@@ -1860,6 +1865,18 @@ func TestEventsSeqAndRoleProjected(t *testing.T) {
 	}
 	if events[0].Role == nil || *events[0].Role != "prover" {
 		t.Fatalf("expected role=prover, got %v", events[0].Role)
+	}
+	if events[0].Schema == nil || *events[0].Schema != "telos.evidence.v2" {
+		t.Fatalf("expected schema, got %v", events[0].Schema)
+	}
+	if events[0].EventID == nil || *events[0].EventID != "sess:event:7" {
+		t.Fatalf("expected event_id, got %v", events[0].EventID)
+	}
+	if events[0].SessionID == nil || *events[0].SessionID != "sess-identity" {
+		t.Fatalf("expected session_id, got %v", events[0].SessionID)
+	}
+	if events[0].EpochID == nil || *events[0].EpochID != 3 {
+		t.Fatalf("expected epoch_id, got %v", events[0].EpochID)
 	}
 }
 
@@ -2091,6 +2108,73 @@ func TestEventsSSEResume(t *testing.T) {
 	body = stream("?after=0", "3")
 	if !strings.Contains(body, `"event":"one"`) {
 		t.Fatalf("expected explicit ?after=0 to override Last-Event-ID, got: %s", body)
+	}
+}
+
+func TestEventsSSEWaitsForTerminalEpochFinalization(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "essf"))
+	stopSession(t, srv.URL, created.SessionID)
+	manifestPath := filepath.Join(store.Root, created.SessionID, "session.json")
+	manifest, err := sessionapi.ReadManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	epoch := manifest.LastEpoch()
+	if epoch == nil {
+		t.Fatal("missing terminal epoch")
+	}
+	epoch.FinalizationKey = created.SessionID + ":epoch:00000001:finalized"
+	if err := sessionapi.WriteManifest(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan string, 1)
+	errs := make(chan error, 1)
+	go func() {
+		req, reqErr := http.NewRequest(http.MethodGet, srv.URL+"/api/sessions/"+created.SessionID+"/events", nil)
+		if reqErr != nil {
+			errs <- reqErr
+			return
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		resp, requestErr := http.DefaultClient.Do(req)
+		if requestErr != nil {
+			errs <- requestErr
+			return
+		}
+		defer resp.Body.Close()
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			errs <- readErr
+			return
+		}
+		done <- string(body)
+	}()
+
+	select {
+	case body := <-done:
+		t.Fatalf("stream closed before finalization: %s", body)
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	writeEventsFixture(t, store.Root, created.SessionID, "essf", []string{
+		fmt.Sprintf(`{"schema":"telos.evidence.v2","event_id":"%s:essf:00000001","event_seq":1,"session_id":"%s","epoch_id":1,"event":"epoch_finalized","data":{"finalization_key":"%s"}}`, created.SessionID, created.SessionID, epoch.FinalizationKey),
+	})
+
+	select {
+	case body := <-done:
+		if !strings.Contains(body, `"event":"epoch_finalized"`) {
+			t.Fatalf("missing finalization event: %s", body)
+		}
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream did not close after finalization")
 	}
 }
 

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -2116,17 +2117,36 @@ func TestEventsSSEWaitsForTerminalEpochFinalization(t *testing.T) {
 	defer srv.Close()
 
 	created := createSession(t, srv.URL, createSessionBody(t, "essf"))
-	stopSession(t, srv.URL, created.SessionID)
+	sessionDir := filepath.Join(store.Root, created.SessionID)
+	lock, err := os.OpenFile(
+		filepath.Join(sessionDir, "runner.lock"),
+		os.O_CREATE|os.O_RDWR,
+		0o600,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatal(err)
+	}
 	manifestPath := filepath.Join(store.Root, created.SessionID, "session.json")
 	manifest, err := sessionapi.ReadManifest(manifestPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	epoch := manifest.LastEpoch()
-	if epoch == nil {
-		t.Fatal("missing terminal epoch")
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	stopped := "stopped"
+	stoppedErr := "stopped by operator"
+	epoch := sessionapi.Epoch{
+		ID:         1,
+		StartedAt:  "2026-08-14T11:59:00.000Z",
+		FinishedAt: &finishedAt,
+		Result:     &stopped,
+		Error:      &stoppedErr,
 	}
-	epoch.FinalizationKey = created.SessionID + ":epoch:00000001:finalized"
+	sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+	manifest.Epochs = append(manifest.Epochs, epoch)
 	if err := sessionapi.WriteManifest(manifestPath, manifest); err != nil {
 		t.Fatal(err)
 	}
@@ -2162,9 +2182,9 @@ func TestEventsSSEWaitsForTerminalEpochFinalization(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 	}
 
-	writeEventsFixture(t, store.Root, created.SessionID, "essf", []string{
-		fmt.Sprintf(`{"schema":"telos.evidence.v2","event_id":"%s:essf:00000001","event_seq":1,"session_id":"%s","epoch_id":1,"event":"epoch_finalized","data":{"finalization_key":"%s"}}`, created.SessionID, created.SessionID, epoch.FinalizationKey),
-	})
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
 
 	select {
 	case body := <-done:

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -779,7 +779,10 @@ func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
 			result = epoch.Result
 		}
 		if result != nil && *result == "stopped" {
-			continue
+			last := manifest.LastEpoch()
+			if !epochFinalizationPending(last) {
+				continue
+			}
 		}
 		kind := manifest.SessionKind
 		sessionDir := fs.sessionDir(entry.Name())
@@ -823,7 +826,17 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 	}
 
 	s, _ := fs.deriveSession(id, m)
-	if s.Status.IsTerminal() {
+	if s.Status.IsTerminal() && s.Status != StatusStale {
+		if m.IsStopped() {
+			if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
+				return nil, fmt.Errorf("repair stopped epoch finalization: %w", repairErr)
+			}
+			m, err = ReadManifest(fs.manifestPath(id))
+			if err != nil {
+				return nil, err
+			}
+			return fs.deriveSession(id, m)
+		}
 		return s, nil
 	}
 
@@ -836,31 +849,81 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 		runner = &copy
 	}
 
+	createdSyntheticEpoch := false
 	m, err = MutateManifest(fs.manifestPath(id), func(m *Manifest) error {
 		now := tsNow()
 		stopped := "stopped"
 		stoppedErr := "stopped by operator"
+		completionReason := "stopped"
+		conceded := false
+		checkpointSaved := false
+		roundCount := 0
 
-		if len(m.Epochs) == 0 {
-			m.Epochs = append(m.Epochs, Epoch{
-				ID:         1,
-				StartedAt:  now,
-				FinishedAt: &now,
-				Result:     &stopped,
-				Error:      &stoppedErr,
-			})
-		} else {
-			last := &m.Epochs[len(m.Epochs)-1]
-			last.FinishedAt = &now
-			last.Result = &stopped
-			last.Error = &stoppedErr
+		if m.IsStopped() {
+			return nil
 		}
+		if open := m.OpenEpoch(); open != nil {
+			open.FinishedAt = &now
+			open.Result = &stopped
+			open.Error = &stoppedErr
+			open.CompletionReason = &completionReason
+			if open.VerifierConceded == nil {
+				open.VerifierConceded = &conceded
+			}
+			if open.CheckpointSaved == nil {
+				open.CheckpointSaved = &checkpointSaved
+			}
+			if open.RoundCount == nil {
+				open.RoundCount = &roundCount
+			}
+			if open.FinalizationKey == "" {
+				epoch := Epoch{
+					ID:               len(m.Epochs) + 1,
+					StartedAt:        now,
+					FinishedAt:       &now,
+					Result:           &stopped,
+					Error:            &stoppedErr,
+					CompletionReason: &completionReason,
+					VerifierConceded: &conceded,
+					CheckpointSaved:  &checkpointSaved,
+					RoundCount:       &roundCount,
+				}
+				BindEpochFinalizationIdentity(m, &epoch)
+				m.Epochs = append(m.Epochs, epoch)
+				createdSyntheticEpoch = true
+			}
+			return nil
+		}
+
+		epoch := Epoch{
+			ID:               len(m.Epochs) + 1,
+			StartedAt:        now,
+			FinishedAt:       &now,
+			Result:           &stopped,
+			Error:            &stoppedErr,
+			CompletionReason: &completionReason,
+			VerifierConceded: &conceded,
+			CheckpointSaved:  &checkpointSaved,
+			RoundCount:       &roundCount,
+		}
+		BindEpochFinalizationIdentity(m, &epoch)
+		m.Epochs = append(m.Epochs, epoch)
+		createdSyntheticEpoch = true
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 	terminateRunner(runner)
+	if createdSyntheticEpoch {
+		if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
+			return nil, fmt.Errorf("record stopped epoch finalization: %w", repairErr)
+		}
+		m, err = ReadManifest(fs.manifestPath(id))
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return fs.deriveSession(id, m)
 }
@@ -907,6 +970,13 @@ func (fs *FileStore) Events(id string) ([]SessionEvent, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("session %s: %w", id, ErrNotFound)
 		}
+		return nil, err
+	}
+	if _, err := RepairFinalizedEpochEvents(fs.sessionDir(id)); err != nil {
+		return nil, fmt.Errorf("repair epoch finalization: %w", err)
+	}
+	m, err = ReadManifest(fs.manifestPath(id))
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -849,7 +849,6 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 		runner = &copy
 	}
 
-	createdSyntheticEpoch := false
 	m, err = MutateManifest(fs.manifestPath(id), func(m *Manifest) error {
 		now := tsNow()
 		stopped := "stopped"
@@ -890,7 +889,6 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 				}
 				BindEpochFinalizationIdentity(m, &epoch)
 				m.Epochs = append(m.Epochs, epoch)
-				createdSyntheticEpoch = true
 			}
 			return nil
 		}
@@ -908,21 +906,18 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 		}
 		BindEpochFinalizationIdentity(m, &epoch)
 		m.Epochs = append(m.Epochs, epoch)
-		createdSyntheticEpoch = true
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 	terminateRunner(runner)
-	if createdSyntheticEpoch {
-		if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
-			return nil, fmt.Errorf("record stopped epoch finalization: %w", repairErr)
-		}
-		m, err = ReadManifest(fs.manifestPath(id))
-		if err != nil {
-			return nil, err
-		}
+	if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
+		return nil, fmt.Errorf("record stopped epoch finalization: %w", repairErr)
+	}
+	m, err = ReadManifest(fs.manifestPath(id))
+	if err != nil {
+		return nil, err
 	}
 
 	return fs.deriveSession(id, m)

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -753,6 +753,47 @@ func (fs *FileStore) List() ([]Session, error) {
 	return sessions, nil
 }
 
+// ListRootWorkerSessions returns only the manifest fields needed by the cloud
+// worker supervisor. It deliberately avoids the public List derivation path,
+// which summarizes complete evidence logs and dashboard state while holding
+// the store mutation lock.
+func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
+	entries, err := os.ReadDir(fs.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return []Session{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]Session, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifest, err := ReadManifest(fs.manifestPath(entry.Name()))
+		if err != nil || manifest.ParentSessionID != nil || manifest.SessionKind != KindController {
+			continue
+		}
+		var result *string
+		if epoch := manifest.LastEpoch(); epoch != nil {
+			result = epoch.Result
+		}
+		if result != nil && *result == "stopped" {
+			continue
+		}
+		kind := manifest.SessionKind
+		sessionDir := fs.sessionDir(entry.Name())
+		sessions = append(sessions, Session{
+			SessionID:       manifest.SessionID,
+			SessionKind:     &kind,
+			ParentSessionID: manifest.ParentSessionID,
+			SessionDir:      &sessionDir,
+			Result:          result,
+		})
+	}
+	return sessions, nil
+}
+
 // Get returns a single session by ID.
 func (fs *FileStore) Get(id string) (*Session, error) {
 	fs.mu.Lock()
@@ -1254,9 +1295,13 @@ func readEvidenceFile(path string, spec *ManifestSpec) ([]SessionEvent, error) {
 
 		ev := SessionEvent{
 			Event:       eventName,
+			Schema:      stringField(raw, "schema"),
+			EventID:     stringField(raw, "event_id"),
 			EventSeq:    eventSeq(raw),
+			EpochID:     intField(raw, "epoch_id"),
 			Role:        strPtr(role),
 			Timestamp:   strPtr(timestamp),
+			SessionID:   stringField(raw, "session_id"),
 			SpecIndex:   spec.Index,
 			SpecName:    strPtr(spec.Name),
 			SpecDirName: strPtr(spec.DirName),
@@ -1265,6 +1310,23 @@ func readEvidenceFile(path string, spec *ManifestSpec) ([]SessionEvent, error) {
 		events = append(events, ev)
 	}
 	return events, nil
+}
+
+func stringField(raw map[string]any, key string) *string {
+	value, ok := raw[key].(string)
+	if !ok || value == "" {
+		return nil
+	}
+	return &value
+}
+
+func intField(raw map[string]any, key string) *int {
+	value, ok := raw[key].(float64)
+	if !ok {
+		return nil
+	}
+	result := int(value)
+	return &result
 }
 
 // eventSeq lifts the evidence writer's sequence number; nil for lines that

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -35,3 +35,49 @@ func TestCreateSessionDirSkipsExistingID(t *testing.T) {
 		t.Fatalf("created session dir missing: %v", err)
 	}
 }
+
+func TestListRootWorkerSessionsReadsOnlyEligibleManifests(t *testing.T) {
+	root := t.TempDir()
+	store := NewFileStore(root, RuntimeCloud)
+	parent := "sess_root"
+	stopped := "stopped"
+	write := func(id string, kind SessionKind, parentID *string, result *string) {
+		t.Helper()
+		dir := filepath.Join(root, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		manifest := &Manifest{
+			SessionID:       id,
+			SessionKind:     kind,
+			ParentSessionID: parentID,
+		}
+		if result != nil {
+			finishedAt := "2026-08-14T12:00:00.000Z"
+			manifest.Epochs = []Epoch{{
+				ID:         1,
+				StartedAt:  "2026-08-14T11:59:00.000Z",
+				FinishedAt: &finishedAt,
+				Result:     result,
+			}}
+		}
+		if err := WriteManifest(filepath.Join(dir, "session.json"), manifest); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("sess_root", KindController, nil, nil)
+	write("sess_child", KindController, &parent, nil)
+	write("sess_task", KindTask, nil, nil)
+	write("sess_stopped", KindController, nil, &stopped)
+
+	sessions, err := store.ListRootWorkerSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != "sess_root" {
+		t.Fatalf("root worker sessions: %#v", sessions)
+	}
+	if sessions[0].SessionDir == nil || *sessions[0].SessionDir != filepath.Join(root, "sess_root") {
+		t.Fatalf("session dir: %#v", sessions[0].SessionDir)
+	}
+}

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -81,3 +81,277 @@ func TestListRootWorkerSessionsReadsOnlyEligibleManifests(t *testing.T) {
 		t.Fatalf("session dir: %#v", sessions[0].SessionDir)
 	}
 }
+
+func TestStopBeforeWorkerEmitsBoundFinalizationExactlyOnce(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+
+	stopped, err := store.Stop(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Status != StatusStopped {
+		t.Fatalf("status: got %s want %s", stopped.Status, StatusStopped)
+	}
+
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	epoch := manifest.LastEpoch()
+	if epoch == nil {
+		t.Fatal("missing stopped epoch")
+	}
+	if epoch.SpecName != manifest.SpecName || epoch.SpecVersion == nil {
+		t.Fatalf("missing bound spec identity: %#v", epoch)
+	}
+	if epoch.PackageDigest == nil || *epoch.PackageDigest == "" || epoch.SpecSHA256 == "" {
+		t.Fatalf("missing bound package identity: %#v", epoch)
+	}
+	if epoch.FinalizationKey != session.SessionID+":epoch:00000001:finalized" {
+		t.Fatalf("finalization key: %q", epoch.FinalizationKey)
+	}
+	if !epoch.FinalizationEventEmitted {
+		t.Fatal("finalization marker was not persisted")
+	}
+
+	assertSingleStoppedFinalization(t, store, session.SessionID, epoch)
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	assertSingleStoppedFinalization(t, store, session.SessionID, epoch)
+}
+
+func TestStopOpenEpochPreservesBoundIdentity(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldVersion := 1
+	oldRevision := "revision-old"
+	oldDigest := "sha256:old"
+	manifest.CurrentSpecVersion = &oldVersion
+	manifest.CurrentRevision = &oldRevision
+	manifest.PackageDigest = &oldDigest
+	manifest.SpecVersions = []map[string]any{{
+		"version":     oldVersion,
+		"spec_sha256": "sha256:old-spec",
+	}}
+	epoch := Epoch{
+		ID:        1,
+		StartedAt: "2026-08-14T11:59:00.000Z",
+		Runner:    &Runner{PID: 999999},
+	}
+	BindEpochFinalizationIdentity(manifest, &epoch)
+	manifest.Epochs = append(manifest.Epochs, epoch)
+	newVersion := 2
+	newRevision := "revision-new"
+	newDigest := "sha256:new"
+	manifest.CurrentSpecVersion = &newVersion
+	manifest.CurrentRevision = &newRevision
+	manifest.PackageDigest = &newDigest
+	manifest.SpecVersions = append(manifest.SpecVersions, map[string]any{
+		"version":     newVersion,
+		"spec_sha256": "sha256:new-spec",
+	})
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := finalizedEvents(events)
+	if len(finalized) != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", len(finalized))
+	}
+	data := finalized[0].Data
+	if data["revision"] != oldRevision || data["package_digest"] != oldDigest {
+		t.Fatalf("event rebound to mutable desired state: %#v", data)
+	}
+	if data["spec_version"] != float64(oldVersion) || data["spec_sha256"] != "sha256:old-spec" {
+		t.Fatalf("unexpected bound spec identity: %#v", data)
+	}
+}
+
+func TestStopLegacyOpenEpochEmitsSeparateCurrentStopIdentity(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentVersion := 2
+	currentRevision := "revision-current"
+	currentDigest := "sha256:current"
+	manifest.CurrentSpecVersion = &currentVersion
+	manifest.CurrentRevision = &currentRevision
+	manifest.PackageDigest = &currentDigest
+	manifest.SpecVersions = append(manifest.SpecVersions, map[string]any{
+		"version":     currentVersion,
+		"spec_sha256": "sha256:current-spec",
+	})
+	manifest.Epochs = append(manifest.Epochs, Epoch{
+		ID:        1,
+		StartedAt: "2026-08-14T11:59:00.000Z",
+		Runner:    &Runner{PID: 999999},
+	})
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.Epochs) != 2 {
+		t.Fatalf("epochs: got %d want 2", len(updated.Epochs))
+	}
+	legacy := updated.Epochs[0]
+	if legacy.Result == nil || *legacy.Result != "stopped" || legacy.FinalizationKey != "" {
+		t.Fatalf("legacy epoch was rebound: %#v", legacy)
+	}
+	synthetic := updated.Epochs[1]
+	if synthetic.FinalizationKey == "" || !synthetic.FinalizationEventEmitted {
+		t.Fatalf("synthetic stop was not finalized: %#v", synthetic)
+	}
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := finalizedEvents(events)
+	if len(finalized) != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", len(finalized))
+	}
+	data := finalized[0].Data
+	if data["revision"] != currentRevision || data["package_digest"] != currentDigest {
+		t.Fatalf("synthetic stop identity: %#v", data)
+	}
+	if data["spec_version"] != float64(currentVersion) || data["spec_sha256"] != "sha256:current-spec" {
+		t.Fatalf("synthetic stop spec identity: %#v", data)
+	}
+}
+
+func TestStopIdleControllerAppendsEpochWithoutRewritingHistory(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed := "completed"
+	finishedAt := "2026-08-14T11:58:00.000Z"
+	epoch := Epoch{
+		ID:                       1,
+		StartedAt:                "2026-08-14T11:57:00.000Z",
+		FinishedAt:               &finishedAt,
+		Result:                   &completed,
+		FinalizationEventEmitted: true,
+	}
+	BindEpochFinalizationIdentity(manifest, &epoch)
+	manifest.Epochs = append(manifest.Epochs, epoch)
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.Epochs) != 2 {
+		t.Fatalf("epochs: got %d want 2", len(updated.Epochs))
+	}
+	if updated.Epochs[0].Result == nil || *updated.Epochs[0].Result != completed {
+		t.Fatalf("completed history was rewritten: %#v", updated.Epochs[0])
+	}
+	if updated.Epochs[1].Result == nil || *updated.Epochs[1].Result != "stopped" {
+		t.Fatalf("missing synthetic stopped epoch: %#v", updated.Epochs[1])
+	}
+}
+
+func TestSecondStopRepairsPersistedFinalizationOutbox(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	badEvidencePath := t.TempDir()
+	manifest.Specs[0].EvidencePath = &badEvidencePath
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err == nil {
+		t.Fatal("expected finalization append failure")
+	}
+	pending, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !epochFinalizationPending(pending.LastEpoch()) {
+		t.Fatalf("stop did not persist repairable outbox: %#v", pending.LastEpoch())
+	}
+	evidencePath := filepath.Join(t.TempDir(), "evidence.jsonl")
+	pending.Specs[0].EvidencePath = &evidencePath
+	if err := WriteManifest(store.manifestPath(session.SessionID), pending); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	assertSingleStoppedFinalization(t, store, session.SessionID, pending.LastEpoch())
+}
+
+func createCloudStoreSession(t *testing.T) (*FileStore, *Session) {
+	t.Helper()
+	store := NewFileStore(t.TempDir(), RuntimeCloud)
+	markdown := "---\nversion: 0.1.0\nname: service\nplatform: cloud\n---\n# Service\n"
+	session, err := store.Create(SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, session
+}
+
+func assertSingleStoppedFinalization(
+	t *testing.T,
+	store *FileStore,
+	sessionID string,
+	epoch *Epoch,
+) {
+	t.Helper()
+	events, err := store.Events(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := finalizedEvents(events)
+	if len(finalized) != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", len(finalized))
+	}
+	data := finalized[0].Data
+	if data["finalization_key"] != epoch.FinalizationKey || data["result"] != "stopped" {
+		t.Fatalf("unexpected stopped finalization: %#v", data)
+	}
+	if data["checkpoint_saved"] != false || data["verifier_conceded"] != false {
+		t.Fatalf("unexpected stop completion metadata: %#v", data)
+	}
+}
+
+func finalizedEvents(events []SessionEvent) []SessionEvent {
+	finalized := make([]SessionEvent, 0)
+	for _, event := range events {
+		if event.Event == "epoch_finalized" {
+			finalized = append(finalized, event)
+		}
+	}
+	return finalized
+}

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -161,6 +161,14 @@ func TestStopOpenEpochPreservesBoundIdentity(t *testing.T) {
 	if _, err := store.Stop(session.SessionID); err != nil {
 		t.Fatal(err)
 	}
+	stoppedManifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stoppedEpoch := stoppedManifest.LastEpoch()
+	if stoppedEpoch == nil || !stoppedEpoch.FinalizationEventEmitted {
+		t.Fatalf("Stop returned before repairing the dead worker outbox: %#v", stoppedEpoch)
+	}
 	events, err := store.Events(session.SessionID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sessionapi/types.go
+++ b/internal/sessionapi/types.go
@@ -145,9 +145,12 @@ type SessionSpecResponse struct {
 }
 
 // RuntimeIdentity identifies the live telosd process serving the API.
+const CapabilityEpochFinalizedEventsV1 = "epoch-finalized-events-v1"
+
 type RuntimeIdentity struct {
-	Version      string `json:"runtime_version,omitempty"`
-	TelosdDigest string `json:"runtime_telosd_digest,omitempty"`
+	Version      string   `json:"runtime_version,omitempty"`
+	TelosdDigest string   `json:"runtime_telosd_digest,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // --------- Spec types ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -332,7 +335,10 @@ type SessionEvent struct {
 	// EventSeq is the evidence writer's dense 1-based sequence number —
 	// the durable cursor for pagination and stream resume. Nil for lines
 	// written before seq-stamping existed.
+	Schema      *string        `json:"schema,omitempty"`
+	EventID     *string        `json:"event_id,omitempty"`
 	EventSeq    *int64         `json:"event_seq,omitempty"`
+	EpochID     *int           `json:"epoch_id,omitempty"`
 	Role        *string        `json:"role,omitempty"`
 	Timestamp   *string        `json:"ts,omitempty"`
 	SessionID   *string        `json:"session_id,omitempty"`

--- a/internal/sessionworker/BUILD.bazel
+++ b/internal/sessionworker/BUILD.bazel
@@ -1,9 +1,16 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sessionworker",
     srcs = ["process.go"],
     importpath = "github.com/telos-org/telos/internal/sessionworker",
     visibility = ["//:__subpackages__"],
+    deps = ["//internal/sessionapi"],
+)
+
+go_test(
+    name = "sessionworker_test",
+    srcs = ["process_test.go"],
+    embed = [":sessionworker"],
     deps = ["//internal/sessionapi"],
 )

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -62,7 +65,131 @@ func StartWithOptions(sessionDir string, opts StartOptions) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start worker: %w", err)
 	}
+	go func() {
+		// Detached workers are supervised through their runner lock and manifest,
+		// but the spawning process must still reap the OS child handle.
+		_ = cmd.Wait()
+	}()
 	return nil
+}
+
+// EnsureStartedWithOptions ensures the active worker implements the current
+// durable lifecycle contract. It asks a pre-capability detached worker left
+// across an API-binary rollout to retire after its current cycle, and launches
+// only when no process owns the runner lock. Concurrent launchers remain safe
+// because the worker performs the authoritative ownership check at startup.
+func EnsureStartedWithOptions(sessionDir string, opts StartOptions) error {
+	alive, err := workerAlive(sessionDir)
+	if err != nil {
+		return err
+	}
+	if alive {
+		manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+		if err != nil {
+			return fmt.Errorf("read active worker identity: %w", err)
+		}
+		if runnerSupportsCapability(
+			manifest.Runner,
+			sessionapi.CapabilityEpochFinalizedEventsV1,
+		) {
+			return nil
+		}
+		if manifest.OpenEpoch() != nil {
+			return nil
+		}
+		return requestWorkerRetirement(sessionDir, manifest.Runner)
+	}
+	return StartWithOptions(sessionDir, opts)
+}
+
+func requestWorkerRetirement(sessionDir string, expected *sessionapi.Runner) error {
+	if expected == nil {
+		return nil
+	}
+	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		return fmt.Errorf("revalidate legacy worker identity: %w", err)
+	}
+	if !sameRunnerIdentity(expected, manifest.Runner) {
+		return nil
+	}
+	if manifest.OpenEpoch() != nil {
+		// The legacy worker may have opened its next epoch after the supervisor's
+		// first idle check. Let it finish rather than interrupting active work.
+		return nil
+	}
+	pid, ok := expected.ProcessID()
+	if !ok || pid == os.Getpid() {
+		return nil
+	}
+	argv, err := processArgv(pid)
+	if err != nil || !workerArgvMatchesSession(argv, sessionDir) {
+		// Failing closed keeps legacy polling active rather than risking a
+		// signal to a recycled PID during a runner-lock handoff.
+		return nil
+	}
+	// SIGTERM is cooperative: the legacy worker finishes an in-flight agent
+	// cycle, then observes its stop channel before the next one. Unlike Stop,
+	// rollout retirement signals only the worker (not its agent process group)
+	// and never escalates to SIGKILL.
+	if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
+		return nil
+	} else if !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("retire legacy worker process %d: %w", pid, err)
+	}
+	return nil
+}
+
+func processArgv(pid int) ([]string, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("process argv inspection is unsupported on %s", runtime.GOOS)
+	}
+	contents, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(string(contents), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return parts, nil
+}
+
+func workerArgvMatchesSession(argv []string, sessionDir string) bool {
+	if len(argv) == 0 || sessionDir == "" || filepath.Base(argv[0]) != "telosd" {
+		return false
+	}
+	for index := 1; index < len(argv); index++ {
+		if argv[index] == "--session-dir" {
+			return index+1 < len(argv) && argv[index+1] == sessionDir
+		}
+		if argv[index] == "--session-dir="+sessionDir {
+			return true
+		}
+	}
+	return false
+}
+
+func sameRunnerIdentity(left, right *sessionapi.Runner) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.PID == right.PID &&
+		left.PGID == right.PGID &&
+		left.StartedAt == right.StartedAt &&
+		left.Kind == right.Kind
+}
+
+func runnerSupportsCapability(runner *sessionapi.Runner, capability string) bool {
+	if runner == nil {
+		return false
+	}
+	for _, candidate := range runner.WorkerCapabilities {
+		if candidate == capability {
+			return true
+		}
+	}
+	return false
 }
 
 func Env(sessionDir string, opts StartOptions) []string {
@@ -270,6 +397,7 @@ func StartEpoch(sessionDir string, manifest *sessionapi.Manifest) (int, error) {
 
 func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid int, logPath string) (int, error) {
 	var epochID int
+	identity := epochIdentity(manifest)
 	_, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(m *sessionapi.Manifest) error {
 		if open := m.OpenEpoch(); open != nil {
 			epochID = open.ID
@@ -281,9 +409,18 @@ func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid 
 			runner.LogPath = logPath
 		}
 		m.Epochs = append(m.Epochs, sessionapi.Epoch{
-			ID:        epochID,
-			StartedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-			Runner:    &runner,
+			ID:              epochID,
+			StartedAt:       time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+			Runner:          &runner,
+			SpecName:        identity.specName,
+			SpecVersion:     identity.specVersion,
+			Revision:        identity.revision,
+			PackageDigest:   identity.packageDigest,
+			SpecSHA256:      identity.specSHA256,
+			FinalizationKey: fmt.Sprintf("%s:epoch:%08d:finalized", identity.sessionID, epochID),
+			WorkerCapabilities: []string{
+				sessionapi.CapabilityEpochFinalizedEventsV1,
+			},
 		})
 		return nil
 	})
@@ -293,12 +430,79 @@ func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid 
 	return epochID, nil
 }
 
+type epochRunIdentity struct {
+	sessionID     string
+	specName      string
+	specVersion   *int
+	revision      *string
+	packageDigest *string
+	specSHA256    string
+}
+
+func epochIdentity(manifest *sessionapi.Manifest) epochRunIdentity {
+	if manifest == nil {
+		return epochRunIdentity{}
+	}
+	identity := epochRunIdentity{
+		sessionID:     manifest.SessionID,
+		specName:      manifest.SpecName,
+		specVersion:   cloneInt(manifest.CurrentSpecVersion),
+		revision:      cloneString(manifest.CurrentRevision),
+		packageDigest: cloneString(manifest.PackageDigest),
+	}
+	if manifest.CurrentSpecVersion == nil {
+		return identity
+	}
+	for _, version := range manifest.SpecVersions {
+		if mapInt(version, "version") == *manifest.CurrentSpecVersion {
+			identity.specSHA256 = mapString(version, "spec_sha256")
+			break
+		}
+	}
+	return identity
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func mapInt(values map[string]any, key string) int {
+	switch value := values[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func mapString(values map[string]any, key string) string {
+	value, _ := values[key].(string)
+	return value
+}
+
 func RunnerIdentity(pid int) sessionapi.Runner {
 	return sessionapi.Runner{
 		Kind:      "local-subprocess",
 		PID:       pid,
 		PGID:      pid,
 		StartedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		WorkerCapabilities: []string{
+			sessionapi.CapabilityEpochFinalizedEventsV1,
+		},
 	}
 }
 

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -17,6 +17,7 @@ import (
 
 var ErrWorkerNotRunning = errors.New("worker is not running")
 var ErrWorkerAlreadyRunning = errors.New("worker is already running")
+var ErrSessionStopped = errors.New("session is stopped")
 
 type Ownership struct {
 	file *os.File
@@ -397,8 +398,10 @@ func StartEpoch(sessionDir string, manifest *sessionapi.Manifest) (int, error) {
 
 func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid int, logPath string) (int, error) {
 	var epochID int
-	identity := epochIdentity(manifest)
 	_, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(m *sessionapi.Manifest) error {
+		if m.IsStopped() {
+			return ErrSessionStopped
+		}
 		if open := m.OpenEpoch(); open != nil {
 			epochID = open.ID
 			return nil
@@ -408,90 +411,19 @@ func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid 
 		if logPath != "" {
 			runner.LogPath = logPath
 		}
-		m.Epochs = append(m.Epochs, sessionapi.Epoch{
-			ID:              epochID,
-			StartedAt:       time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-			Runner:          &runner,
-			SpecName:        identity.specName,
-			SpecVersion:     identity.specVersion,
-			Revision:        identity.revision,
-			PackageDigest:   identity.packageDigest,
-			SpecSHA256:      identity.specSHA256,
-			FinalizationKey: fmt.Sprintf("%s:epoch:%08d:finalized", identity.sessionID, epochID),
-			WorkerCapabilities: []string{
-				sessionapi.CapabilityEpochFinalizedEventsV1,
-			},
-		})
+		epoch := sessionapi.Epoch{
+			ID:        epochID,
+			StartedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+			Runner:    &runner,
+		}
+		sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+		m.Epochs = append(m.Epochs, epoch)
 		return nil
 	})
 	if err != nil {
 		return 0, fmt.Errorf("start epoch: %w", err)
 	}
 	return epochID, nil
-}
-
-type epochRunIdentity struct {
-	sessionID     string
-	specName      string
-	specVersion   *int
-	revision      *string
-	packageDigest *string
-	specSHA256    string
-}
-
-func epochIdentity(manifest *sessionapi.Manifest) epochRunIdentity {
-	if manifest == nil {
-		return epochRunIdentity{}
-	}
-	identity := epochRunIdentity{
-		sessionID:     manifest.SessionID,
-		specName:      manifest.SpecName,
-		specVersion:   cloneInt(manifest.CurrentSpecVersion),
-		revision:      cloneString(manifest.CurrentRevision),
-		packageDigest: cloneString(manifest.PackageDigest),
-	}
-	if manifest.CurrentSpecVersion == nil {
-		return identity
-	}
-	for _, version := range manifest.SpecVersions {
-		if mapInt(version, "version") == *manifest.CurrentSpecVersion {
-			identity.specSHA256 = mapString(version, "spec_sha256")
-			break
-		}
-	}
-	return identity
-}
-
-func cloneInt(value *int) *int {
-	if value == nil {
-		return nil
-	}
-	copy := *value
-	return &copy
-}
-
-func cloneString(value *string) *string {
-	if value == nil {
-		return nil
-	}
-	copy := *value
-	return &copy
-}
-
-func mapInt(values map[string]any, key string) int {
-	switch value := values[key].(type) {
-	case int:
-		return value
-	case float64:
-		return int(value)
-	default:
-		return 0
-	}
-}
-
-func mapString(values map[string]any, key string) string {
-	value, _ := values[key].(string)
-	return value
 }
 
 func RunnerIdentity(pid int) sessionapi.Runner {

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -74,3 +74,98 @@ func TestStartEpochWithRunnerPreservesOpenEpochRunner(t *testing.T) {
 		t.Fatalf("epoch runner should be history, got log %q want %q", got, oldLog)
 	}
 }
+
+func TestStartEpochBindsProvidedRevisionIdentity(t *testing.T) {
+	sessionDir := t.TempDir()
+	oldVersion := 1
+	oldRevision := "0.1.0"
+	oldDigest := "sha256:old"
+	provided := &sessionapi.Manifest{
+		SessionID:          "sess-controller",
+		SessionKind:        sessionapi.KindController,
+		SpecName:           "controller",
+		CurrentSpecVersion: &oldVersion,
+		CurrentRevision:    &oldRevision,
+		PackageDigest:      &oldDigest,
+		SpecVersions: []map[string]any{{
+			"version":     oldVersion,
+			"spec_sha256": "sha256:old-spec",
+		}},
+	}
+	newVersion := 2
+	newRevision := "0.2.0"
+	newDigest := "sha256:new"
+	onDisk := *provided
+	onDisk.CurrentSpecVersion = &newVersion
+	onDisk.CurrentRevision = &newRevision
+	onDisk.PackageDigest = &newDigest
+	onDisk.SpecVersions = []map[string]any{{
+		"version":     newVersion,
+		"spec_sha256": "sha256:new-spec",
+	}}
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &onDisk); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := StartEpochWithRunner(sessionDir, provided, os.Getpid(), ""); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	epoch := updated.LastEpoch()
+	if epoch.SpecVersion == nil || *epoch.SpecVersion != oldVersion {
+		t.Fatalf("spec version: %#v", epoch.SpecVersion)
+	}
+	if epoch.Revision == nil || *epoch.Revision != oldRevision {
+		t.Fatalf("revision: %#v", epoch.Revision)
+	}
+	if epoch.PackageDigest == nil || *epoch.PackageDigest != oldDigest {
+		t.Fatalf("package digest: %#v", epoch.PackageDigest)
+	}
+	if epoch.SpecSHA256 != "sha256:old-spec" {
+		t.Fatalf("spec sha: %q", epoch.SpecSHA256)
+	}
+	if epoch.FinalizationKey != "sess-controller:epoch:00000001:finalized" {
+		t.Fatalf("finalization key: %q", epoch.FinalizationKey)
+	}
+	if len(epoch.WorkerCapabilities) != 1 || epoch.WorkerCapabilities[0] != sessionapi.CapabilityEpochFinalizedEventsV1 {
+		t.Fatalf("worker capabilities: %#v", epoch.WorkerCapabilities)
+	}
+}
+
+func TestRunnerIdentityAdvertisesFinalizationCapability(t *testing.T) {
+	runner := RunnerIdentity(42)
+	if !runnerSupportsCapability(&runner, sessionapi.CapabilityEpochFinalizedEventsV1) {
+		t.Fatalf("runner capabilities: %#v", runner.WorkerCapabilities)
+	}
+}
+
+func TestWorkerArgvMustMatchSessionBeforeRetirement(t *testing.T) {
+	sessionDir := "/var/lib/telos/sessions/sess_1"
+	if !workerArgvMatchesSession(
+		[]string{"/usr/local/bin/telosd", "--session-dir", sessionDir},
+		sessionDir,
+	) {
+		t.Fatal("expected exact telosd session command to match")
+	}
+	if !workerArgvMatchesSession(
+		[]string{"/usr/local/bin/telosd", "--session-dir=" + sessionDir},
+		sessionDir,
+	) {
+		t.Fatal("expected exact telosd session assignment to match")
+	}
+	if workerArgvMatchesSession(
+		[]string{"/usr/local/bin/telosd", "--session-dir", "/var/lib/telos/sessions/sess_10"},
+		sessionDir,
+	) {
+		t.Fatal("must not match a different session")
+	}
+	if workerArgvMatchesSession(
+		[]string{"/usr/local/bin/telosd-helper", "--session-dir", sessionDir},
+		sessionDir,
+	) {
+		t.Fatal("must not match an unrelated recycled PID")
+	}
+}

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -135,6 +135,39 @@ func TestStartEpochBindsProvidedRevisionIdentity(t *testing.T) {
 	}
 }
 
+func TestStartEpochDoesNotAppendAfterSessionStops(t *testing.T) {
+	sessionDir := t.TempDir()
+	manifest := &sessionapi.Manifest{
+		SessionID:   "sess-stopped",
+		SessionKind: sessionapi.KindController,
+		SpecName:    "controller",
+	}
+	stopped := "stopped"
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	epoch := sessionapi.Epoch{
+		ID:         1,
+		StartedAt:  finishedAt,
+		FinishedAt: &finishedAt,
+		Result:     &stopped,
+	}
+	sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+	manifest.Epochs = append(manifest.Epochs, epoch)
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := StartEpochWithRunner(sessionDir, manifest, os.Getpid(), ""); !errors.Is(err, ErrSessionStopped) {
+		t.Fatalf("StartEpochWithRunner error: got %v want %v", err, ErrSessionStopped)
+	}
+	updated, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.Epochs) != 1 {
+		t.Fatalf("epochs: got %d want 1", len(updated.Epochs))
+	}
+}
+
 func TestRunnerIdentityAdvertisesFinalizationCapability(t *testing.T) {
 	runner := RunnerIdentity(42)
 	if !runnerSupportsCapability(&runner, sessionapi.CapabilityEpochFinalizedEventsV1) {

--- a/internal/telosd/controller_reconciler.go
+++ b/internal/telosd/controller_reconciler.go
@@ -181,6 +181,19 @@ func (s *controllerReconciler) ensureRootWorkers(wakeReason string) error {
 			continue
 		}
 		if session.Result != nil && *session.Result == "stopped" {
+			if session.SessionDir == nil || *session.SessionDir == "" {
+				continue
+			}
+			if _, err := sessionapi.RepairFinalizedEpochEvents(*session.SessionDir); err != nil {
+				errs = append(
+					errs,
+					fmt.Errorf(
+						"repair session %s finalization: %w",
+						session.SessionID,
+						err,
+					),
+				)
+			}
 			continue
 		}
 		if err := s.apply(session, wakeReason); err != nil {
@@ -233,6 +246,16 @@ func (s *controllerReconciler) Stop(id string) (*sessionapi.Session, error) {
 	session, err = s.FileStore.Stop(id)
 	if err != nil {
 		return nil, err
+	}
+	if session.SessionDir != nil && *session.SessionDir != "" {
+		if _, err := sessionapi.RepairFinalizedEpochEvents(*session.SessionDir); err != nil {
+			return nil, fmt.Errorf(
+				"record session %s stop finalization: %w",
+				session.SessionID,
+				err,
+			)
+		}
+		return s.FileStore.Get(id)
 	}
 	return session, nil
 }

--- a/internal/telosd/controller_reconciler.go
+++ b/internal/telosd/controller_reconciler.go
@@ -167,7 +167,7 @@ func (s *controllerReconciler) apply(session *sessionapi.Session, wakeReason str
 }
 
 func (s *controllerReconciler) ensureRootWorkers(wakeReason string) error {
-	sessions, err := s.FileStore.List()
+	sessions, err := s.FileStore.ListRootWorkerSessions()
 	if err != nil {
 		return err
 	}

--- a/internal/telosd/controller_reconciler_test.go
+++ b/internal/telosd/controller_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -24,6 +25,25 @@ type recordedApply struct {
 	sessionID  string
 	wakeReason string
 }
+
+type inlineWorkerSubstrate struct{}
+
+func (inlineWorkerSubstrate) Apply(session *sessionapi.Session, _ string) error {
+	if session.SessionDir == nil {
+		return errors.New("session dir is missing")
+	}
+	code, err := RunSessionWorker(*session.SessionDir, true)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return errors.New("worker returned a nonzero exit code")
+	}
+	return nil
+}
+
+func (inlineWorkerSubstrate) Wake(*sessionapi.Session, string) error { return nil }
+func (inlineWorkerSubstrate) Stop(*sessionapi.Session) error         { return nil }
 
 func (s *recordingSubstrate) Apply(session *sessionapi.Session, wakeReason string) error {
 	s.applies = append(s.applies, recordedApply{sessionID: session.SessionID, wakeReason: wakeReason})
@@ -86,6 +106,80 @@ func TestControllerReconcilerAppliesAndStopsWorkers(t *testing.T) {
 	}
 	if len(substrate.stops) != 1 || substrate.stops[0] != session.SessionID {
 		t.Fatalf("stops: got %+v", substrate.stops)
+	}
+}
+
+func TestRootWorkerReconciliationRepairsFinalizationOutboxAfterWorkerExit(t *testing.T) {
+	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
+	substrate := &recordingSubstrate{}
+	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
+	markdown := "---\nversion: 0.1.0\nname: postgres\nplatform: cloud\n---\n# Postgres\n"
+	session, err := store.Create(sessionapi.SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionDir == nil {
+		t.Fatal("session dir is missing")
+	}
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	completed := "completed"
+	completionReason := "verifier_conceded"
+	conceded := true
+	checkpointSaved := true
+	rounds := 2
+	_, err = sessionapi.MutateManifest(
+		filepath.Join(*session.SessionDir, "session.json"),
+		func(manifest *sessionapi.Manifest) error {
+			manifest.Epochs = append(manifest.Epochs, sessionapi.Epoch{
+				ID:                 1,
+				StartedAt:          "2026-08-14T11:59:00.000Z",
+				FinishedAt:         &finishedAt,
+				Result:             &completed,
+				SpecName:           manifest.SpecName,
+				SpecVersion:        manifest.CurrentSpecVersion,
+				Revision:           manifest.CurrentRevision,
+				PackageDigest:      manifest.PackageDigest,
+				SpecSHA256:         "sha256:bound-spec",
+				CompletionReason:   &completionReason,
+				VerifierConceded:   &conceded,
+				CheckpointSaved:    &checkpointSaved,
+				RoundCount:         &rounds,
+				FinalizationKey:    session.SessionID + ":epoch:00000001:finalized",
+				WorkerCapabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
+			})
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the real worker entrypoint behind the same Apply boundary used by the
+	// periodic server supervisor. Its startup repair must emit the event and
+	// exit without beginning another agent cycle.
+	store.substrate = inlineWorkerSubstrate{}
+	if err := store.ensureRootWorkers("worker_supervision"); err != nil {
+		t.Fatal(err)
+	}
+	events, err := base.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := 0
+	for _, event := range events {
+		if event.Event == "epoch_finalized" {
+			finalized++
+		}
+	}
+	if finalized != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", finalized)
+	}
+	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.LastEpoch().FinalizationEventEmitted {
+		t.Fatal("finalization outbox marker was not persisted")
 	}
 }
 

--- a/internal/telosd/controller_reconciler_test.go
+++ b/internal/telosd/controller_reconciler_test.go
@@ -183,6 +183,75 @@ func TestRootWorkerReconciliationRepairsFinalizationOutboxAfterWorkerExit(t *tes
 	}
 }
 
+func TestRootWorkerReconciliationRepairsStoppedSessionWithoutRestart(t *testing.T) {
+	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
+	substrate := &recordingSubstrate{}
+	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
+	markdown := "---\nversion: 0.1.0\nname: postgres\nplatform: cloud\n---\n# Postgres\n"
+	session, err := store.Create(sessionapi.SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionDir == nil {
+		t.Fatal("session dir is missing")
+	}
+	_, err = sessionapi.MutateManifest(
+		filepath.Join(*session.SessionDir, "session.json"),
+		func(manifest *sessionapi.Manifest) error {
+			finishedAt := "2026-08-14T12:00:00.000Z"
+			stopped := "stopped"
+			stoppedErr := "stopped by operator"
+			epoch := sessionapi.Epoch{
+				ID:         1,
+				StartedAt:  "2026-08-14T11:59:00.000Z",
+				FinishedAt: &finishedAt,
+				Result:     &stopped,
+				Error:      &stoppedErr,
+			}
+			sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+			manifest.Epochs = append(manifest.Epochs, epoch)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	substrate.applies = nil
+
+	if err := store.ensureRootWorkers("worker_supervision"); err != nil {
+		t.Fatal(err)
+	}
+	if len(substrate.applies) != 0 {
+		t.Fatalf("stopped finalization repair restarted worker: %#v", substrate.applies)
+	}
+	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.LastEpoch().FinalizationEventEmitted {
+		t.Fatal("stopped finalization outbox marker was not persisted")
+	}
+	events, err := base.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := 0
+	for _, event := range events {
+		if event.Event == "epoch_finalized" {
+			finalized++
+		}
+	}
+	if finalized != 1 {
+		t.Fatalf("epoch_finalized events: got %d want 1", finalized)
+	}
+	if err := store.ensureRootWorkers("worker_supervision"); err != nil {
+		t.Fatal(err)
+	}
+	if len(substrate.applies) != 0 {
+		t.Fatalf("repeated repair restarted worker: %#v", substrate.applies)
+	}
+}
+
 func TestControllerReconcilerDefaultsSpecPutCreatedSessions(t *testing.T) {
 	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
 	substrate := &recordingSubstrate{}

--- a/internal/telosd/local_process_worker.go
+++ b/internal/telosd/local_process_worker.go
@@ -25,7 +25,7 @@ func (s localProcessSubstrate) Apply(session *sessionapi.Session, wakeReason str
 	if sessionDir == "" {
 		return fmt.Errorf("session %s has no session_dir", session.SessionID)
 	}
-	return sessionworker.StartWithOptions(sessionDir, sessionworker.StartOptions{
+	return sessionworker.EnsureStartedWithOptions(sessionDir, sessionworker.StartOptions{
 		Runtime:    sessionapi.RuntimeCloud,
 		WakeReason: wakeReason,
 	})

--- a/internal/telosd/runtime_identity.go
+++ b/internal/telosd/runtime_identity.go
@@ -47,5 +47,6 @@ func runtimeIdentity(version string, executable io.Reader) (sessionapi.RuntimeId
 	return sessionapi.RuntimeIdentity{
 		Version:      version,
 		TelosdDigest: fmt.Sprintf("sha256:%x", hasher.Sum(nil)),
+		Capabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
 	}, nil
 }

--- a/internal/telosd/runtime_identity_test.go
+++ b/internal/telosd/runtime_identity_test.go
@@ -22,6 +22,9 @@ func TestCurrentRuntimeIdentityHashesTheRunningExecutable(t *testing.T) {
 	if !regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(identity.TelosdDigest) {
 		t.Fatalf("digest: got %q", identity.TelosdDigest)
 	}
+	if len(identity.Capabilities) != 1 || identity.Capabilities[0] != "epoch-finalized-events-v1" {
+		t.Fatalf("capabilities: %#v", identity.Capabilities)
+	}
 	path, err := runningExecutablePath()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/telosd/server.go
+++ b/internal/telosd/server.go
@@ -22,6 +22,8 @@ import (
 // `app.usetelos.ai` both match).
 var cloudAllowedOrigin = regexp.MustCompile(`^https://(.*\.)?usetelos\.ai$|^http://localhost(:[0-9]+)?$|^http://127\.0\.0\.1(:[0-9]+)?$`)
 
+const rootWorkerReconcileInterval = 5 * time.Second
+
 func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) error {
 	cfg, err := NormalizeConfig(cfg)
 	if err != nil {
@@ -44,6 +46,7 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 		if err := reconciler.ensureRootWorkers("server_started"); err != nil {
 			log.Printf("ensure root workers: %v", err)
 		}
+		startRootWorkerReconciler(ctx, reconciler)
 		startSessionBootstrapReconciler(ctx, store, materializer)
 	}
 	mux := http.NewServeMux()
@@ -84,6 +87,23 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 		return fmt.Errorf("serve: %w", err)
 	}
 	return nil
+}
+
+func startRootWorkerReconciler(ctx context.Context, reconciler *controllerReconciler) {
+	go func() {
+		ticker := time.NewTicker(rootWorkerReconcileInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := reconciler.ensureRootWorkers("worker_supervision"); err != nil {
+					log.Printf("ensure root workers: %v", err)
+				}
+			}
+		}
+	}()
 }
 
 func storeForConfig(cfg Config) *sessionapi.FileStore {

--- a/internal/telosd/worker.go
+++ b/internal/telosd/worker.go
@@ -86,9 +86,16 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 		}
 		failures = 0
 		if root {
+			completedDesired := desired
+			if completed, ok, err := LoadCompletedEpochDesired(sessionDir); err == nil && ok {
+				completedDesired = completed
+			}
 			current, err := LoadWorkerManifest(sessionDir)
-			if err == nil && !current.Desired.Equal(desired) {
+			if err == nil && !current.Desired.Equal(completedDesired) {
 				drainWake(wake)
+				if stopRequested(stop) {
+					return 0, nil
+				}
 				continue
 			}
 		}
@@ -96,6 +103,32 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 			return 0, nil
 		}
 	}
+}
+
+func stopRequested(stop <-chan os.Signal) bool {
+	select {
+	case <-stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// LoadCompletedEpochDesired returns the immutable desired identity bound to
+// the most recently completed epoch. Legacy epochs do not carry this identity.
+func LoadCompletedEpochDesired(sessionDir string) (DesiredState, bool, error) {
+	m, err := sessionapi.ReadManifest(filepath.Join(sessionDir, "session.json"))
+	if err != nil {
+		return DesiredState{}, false, fmt.Errorf("read worker manifest: %w", err)
+	}
+	epoch := m.LastEpoch()
+	if epoch == nil || epoch.FinishedAt == nil || epoch.SpecVersion == nil {
+		return DesiredState{}, false, nil
+	}
+	return DesiredState{
+		SpecVersion:   *epoch.SpecVersion,
+		PackageDigest: strValue(epoch.PackageDigest),
+	}, true, nil
 }
 
 type WorkerManifest struct {

--- a/internal/telosd/worker_test.go
+++ b/internal/telosd/worker_test.go
@@ -103,6 +103,34 @@ func TestDesiredStateIncludesSpecVersion(t *testing.T) {
 	}
 }
 
+func TestLoadCompletedEpochDesiredUsesBoundIdentity(t *testing.T) {
+	sessionDir := writeWorkerManifest(t, map[string]any{
+		"session_kind":         "controller",
+		"current_spec_version": 8,
+		"package_digest":       "sha256:current",
+		"specs":                []map[string]any{{"name": "demo"}},
+		"epochs": []map[string]any{{
+			"id":             4,
+			"started_at":     "2026-08-14T12:00:00.000Z",
+			"finished_at":    "2026-08-14T12:01:00.000Z",
+			"result":         "completed",
+			"spec_version":   7,
+			"package_digest": "sha256:completed",
+		}},
+	})
+
+	desired, ok, err := LoadCompletedEpochDesired(sessionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected bound completion identity")
+	}
+	if desired.SpecVersion != 7 || desired.PackageDigest != "sha256:completed" {
+		t.Fatalf("unexpected desired identity: %#v", desired)
+	}
+}
+
 func TestDrainWakeClearsBufferedWakeSignals(t *testing.T) {
 	wake := make(chan os.Signal, 2)
 	wake <- syscall.SIGUSR1
@@ -114,6 +142,14 @@ func TestDrainWakeClearsBufferedWakeSignals(t *testing.T) {
 	case signal := <-wake:
 		t.Fatalf("unexpected buffered wake after drain: %v", signal)
 	default:
+	}
+}
+
+func TestStopRequestWinsBeforeImmediateDesiredStateCycle(t *testing.T) {
+	stop := make(chan os.Signal, 1)
+	stop <- syscall.SIGTERM
+	if !stopRequested(stop) {
+		t.Fatal("expected buffered retirement signal to stop the worker")
 	}
 }
 


### PR DESCRIPTION
## Summary

- bind every epoch to the immutable spec name, version, revision, package digest, and spec hash it actually ran
- emit an idempotent epoch_finalized evidence event only after workspace checkpointing and terminal epoch persistence complete
- expose runtime and worker capability markers, complete SSE event identity, resume support, and durable crash-gap repair
- supervise root workers and safely retire legacy workers without interrupting active epochs

## Rollout

This is additive and can be merged and deployed before the Cloud consumer. Existing Cloud versions ignore the new event and continue polling.\n\n## Verification\n\n- go test ./...\n- uncached race tests for evidence, CLI, session API, session worker, and telosd\n- Bazel targets for the changed packages\n- gofmt and diff checks\n- adversarial pre-commit and post-commit review