### PR TITLE
refactor(session): make finalization drive reconciliation

### DIFF
--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -99,8 +99,9 @@ func CreateLocalSession(specPath string, cfg LocalRunConfig) (*LocalSession, err
 	}
 	sourceSpecPath := absSpec
 	sessionSpecPath := state.SpecPath()
-	var currentRevision *string
-	var currentSpecVersion *int
+	currentRevision := strPtr(compiled.Environment.Version)
+	version := 1
+	currentSpecVersion := &version
 	var specVersions []map[string]any
 	var packageDigest *string
 	var applyPackageLock *spec.ApplyPackageManifest
@@ -112,8 +113,6 @@ func CreateLocalSession(specPath string, cfg LocalRunConfig) (*LocalSession, err
 		sourceSpecPath = revision.PackageSpecPath
 		sessionSpecPath = revision.ActiveSpecPath
 		currentRevision = strPtr(revision.Version)
-		version := 1
-		currentSpecVersion = &version
 		packageDigest = strPtr(revision.PackageDigest)
 		applyPackageLock = revision.ApplyPackageLock
 		specVersions = []map[string]any{{
@@ -132,6 +131,13 @@ func CreateLocalSession(specPath string, cfg LocalRunConfig) (*LocalSession, err
 		if err := os.WriteFile(state.SpecPath(), data, 0o644); err != nil {
 			return nil, fmt.Errorf("write session spec: %w", err)
 		}
+		specVersions = []map[string]any{{
+			"version":     version,
+			"revision":    compiled.Environment.Version,
+			"spec_path":   state.SpecPath(),
+			"spec_sha256": specDataSHA256(data),
+			"created_at":  time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		}}
 	}
 
 	if err := writeLocalManifest(sessionDir, compiled, sourceSpecPath, sessionSpecPath, state, cfg, workspace, currentRevision, currentSpecVersion, specVersions, packageDigest, applyPackageLock); err != nil {
@@ -170,10 +176,7 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if err != nil {
 		return nil, fmt.Errorf("read session manifest: %w", err)
 	}
-	repairedFinalization, err := sessionapi.EmitFinalizedEpochEvents(
-		sessionDir,
-		manifest,
-	)
+	repairedFinalization, err := sessionapi.EmitPendingEpochFinalization(sessionDir)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile epoch finalization events: %w", err)
 	}
@@ -222,7 +225,7 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	epochID, err := sessionworker.StartEpoch(sessionDir, manifest)
 	if err != nil {
 		if errors.Is(err, sessionworker.ErrSessionStopped) {
-			if _, eventErr := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
+			if _, eventErr := sessionapi.EmitPendingEpochFinalization(sessionDir); eventErr != nil {
 				return nil, fmt.Errorf(
 					"record stopped epoch finalization: %w",
 					eventErr,
@@ -246,7 +249,7 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 			if finishErr := finishEpoch(sessionDir, epochID, fail); finishErr != nil {
 				return nil, fmt.Errorf("%w; also failed to finish epoch: %v", err, finishErr)
 			}
-			if _, eventErr := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); eventErr != nil {
+			if _, eventErr := sessionapi.EmitPendingEpochFinalization(sessionDir); eventErr != nil {
 				return nil, fmt.Errorf("%w; also failed to record epoch finalization: %v", err, eventErr)
 			}
 			return nil, err
@@ -271,7 +274,7 @@ func RunLocalSessionWithExecutor(sessionDir string, exec game.AgentExecutor) (*g
 	if err := finishEpoch(sessionDir, epochID, result); err != nil {
 		return result, err
 	}
-	if _, err := sessionapi.EmitFinalizedEpochEventsFromDisk(sessionDir); err != nil {
+	if _, err := sessionapi.EmitPendingEpochFinalization(sessionDir); err != nil {
 		return result, fmt.Errorf("record epoch finalization: %w", err)
 	}
 	if manifest.SessionKind != sessionapi.KindController {

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -1087,7 +1087,7 @@ func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
 	}
 }
 
-func TestEmitPendingEpochFinalizationOnlyPublishesLatestEpoch(t *testing.T) {
+func TestEmitPendingEpochFinalizationPublishesAllTerminalEpochs(t *testing.T) {
 	dir := t.TempDir()
 	evidencePath := filepath.Join(dir, "evidence.jsonl")
 	finishedAt := "2026-08-14T12:00:00.000Z"
@@ -1132,7 +1132,7 @@ func TestEmitPendingEpochFinalizationOnlyPublishesLatestEpoch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(data), "epoch:00000001:finalized") ||
+	if !strings.Contains(string(data), "epoch:00000001:finalized") ||
 		!strings.Contains(string(data), "epoch:00000002:finalized") {
 		t.Fatalf("unexpected finalization evidence: %s", data)
 	}

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -294,6 +294,15 @@ func TestCreateLocalSessionRecordsParentSession(t *testing.T) {
 	if manifest.ParentSessionID == nil || *manifest.ParentSessionID != parentID {
 		t.Fatalf("parent session id: got %#v, want %q", manifest.ParentSessionID, parentID)
 	}
+	if manifest.CurrentRevision == nil || *manifest.CurrentRevision != "0.1.0" {
+		t.Fatalf("current_revision: %#v", manifest.CurrentRevision)
+	}
+	if manifest.CurrentSpecVersion == nil || *manifest.CurrentSpecVersion != 1 {
+		t.Fatalf("current_spec_version: %#v", manifest.CurrentSpecVersion)
+	}
+	if len(manifest.SpecVersions) != 1 || manifest.SpecVersions[0]["revision"] != "0.1.0" {
+		t.Fatalf("child spec identity: %#v", manifest.SpecVersions)
+	}
 }
 
 func TestCreateLocalControllerMaterializesInitialRevision(t *testing.T) {
@@ -1045,11 +1054,6 @@ func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
 	if err := os.WriteFile(evidencePath, []byte(withoutFinalization), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	manifest.LastEpoch().FinalizationEventEmitted = false
-	if err := sessionapi.WriteManifest(manifestPath(session.SessionDir), manifest); err != nil {
-		t.Fatal(err)
-	}
-
 	repairExecutor := &fakeExecutor{
 		proverResult:   game.TurnResult{Role: "prover", Status: game.StatusContinue},
 		verifierResult: game.TurnResult{Role: "verifier", Status: game.StatusConcede},
@@ -1064,11 +1068,7 @@ func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
 	if len(repairExecutor.tasks) != 0 {
 		t.Fatalf("repair must not start another agent cycle: %d tasks", len(repairExecutor.tasks))
 	}
-	manifest, err = sessionapi.ReadManifest(manifestPath(session.SessionDir))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if appended, err := sessionapi.EmitFinalizedEpochEvents(session.SessionDir, manifest); err != nil || appended {
+	if appended, err := sessionapi.EmitPendingEpochFinalization(session.SessionDir); err != nil || appended {
 		t.Fatalf("idempotent repair: %v", err)
 	}
 	store := sessionapi.NewFileStore(filepath.Dir(session.SessionDir), sessionapi.RuntimeLocal)
@@ -1087,7 +1087,7 @@ func TestReconcileFinalizedEpochEventRepairsCrashGapOnce(t *testing.T) {
 	}
 }
 
-func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
+func TestEmitPendingEpochFinalizationOnlyPublishesLatestEpoch(t *testing.T) {
 	dir := t.TempDir()
 	evidencePath := filepath.Join(dir, "evidence.jsonl")
 	finishedAt := "2026-08-14T12:00:00.000Z"
@@ -1102,19 +1102,18 @@ func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
 		}},
 		Epochs: []sessionapi.Epoch{
 			{
-				ID:              1,
-				StartedAt:       "2026-08-14T11:58:00.000Z",
-				FinishedAt:      &finishedAt,
-				Result:          &completed,
-				FinalizationKey: "sess_history:epoch:00000001:finalized",
+				ID:                 1,
+				StartedAt:          "2026-08-14T11:58:00.000Z",
+				FinishedAt:         &finishedAt,
+				Result:             &completed,
+				WorkerCapabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
 			},
 			{
-				ID:                       2,
-				StartedAt:                "2026-08-14T11:59:00.000Z",
-				FinishedAt:               &finishedAt,
-				Result:                   &completed,
-				FinalizationKey:          "sess_history:epoch:00000002:finalized",
-				FinalizationEventEmitted: true,
+				ID:                 2,
+				StartedAt:          "2026-08-14T11:59:00.000Z",
+				FinishedAt:         &finishedAt,
+				Result:             &completed,
+				WorkerCapabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
 			},
 		},
 	}
@@ -1122,19 +1121,23 @@ func TestReconcileHistoricalFinalizationDoesNotRepairLatestEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repairedLatest, err := sessionapi.EmitFinalizedEpochEvents(dir, manifest)
+	appended, err := sessionapi.EmitPendingEpochFinalization(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if repairedLatest {
-		t.Fatal("repairing a historical epoch must not be treated as repairing the latest epoch")
+	if !appended {
+		t.Fatal("latest finalization was not appended")
 	}
-	updated, err := sessionapi.ReadManifest(manifestPath(dir))
+	data, err := os.ReadFile(evidencePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !updated.Epochs[0].FinalizationEventEmitted {
-		t.Fatal("historical epoch finalization marker was not persisted")
+	if strings.Contains(string(data), "epoch:00000001:finalized") ||
+		!strings.Contains(string(data), "epoch:00000002:finalized") {
+		t.Fatalf("unexpected finalization evidence: %s", data)
+	}
+	if appended, err := sessionapi.EmitPendingEpochFinalization(dir); err != nil || appended {
+		t.Fatalf("idempotent publish: appended=%v err=%v", appended, err)
 	}
 }
 
@@ -1160,7 +1163,6 @@ func TestFinishEpochMergesCheckpointIntoOriginalLegacyEpoch(t *testing.T) {
 				FinishedAt:      &finishedAt,
 				Result:          &stopped,
 				CheckpointSaved: &checkpointSaved,
-				FinalizationKey: "sess-stop-race:epoch:00000002:finalized",
 			},
 		},
 	}
@@ -1668,9 +1670,6 @@ func TestRunLocalSessionStopsWhenManifestIsStopped(t *testing.T) {
 	}
 	if epoch.CheckpointBytes == nil || *epoch.CheckpointBytes != 4 {
 		t.Fatalf("stopped epoch checkpoint bytes: %#v", epoch.CheckpointBytes)
-	}
-	if !epoch.FinalizationEventEmitted {
-		t.Fatal("stopped epoch finalization marker was not persisted")
 	}
 	events, err := store.Events(session.SessionID)
 	if err != nil {

--- a/internal/sessionapi/finalization.go
+++ b/internal/sessionapi/finalization.go
@@ -8,9 +8,10 @@ import (
 	"github.com/telos-org/telos/internal/evidence"
 )
 
-// EmitPendingEpochFinalization publishes the latest terminal epoch exactly
-// once. The evidence writer deduplicates the deterministic finalization key,
-// so a crash never requires a second acknowledgement in the manifest.
+// EmitPendingEpochFinalization publishes terminal epochs exactly once. The
+// evidence writer deduplicates deterministic finalization keys, so a crash
+// never requires a second acknowledgement in the manifest. The bool reports
+// whether the latest epoch was appended during this call.
 func EmitPendingEpochFinalization(sessionDir string) (bool, error) {
 	manifest, err := ReadManifest(filepath.Join(sessionDir, "session.json"))
 	if err != nil {
@@ -23,11 +24,38 @@ func EmitPendingEpochFinalization(sessionDir string) (bool, error) {
 	if evidencePath == nil || *evidencePath == "" {
 		return false, nil
 	}
-	epoch := manifest.LastEpoch()
-	if !epochNeedsFinalization(epoch) {
-		return false, nil
+	finalized := make(map[string]struct{})
+	if events, err := readEvidenceFile(*evidencePath, &manifest.Specs[0]); err == nil {
+		for _, event := range events {
+			if event.Event != "epoch_finalized" {
+				continue
+			}
+			if key, ok := event.Data["finalization_key"].(string); ok {
+				finalized[key] = struct{}{}
+			}
+		}
 	}
+	appendedLatest := false
+	for i := range manifest.Epochs {
+		epoch := &manifest.Epochs[i]
+		if !epochNeedsFinalization(epoch) {
+			continue
+		}
+		if _, ok := finalized[epochFinalizationKey(manifest.SessionID, epoch.ID)]; ok {
+			continue
+		}
+		appended, err := emitEpochFinalization(manifest, epoch, *evidencePath)
+		if err != nil {
+			return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
+		}
+		if i == len(manifest.Epochs)-1 && appended {
+			appendedLatest = true
+		}
+	}
+	return appendedLatest, nil
+}
 
+func emitEpochFinalization(manifest *Manifest, epoch *Epoch, evidencePath string) (bool, error) {
 	specName := epoch.SpecName
 	if specName == "" {
 		specName = manifest.SpecName
@@ -35,7 +63,7 @@ func EmitPendingEpochFinalization(sessionDir string) (bool, error) {
 	key := epochFinalizationKey(manifest.SessionID, epoch.ID)
 	writer := evidence.New(
 		specName,
-		*evidencePath,
+		evidencePath,
 		manifest.SessionID,
 		epoch.ID,
 	)
@@ -61,10 +89,7 @@ func EmitPendingEpochFinalization(sessionDir string) (bool, error) {
 			Error:            ptrOr(epoch.Error, ""),
 		},
 	)
-	if err != nil {
-		return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
-	}
-	return appended, nil
+	return appended, err
 }
 
 // repairEpochFinalization publishes only after the worker releases ownership,

--- a/internal/sessionapi/finalization.go
+++ b/internal/sessionapi/finalization.go
@@ -3,129 +3,73 @@ package sessionapi
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/telos-org/telos/internal/evidence"
 )
 
-// BindEpochFinalizationIdentity snapshots the desired spec identity onto a new
-// epoch before it can run or become terminal. Callers must not use it to rebind
-// an existing epoch: current session state may have advanced since that epoch
-// started.
-func BindEpochFinalizationIdentity(manifest *Manifest, epoch *Epoch) {
-	if manifest == nil || epoch == nil {
-		return
-	}
-	epoch.SpecName = manifest.SpecName
-	epoch.SpecVersion = cloneInt(manifest.CurrentSpecVersion)
-	epoch.Revision = cloneString(manifest.CurrentRevision)
-	epoch.PackageDigest = cloneString(manifest.PackageDigest)
-	epoch.SpecSHA256 = specSHA256ForVersion(
-		manifest.SpecVersions,
-		manifest.CurrentSpecVersion,
-	)
-	epoch.FinalizationKey = fmt.Sprintf(
-		"%s:epoch:%08d:finalized",
-		manifest.SessionID,
-		epoch.ID,
-	)
-	if !containsString(
-		epoch.WorkerCapabilities,
-		CapabilityEpochFinalizedEventsV1,
-	) {
-		epoch.WorkerCapabilities = append(
-			epoch.WorkerCapabilities,
-			CapabilityEpochFinalizedEventsV1,
-		)
-	}
-}
-
-// EmitFinalizedEpochEventsFromDisk drains the durable manifest-to-event outbox
-// on behalf of the epoch owner. The owner calls it only after checkpoint and
-// terminal metadata are fully persisted.
-func EmitFinalizedEpochEventsFromDisk(sessionDir string) (bool, error) {
+// EmitPendingEpochFinalization publishes the latest terminal epoch exactly
+// once. The evidence writer deduplicates the deterministic finalization key,
+// so a crash never requires a second acknowledgement in the manifest.
+func EmitPendingEpochFinalization(sessionDir string) (bool, error) {
 	manifest, err := ReadManifest(filepath.Join(sessionDir, "session.json"))
 	if err != nil {
 		return false, err
 	}
-	return EmitFinalizedEpochEvents(sessionDir, manifest)
-}
-
-// EmitFinalizedEpochEvents emits every fully bound terminal epoch that
-// has not yet cleared its durable outbox marker. The bool reports whether the
-// latest epoch was repaired, allowing a restarted worker to return that result
-// without starting another agent cycle.
-func EmitFinalizedEpochEvents(
-	sessionDir string,
-	manifest *Manifest,
-) (bool, error) {
-	if manifest == nil || len(manifest.Specs) == 0 {
+	if len(manifest.Specs) == 0 {
 		return false, nil
 	}
 	evidencePath := manifest.Specs[0].EvidencePath
 	if evidencePath == nil || *evidencePath == "" {
 		return false, nil
 	}
-	repairedLatest := false
-	for i := range manifest.Epochs {
-		epoch := &manifest.Epochs[i]
-		if !epochFinalizationPending(epoch) {
-			continue
-		}
-		specName := epoch.SpecName
-		if specName == "" {
-			specName = manifest.SpecName
-		}
-		writer := evidence.New(
-			specName,
-			*evidencePath,
-			manifest.SessionID,
-			epoch.ID,
-		)
-		_, err := writer.LogEpochFinalized(
-			intValue(epoch.RoundCount),
-			evidence.EpochFinalized{
-				EpochID:          epoch.ID,
-				SpecName:         epoch.SpecName,
-				SpecVersion:      epoch.SpecVersion,
-				Revision:         stringValue(epoch.Revision),
-				PackageDigest:    stringValue(epoch.PackageDigest),
-				SpecSHA256:       epoch.SpecSHA256,
-				EpochStartedAt:   epoch.StartedAt,
-				EpochFinishedAt:  *epoch.FinishedAt,
-				Result:           *epoch.Result,
-				GameResult:       epochGameResult(*epoch.Result),
-				CompletionReason: stringValue(epoch.CompletionReason),
-				VerifierConceded: boolValue(epoch.VerifierConceded),
-				CheckpointSaved:  boolValue(epoch.CheckpointSaved),
-				CheckpointPath:   stringValue(epoch.CheckpointPath),
-				CheckpointBytes:  epoch.CheckpointBytes,
-				FinalizationKey:  epoch.FinalizationKey,
-				Error:            stringValue(epoch.Error),
-			},
-		)
-		if err != nil {
-			return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
-		}
-		if err := markFinalizationEventEmitted(
-			sessionDir,
-			epoch.ID,
-			epoch.FinalizationKey,
-		); err != nil {
-			return false, fmt.Errorf("mark epoch %d finalization: %w", epoch.ID, err)
-		}
-		epoch.FinalizationEventEmitted = true
-		if i == len(manifest.Epochs)-1 {
-			repairedLatest = true
-		}
+	epoch := manifest.LastEpoch()
+	if !epochNeedsFinalization(epoch) {
+		return false, nil
 	}
-	return repairedLatest, nil
+
+	specName := epoch.SpecName
+	if specName == "" {
+		specName = manifest.SpecName
+	}
+	key := epochFinalizationKey(manifest.SessionID, epoch.ID)
+	writer := evidence.New(
+		specName,
+		*evidencePath,
+		manifest.SessionID,
+		epoch.ID,
+	)
+	appended, err := writer.LogEpochFinalized(
+		ptrOr(epoch.RoundCount, 0),
+		evidence.EpochFinalized{
+			EpochID:          epoch.ID,
+			SpecName:         epoch.SpecName,
+			SpecVersion:      epoch.SpecVersion,
+			Revision:         ptrOr(epoch.Revision, ""),
+			PackageDigest:    ptrOr(epoch.PackageDigest, ""),
+			SpecSHA256:       epoch.SpecSHA256,
+			EpochStartedAt:   epoch.StartedAt,
+			EpochFinishedAt:  *epoch.FinishedAt,
+			Result:           *epoch.Result,
+			GameResult:       epochGameResult(*epoch.Result),
+			CompletionReason: ptrOr(epoch.CompletionReason, ""),
+			VerifierConceded: ptrOr(epoch.VerifierConceded, false),
+			CheckpointSaved:  ptrOr(epoch.CheckpointSaved, false),
+			CheckpointPath:   ptrOr(epoch.CheckpointPath, ""),
+			CheckpointBytes:  epoch.CheckpointBytes,
+			FinalizationKey:  key,
+			Error:            ptrOr(epoch.Error, ""),
+		},
+	)
+	if err != nil {
+		return false, fmt.Errorf("epoch %d: %w", epoch.ID, err)
+	}
+	return appended, nil
 }
 
-// RepairFinalizedEpochEvents drains the outbox only when no worker owns the
-// session. This keeps an API reader or supervisor from publishing terminal
-// evidence before a cooperative worker has persisted its final checkpoint
-// metadata.
-func RepairFinalizedEpochEvents(sessionDir string) (bool, error) {
+// repairEpochFinalization publishes only after the worker releases ownership,
+// ensuring checkpoint metadata is complete before an API read repairs a crash.
+func repairEpochFinalization(sessionDir string) (bool, error) {
 	held, err := runnerLockHeld(sessionDir)
 	if err != nil {
 		return false, fmt.Errorf("inspect runner lock: %w", err)
@@ -133,88 +77,25 @@ func RepairFinalizedEpochEvents(sessionDir string) (bool, error) {
 	if held {
 		return false, nil
 	}
-	return EmitFinalizedEpochEventsFromDisk(sessionDir)
+	return EmitPendingEpochFinalization(sessionDir)
 }
 
-func epochFinalizationPending(epoch *Epoch) bool {
+func epochNeedsFinalization(epoch *Epoch) bool {
 	return epoch != nil &&
-		!epoch.FinalizationEventEmitted &&
-		epoch.FinalizationKey != "" &&
 		epoch.FinishedAt != nil &&
-		epoch.Result != nil
+		epoch.Result != nil &&
+		epochSupportsFinalization(epoch)
 }
 
-func markFinalizationEventEmitted(
-	sessionDir string,
-	epochID int,
-	key string,
-) error {
-	_, err := MutateManifest(
-		filepath.Join(sessionDir, "session.json"),
-		func(manifest *Manifest) error {
-			for i := range manifest.Epochs {
-				epoch := &manifest.Epochs[i]
-				if epoch.ID == epochID && epoch.FinalizationKey == key {
-					epoch.FinalizationEventEmitted = true
-					return nil
-				}
-			}
-			return fmt.Errorf("epoch %d finalization identity changed", epochID)
-		},
+func epochSupportsFinalization(epoch *Epoch) bool {
+	return epoch != nil && slices.Contains(
+		epoch.WorkerCapabilities,
+		CapabilityEpochFinalizedEventsV1,
 	)
-	return err
 }
 
-func specSHA256ForVersion(
-	versions []map[string]any,
-	version *int,
-) string {
-	if version == nil {
-		return ""
-	}
-	for _, candidate := range versions {
-		if numericMapValue(candidate, "version") == *version {
-			value, _ := candidate["spec_sha256"].(string)
-			return value
-		}
-	}
-	return ""
-}
-
-func numericMapValue(values map[string]any, key string) int {
-	switch value := values[key].(type) {
-	case int:
-		return value
-	case float64:
-		return int(value)
-	default:
-		return 0
-	}
-}
-
-func cloneInt(value *int) *int {
-	if value == nil {
-		return nil
-	}
-	copy := *value
-	return &copy
-}
-
-func cloneString(value *string) *string {
-	if value == nil {
-		return nil
-	}
-	copy := *value
-	return &copy
-}
-
-func containsString(values []string, candidate string) bool {
-	for _, value := range values {
-		if value == candidate {
-			return true
-		}
-	}
-	return false
+func epochFinalizationKey(sessionID string, epochID int) string {
+	return fmt.Sprintf("%s:epoch:%08d:finalized", sessionID, epochID)
 }
 
 func epochGameResult(result string) string {
@@ -226,22 +107,4 @@ func epochGameResult(result string) string {
 	default:
 		return "failure"
 	}
-}
-
-func stringValue(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-func intValue(value *int) int {
-	if value == nil {
-		return 0
-	}
-	return *value
-}
-
-func boolValue(value *bool) bool {
-	return value != nil && *value
 }

--- a/internal/sessionapi/manifest.go
+++ b/internal/sessionapi/manifest.go
@@ -14,6 +14,7 @@ import (
 type Manifest struct {
 	SessionID          string                     `json:"session_id"`
 	SessionKind        SessionKind                `json:"session_kind"`
+	DesiredStatus      SessionDesiredStatus       `json:"desired_status,omitempty"`
 	Runtime            SessionRuntime             `json:"runtime,omitempty"`
 	CreatedAt          string                     `json:"created_at"`
 	Launcher           string                     `json:"launcher"`
@@ -64,27 +65,32 @@ type ManifestSpec struct {
 }
 
 type Epoch struct {
-	ID                       int      `json:"id"`
-	StartedAt                string   `json:"started_at"`
-	FinishedAt               *string  `json:"finished_at"`
-	Result                   *string  `json:"result"`
-	Error                    *string  `json:"error"`
-	Runner                   *Runner  `json:"runner"`
-	SpecName                 string   `json:"spec_name,omitempty"`
-	SpecVersion              *int     `json:"spec_version,omitempty"`
-	Revision                 *string  `json:"revision,omitempty"`
-	PackageDigest            *string  `json:"package_digest,omitempty"`
-	SpecSHA256               string   `json:"spec_sha256,omitempty"`
-	CompletionReason         *string  `json:"completion_reason,omitempty"`
-	VerifierConceded         *bool    `json:"verifier_conceded,omitempty"`
-	CheckpointSaved          *bool    `json:"checkpoint_saved,omitempty"`
-	CheckpointPath           *string  `json:"checkpoint_path,omitempty"`
-	CheckpointBytes          *int64   `json:"checkpoint_bytes,omitempty"`
-	RoundCount               *int     `json:"round_count,omitempty"`
-	FinalizationKey          string   `json:"finalization_key,omitempty"`
-	FinalizationEventEmitted bool     `json:"finalization_event_emitted,omitempty"`
-	WorkerCapabilities       []string `json:"worker_capabilities,omitempty"`
+	ID                 int      `json:"id"`
+	StartedAt          string   `json:"started_at"`
+	FinishedAt         *string  `json:"finished_at"`
+	Result             *string  `json:"result"`
+	Error              *string  `json:"error"`
+	Runner             *Runner  `json:"runner"`
+	SpecName           string   `json:"spec_name,omitempty"`
+	SpecVersion        *int     `json:"spec_version,omitempty"`
+	Revision           *string  `json:"revision,omitempty"`
+	PackageDigest      *string  `json:"package_digest,omitempty"`
+	SpecSHA256         string   `json:"spec_sha256,omitempty"`
+	CompletionReason   *string  `json:"completion_reason,omitempty"`
+	VerifierConceded   *bool    `json:"verifier_conceded,omitempty"`
+	CheckpointSaved    *bool    `json:"checkpoint_saved,omitempty"`
+	CheckpointPath     *string  `json:"checkpoint_path,omitempty"`
+	CheckpointBytes    *int64   `json:"checkpoint_bytes,omitempty"`
+	RoundCount         *int     `json:"round_count,omitempty"`
+	WorkerCapabilities []string `json:"worker_capabilities,omitempty"`
 }
+
+type SessionDesiredStatus string
+
+const (
+	DesiredStatusRunning SessionDesiredStatus = "running"
+	DesiredStatusStopped SessionDesiredStatus = "stopped"
+)
 
 type Runner struct {
 	Kind               string   `json:"kind,omitempty"`
@@ -198,6 +204,7 @@ func ManifestFromInitial(input InitialManifest) Manifest {
 	return Manifest{
 		SessionID:          input.SessionID,
 		SessionKind:        input.SessionKind,
+		DesiredStatus:      DesiredStatusRunning,
 		Runtime:            input.Runtime,
 		CreatedAt:          input.CreatedAt,
 		Launcher:           input.Launcher,
@@ -308,8 +315,73 @@ func (m *Manifest) OpenEpoch() *Epoch {
 }
 
 func (m *Manifest) IsStopped() bool {
+	if m == nil {
+		return false
+	}
+	switch m.DesiredStatus {
+	case DesiredStatusStopped:
+		return true
+	case DesiredStatusRunning:
+		return false
+	}
+	// Manifests created before desired_status used the final epoch as session
+	// intent. Keep that narrow read-side compatibility path during migration.
 	last := m.LastEpoch()
 	return last != nil && last.Result != nil && *last.Result == "stopped"
+}
+
+// NewEpoch snapshots the spec and worker identity for one execution.
+func NewEpoch(manifest *Manifest, id int, startedAt string, runner *Runner) Epoch {
+	epoch := Epoch{
+		ID:                 id,
+		StartedAt:          startedAt,
+		Runner:             runner,
+		WorkerCapabilities: []string{CapabilityEpochFinalizedEventsV1},
+	}
+	if manifest == nil {
+		return epoch
+	}
+	epoch.SpecName = manifest.SpecName
+	epoch.SpecVersion = clonePtr(manifest.CurrentSpecVersion)
+	epoch.Revision = clonePtr(manifest.CurrentRevision)
+	epoch.PackageDigest = clonePtr(manifest.PackageDigest)
+	epoch.SpecSHA256 = specSHA256ForVersion(
+		manifest.SpecVersions,
+		manifest.CurrentSpecVersion,
+	)
+	return epoch
+}
+
+func specSHA256ForVersion(versions []map[string]any, version *int) string {
+	if version == nil {
+		return ""
+	}
+	for _, candidate := range versions {
+		if numericMapValue(candidate, "version") == *version {
+			value, _ := candidate["spec_sha256"].(string)
+			return value
+		}
+	}
+	return ""
+}
+
+func numericMapValue(values map[string]any, key string) int {
+	switch value := values[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func clonePtr[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
 }
 
 func (c SessionConfig) AsMap() map[string]any {

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -434,16 +434,22 @@ func terminalFinalizationObserved(session *Session, events []SessionEvent) bool 
 		return true
 	}
 	last := session.Epochs[len(session.Epochs)-1]
-	key, _ := last["finalization_key"].(string)
-	if key == "" {
-		capabilities, _ := last["worker_capabilities"].([]any)
-		for _, capability := range capabilities {
-			if capability == CapabilityEpochFinalizedEventsV1 {
-				return false
-			}
+	capabilities, _ := last["worker_capabilities"].([]any)
+	supportsFinalization := false
+	for _, capability := range capabilities {
+		if capability == CapabilityEpochFinalizedEventsV1 {
+			supportsFinalization = true
+			break
 		}
+	}
+	if !supportsFinalization {
 		return true
 	}
+	epochID := numericMapValue(last, "id")
+	if epochID == 0 {
+		return true
+	}
+	key := epochFinalizationKey(session.SessionID, epochID)
 	for _, event := range events {
 		if event.Event != "epoch_finalized" {
 			continue

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -350,8 +350,11 @@ func TestCloudCreateSessionHonorsExplicitChildTaskKind(t *testing.T) {
 	if session.SessionKind == nil || *session.SessionKind != sessionapi.KindTask {
 		t.Fatalf("session_kind: got %#v", session.SessionKind)
 	}
-	if session.CurrentSpecVersion != nil {
-		t.Fatalf("child should not have current_spec_version: %#v", session.CurrentSpecVersion)
+	if session.CurrentSpecVersion == nil || *session.CurrentSpecVersion != 1 {
+		t.Fatalf("current_spec_version: %#v", session.CurrentSpecVersion)
+	}
+	if len(session.SpecVersions) != 1 || session.SpecVersions[0]["revision"] != "0.1.0" {
+		t.Fatalf("child spec identity: %#v", session.SpecVersions)
 	}
 }
 
@@ -2138,14 +2141,10 @@ func TestEventsSSEWaitsForTerminalEpochFinalization(t *testing.T) {
 	finishedAt := "2026-08-14T12:00:00.000Z"
 	stopped := "stopped"
 	stoppedErr := "stopped by operator"
-	epoch := sessionapi.Epoch{
-		ID:         1,
-		StartedAt:  "2026-08-14T11:59:00.000Z",
-		FinishedAt: &finishedAt,
-		Result:     &stopped,
-		Error:      &stoppedErr,
-	}
-	sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+	epoch := sessionapi.NewEpoch(manifest, 1, "2026-08-14T11:59:00.000Z", nil)
+	epoch.FinishedAt = &finishedAt
+	epoch.Result = &stopped
+	epoch.Error = &stoppedErr
 	manifest.Epochs = append(manifest.Epochs, epoch)
 	if err := sessionapi.WriteManifest(manifestPath, manifest); err != nil {
 		t.Fatal(err)

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -1468,10 +1468,16 @@ func TestListSessionsJSONShape(t *testing.T) {
 			t.Fatalf("list summary should not include %q: %#v", key, session)
 		}
 	}
-	for _, key := range []string{"session_id", "spec_name", "status", "runtime"} {
+	for _, key := range []string{
+		"session_id", "spec_name", "status", "runtime", "reconciliation",
+	} {
 		if _, ok := session[key]; !ok {
 			t.Fatalf("list summary missing %q: %#v", key, session)
 		}
+	}
+	reconciliation := session["reconciliation"].(map[string]any)
+	if reconciliation["state"] != "pending" {
+		t.Fatalf("reconciliation: %#v", reconciliation)
 	}
 }
 
@@ -1495,6 +1501,9 @@ func TestGetSession(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&session)
 	assertEqual(t, "session_id", created.SessionID, session.SessionID)
 	assertEqual(t, "status", "pending", string(session.Status))
+	if session.Reconciliation == nil || session.Reconciliation.State != sessionapi.ReconciliationPending {
+		t.Fatalf("reconciliation: %#v", session.Reconciliation)
+	}
 }
 
 func TestGetSessionNotFound(t *testing.T) {

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -1038,8 +1038,13 @@ func (fs *FileStore) deriveSession(id string, m *Manifest) (*Session, error) {
 	dir := fs.sessionDir(id)
 
 	specs := make([]SessionSpec, len(m.Specs))
+	var primarySummary *evidenceSummary
 	for i, ms := range m.Specs {
-		specs[i] = deriveSpec(ms)
+		summary, _ := readEvidenceSummary(ms.EvidencePath)
+		specs[i] = deriveSpec(ms, summary)
+		if i == 0 {
+			primarySummary = summary
+		}
 	}
 
 	epochs := make([]map[string]any, len(m.Epochs))
@@ -1078,6 +1083,7 @@ func (fs *FileStore) deriveSession(id string, m *Manifest) (*Session, error) {
 		Epochs:                epochs,
 		CurrentSpecVersion:    m.CurrentSpecVersion,
 		SpecVersions:          cloneSpecVersions(m.SpecVersions),
+		Reconciliation:        deriveReconciliation(m, primarySummary),
 	}
 
 	if s.Config == nil {
@@ -1103,7 +1109,7 @@ func (fs *FileStore) deriveSession(id string, m *Manifest) (*Session, error) {
 	return &s, nil
 }
 
-func deriveSpec(ms ManifestSpec) SessionSpec {
+func deriveSpec(ms ManifestSpec, summary *evidenceSummary) SessionSpec {
 	ss := SessionSpec{
 		Index:           ms.Index,
 		Name:            strPtr(ms.Name),
@@ -1128,7 +1134,7 @@ func deriveSpec(ms ManifestSpec) SessionSpec {
 		exists := fileExists(*ms.WorkspacePath)
 		ss.WorkspaceExists = &exists
 	}
-	if summary, err := readEvidenceSummary(ms.EvidencePath); err == nil && summary != nil {
+	if summary != nil {
 		ss.TotalCostUSD = summary.TotalCostUSD
 		ss.TotalInputTokens = summary.TotalInputTokens
 		ss.TotalOutputTokens = summary.TotalOutputTokens
@@ -1142,6 +1148,33 @@ func deriveSpec(ms ManifestSpec) SessionSpec {
 	}
 
 	return ss
+}
+
+func deriveReconciliation(m *Manifest, summary *evidenceSummary) *SessionReconciliation {
+	if m == nil || m.CurrentSpecVersion == nil {
+		return nil
+	}
+	version := *m.CurrentSpecVersion
+	reconciliation := &SessionReconciliation{
+		PackageDigest: ptrOr(m.PackageDigest, ""),
+		State:         ReconciliationPending,
+	}
+	if summary != nil {
+		if finalized, ok := summary.Finalizations[version]; ok {
+			latestEpochID := 0
+			for i := range m.Epochs {
+				epoch := &m.Epochs[i]
+				if ptrOr(epoch.SpecVersion, 0) == version && epoch.ID > latestEpochID {
+					latestEpochID = epoch.ID
+				}
+			}
+			if finalized.EpochID >= latestEpochID {
+				reconciliation.State = finalized.State
+				reconciliation.Error = finalized.Error
+			}
+		}
+	}
+	return reconciliation
 }
 
 func applySessionEvidenceSummary(session *Session) {
@@ -1406,6 +1439,13 @@ type evidenceSummary struct {
 	VerifierConceded       *bool
 	CurrentRound           *int
 	CurrentRole            *string
+	Finalizations          map[int]epochFinalization
+}
+
+type epochFinalization struct {
+	EpochID int
+	State   ReconciliationState
+	Error   string
 }
 
 func readEvidenceSummary(path *string) (*evidenceSummary, error) {
@@ -1420,6 +1460,7 @@ func readEvidenceSummary(path *string) (*evidenceSummary, error) {
 	var summary *evidenceSummary
 	var activeRound *int
 	var activeRole *string
+	finalizations := make(map[int]epochFinalization)
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -1470,13 +1511,43 @@ func readEvidenceSummary(path *string) (*evidenceSummary, error) {
 				CompletionReason:       stringPtrFromAny(dataField["completion_reason"]),
 				VerifierConceded:       boolPtrFromAny(dataField["verifier_conceded"]),
 			}
+		case "epoch_finalized":
+			version := numberAsInt(dataField["spec_version"])
+			epochID := numberAsInt(dataField["epoch_id"])
+			if version == nil || epochID == nil {
+				continue
+			}
+			finalized := epochFinalization{
+				EpochID: *epochID,
+				State:   reconciliationState(dataField),
+				Error:   ptrOr(stringPtrFromAny(dataField["error"]), ""),
+			}
+			if previous, ok := finalizations[*version]; !ok || finalized.EpochID > previous.EpochID {
+				finalizations[*version] = finalized
+			}
 		}
+	}
+	if summary == nil && len(finalizations) > 0 {
+		summary = &evidenceSummary{}
 	}
 	if summary != nil {
 		summary.CurrentRound = activeRound
 		summary.CurrentRole = activeRole
+		summary.Finalizations = finalizations
 	}
 	return summary, nil
+}
+
+func reconciliationState(data map[string]any) ReconciliationState {
+	result, _ := data["result"].(string)
+	completionReason, _ := data["completion_reason"].(string)
+	verifierConceded, _ := data["verifier_conceded"].(bool)
+	checkpointSaved, _ := data["checkpoint_saved"].(bool)
+	if result == "completed" && completionReason == "verifier_conceded" &&
+		verifierConceded && checkpointSaved {
+		return ReconciliationAccepted
+	}
+	return ReconciliationFailed
 }
 
 func evidenceRoundCount(raw map[string]any, data map[string]any) *int {

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -190,6 +190,7 @@ func (fs *FileStore) createLocked(req SessionCreateRequest) (*Session, error) {
 				PackageSpecPath: paths.PackageSpecPath,
 			})
 		} else {
+			currentRevision = strPtr(prepared.Version)
 			if err := materializePreparedPackageSource(dir, &prepared); err != nil {
 				return nil, err
 			}
@@ -235,11 +236,18 @@ func (fs *FileStore) createLocked(req SessionCreateRequest) (*Session, error) {
 			IntervalSeconds: prepared.IntervalSeconds,
 		}},
 	})
-	if isTopLevelManifest(&m) && sessionSpecPath != "" {
+	if sessionSpecPath != "" {
 		version := 1
 		m.CurrentSpecVersion = &version
 		if initialVersionEntry == nil {
-			initialVersionEntry = specVersionEntry(version, sessionSpecPath, prepared.SpecData, nil, prepared.PackageDigest, specVersionMetadata{})
+			initialVersionEntry = specVersionEntry(
+				version,
+				sessionSpecPath,
+				prepared.SpecData,
+				nil,
+				prepared.PackageDigest,
+				specVersionMetadata{Revision: prepared.Version},
+			)
 		}
 		m.SpecVersions = append(m.SpecVersions, initialVersionEntry)
 	}
@@ -753,10 +761,10 @@ func (fs *FileStore) List() ([]Session, error) {
 	return sessions, nil
 }
 
-// ListRootWorkerSessions returns only the manifest fields needed by the cloud
-// worker supervisor. It deliberately avoids the public List derivation path,
-// which summarizes complete evidence logs and dashboard state while holding
-// the store mutation lock.
+// ListRootWorkerSessions returns the runnable roots needed by the cloud worker
+// supervisor. Before excluding a stopped root, it idempotently closes any
+// crash gap between the terminal manifest write and finalization evidence.
+// Runnable roots are still returned when an unrelated repair fails.
 func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
 	entries, err := os.ReadDir(fs.Root)
 	if errors.Is(err, os.ErrNotExist) {
@@ -766,6 +774,7 @@ func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
 		return nil, err
 	}
 	sessions := make([]Session, 0)
+	var repairErrs []error
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -774,18 +783,22 @@ func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
 		if err != nil || manifest.ParentSessionID != nil || manifest.SessionKind != KindController {
 			continue
 		}
+		sessionDir := fs.sessionDir(entry.Name())
+		if manifest.IsStopped() {
+			if _, err := repairEpochFinalization(sessionDir); err != nil {
+				repairErrs = append(repairErrs, fmt.Errorf(
+					"repair session %s finalization: %w",
+					manifest.SessionID,
+					err,
+				))
+			}
+			continue
+		}
 		var result *string
 		if epoch := manifest.LastEpoch(); epoch != nil {
 			result = epoch.Result
 		}
-		if result != nil && *result == "stopped" {
-			last := manifest.LastEpoch()
-			if !epochFinalizationPending(last) {
-				continue
-			}
-		}
 		kind := manifest.SessionKind
-		sessionDir := fs.sessionDir(entry.Name())
 		sessions = append(sessions, Session{
 			SessionID:       manifest.SessionID,
 			SessionKind:     &kind,
@@ -794,7 +807,7 @@ func (fs *FileStore) ListRootWorkerSessions() ([]Session, error) {
 			Result:          result,
 		})
 	}
-	return sessions, nil
+	return sessions, errors.Join(repairErrs...)
 }
 
 // Get returns a single session by ID.
@@ -826,17 +839,13 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 	}
 
 	s, _ := fs.deriveSession(id, m)
-	if s.Status.IsTerminal() && s.Status != StatusStale {
-		if m.IsStopped() {
-			if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
-				return nil, fmt.Errorf("repair stopped epoch finalization: %w", repairErr)
-			}
-			m, err = ReadManifest(fs.manifestPath(id))
-			if err != nil {
-				return nil, err
-			}
-			return fs.deriveSession(id, m)
+	if m.IsStopped() {
+		if _, repairErr := repairEpochFinalization(fs.sessionDir(id)); repairErr != nil {
+			return nil, fmt.Errorf("repair stopped epoch finalization: %w", repairErr)
 		}
+		return fs.deriveSession(id, m)
+	}
+	if s.Status.IsTerminal() && s.Status != StatusStale && m.SessionKind != KindController {
 		return s, nil
 	}
 
@@ -858,9 +867,7 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 		checkpointSaved := false
 		roundCount := 0
 
-		if m.IsStopped() {
-			return nil
-		}
+		m.DesiredStatus = DesiredStatusStopped
 		if open := m.OpenEpoch(); open != nil {
 			open.FinishedAt = &now
 			open.Result = &stopped
@@ -875,36 +882,19 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 			if open.RoundCount == nil {
 				open.RoundCount = &roundCount
 			}
-			if open.FinalizationKey == "" {
-				epoch := Epoch{
-					ID:               len(m.Epochs) + 1,
-					StartedAt:        now,
-					FinishedAt:       &now,
-					Result:           &stopped,
-					Error:            &stoppedErr,
-					CompletionReason: &completionReason,
-					VerifierConceded: &conceded,
-					CheckpointSaved:  &checkpointSaved,
-					RoundCount:       &roundCount,
-				}
-				BindEpochFinalizationIdentity(m, &epoch)
-				m.Epochs = append(m.Epochs, epoch)
+			if epochSupportsFinalization(open) {
+				return nil
 			}
-			return nil
 		}
 
-		epoch := Epoch{
-			ID:               len(m.Epochs) + 1,
-			StartedAt:        now,
-			FinishedAt:       &now,
-			Result:           &stopped,
-			Error:            &stoppedErr,
-			CompletionReason: &completionReason,
-			VerifierConceded: &conceded,
-			CheckpointSaved:  &checkpointSaved,
-			RoundCount:       &roundCount,
-		}
-		BindEpochFinalizationIdentity(m, &epoch)
+		epoch := NewEpoch(m, len(m.Epochs)+1, now, nil)
+		epoch.FinishedAt = &now
+		epoch.Result = &stopped
+		epoch.Error = &stoppedErr
+		epoch.CompletionReason = &completionReason
+		epoch.VerifierConceded = &conceded
+		epoch.CheckpointSaved = &checkpointSaved
+		epoch.RoundCount = &roundCount
 		m.Epochs = append(m.Epochs, epoch)
 		return nil
 	})
@@ -912,7 +902,7 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 		return nil, err
 	}
 	terminateRunner(runner)
-	if _, repairErr := RepairFinalizedEpochEvents(fs.sessionDir(id)); repairErr != nil {
+	if _, repairErr := repairEpochFinalization(fs.sessionDir(id)); repairErr != nil {
 		return nil, fmt.Errorf("record stopped epoch finalization: %w", repairErr)
 	}
 	m, err = ReadManifest(fs.manifestPath(id))
@@ -967,7 +957,7 @@ func (fs *FileStore) Events(id string) ([]SessionEvent, error) {
 		}
 		return nil, err
 	}
-	if _, err := RepairFinalizedEpochEvents(fs.sessionDir(id)); err != nil {
+	if _, err := repairEpochFinalization(fs.sessionDir(id)); err != nil {
 		return nil, fmt.Errorf("repair epoch finalization: %w", err)
 	}
 	m, err = ReadManifest(fs.manifestPath(id))

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -288,6 +288,118 @@ func TestStopIdleControllerAppendsEpochWithoutRewritingHistory(t *testing.T) {
 	if updated.Epochs[1].Result == nil || *updated.Epochs[1].Result != "stopped" {
 		t.Fatalf("missing synthetic stopped epoch: %#v", updated.Epochs[1])
 	}
+	events, err := store.Events(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := finalizedEvents(events)
+	if len(finalized) != 2 {
+		t.Fatalf("epoch_finalized events: got %d want 2", len(finalized))
+	}
+	if finalized[0].Data["epoch_id"] != float64(1) || finalized[1].Data["epoch_id"] != float64(2) {
+		t.Fatalf("finalized history: %#v", finalized)
+	}
+}
+
+func TestSessionReconciliationUsesDurableCurrentVersionFinalization(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed := "completed"
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	completionReason := "verifier_conceded"
+	conceded := true
+	checkpointSaved := true
+	epoch := NewEpoch(manifest, 1, "2026-08-14T11:59:00.000Z", nil)
+	epoch.FinishedAt = &finishedAt
+	epoch.Result = &completed
+	epoch.CompletionReason = &completionReason
+	epoch.VerifierConceded = &conceded
+	epoch.CheckpointSaved = &checkpointSaved
+	manifest.Epochs = append(manifest.Epochs, epoch)
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending.Reconciliation == nil || pending.Reconciliation.State != ReconciliationPending {
+		t.Fatalf("manifest completion bypassed durable evidence: %#v", pending.Reconciliation)
+	}
+	if _, err := EmitPendingEpochFinalization(*session.SessionDir); err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Reconciliation == nil || accepted.Reconciliation.State != ReconciliationAccepted {
+		t.Fatalf("accepted reconciliation: %#v", accepted.Reconciliation)
+	}
+
+	manifest.Epochs = append(
+		manifest.Epochs,
+		NewEpoch(manifest, 2, "2026-08-14T12:00:30.000Z", nil),
+	)
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+	retrying, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retrying.Reconciliation == nil || retrying.Reconciliation.State != ReconciliationPending {
+		t.Fatalf("retrying reconciliation: %#v", retrying.Reconciliation)
+	}
+
+	newVersion := *manifest.CurrentSpecVersion + 1
+	newDigest := "sha256:new-package"
+	manifest.CurrentSpecVersion = &newVersion
+	manifest.PackageDigest = &newDigest
+	manifest.Epochs = append(
+		manifest.Epochs,
+		NewEpoch(manifest, 3, "2026-08-14T12:01:00.000Z", nil),
+	)
+	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
+		t.Fatal(err)
+	}
+	running, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running.Reconciliation == nil || running.Reconciliation.State != ReconciliationPending {
+		t.Fatalf("current reconciliation: %#v", running.Reconciliation)
+	}
+	if running.Reconciliation.PackageDigest != newDigest {
+		t.Fatalf("current package: %#v", running.Reconciliation)
+	}
+}
+
+func TestSessionReconciliationUsesHighestEpochAfterHistoricalRepair(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	manifest, err := ReadManifest(store.manifestPath(session.SessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidencePath := *manifest.Specs[0].EvidencePath
+	events := "" +
+		`{"event":"epoch_finalized","data":{"spec_version":1,"epoch_id":2,"result":"completed","completion_reason":"verifier_conceded","verifier_conceded":true,"checkpoint_saved":true}}` + "\n" +
+		`{"event":"epoch_finalized","data":{"spec_version":1,"epoch_id":1,"result":"failed","error":"repaired late"}}` + "\n"
+	if err := os.WriteFile(evidencePath, []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Reconciliation == nil || current.Reconciliation.State != ReconciliationAccepted {
+		t.Fatalf("reconciliation: %#v", current.Reconciliation)
+	}
 }
 
 func TestSecondStopRepairsPersistedFinalizationOutbox(t *testing.T) {

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -69,16 +69,37 @@ func TestListRootWorkerSessionsReadsOnlyEligibleManifests(t *testing.T) {
 	write("sess_child", KindController, &parent, nil)
 	write("sess_task", KindTask, nil, nil)
 	write("sess_stopped", KindController, nil, &stopped)
+	write("sess_interrupted", KindController, nil, &stopped)
+	if _, err := MutateManifest(
+		filepath.Join(root, "sess_interrupted", "session.json"),
+		func(manifest *Manifest) error {
+			manifest.DesiredStatus = DesiredStatusRunning
+			return nil
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	sessions, err := store.ListRootWorkerSessions()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].SessionID != "sess_root" {
+	if len(sessions) != 2 {
 		t.Fatalf("root worker sessions: %#v", sessions)
 	}
-	if sessions[0].SessionDir == nil || *sessions[0].SessionDir != filepath.Join(root, "sess_root") {
-		t.Fatalf("session dir: %#v", sessions[0].SessionDir)
+	byID := map[string]Session{}
+	for _, session := range sessions {
+		byID[session.SessionID] = session
+	}
+	rootSession, ok := byID["sess_root"]
+	if !ok {
+		t.Fatalf("missing root session: %#v", sessions)
+	}
+	if _, ok := byID["sess_interrupted"]; !ok {
+		t.Fatalf("explicit running intent was lost: %#v", sessions)
+	}
+	if rootSession.SessionDir == nil || *rootSession.SessionDir != filepath.Join(root, "sess_root") {
+		t.Fatalf("session dir: %#v", rootSession.SessionDir)
 	}
 }
 
@@ -107,11 +128,8 @@ func TestStopBeforeWorkerEmitsBoundFinalizationExactlyOnce(t *testing.T) {
 	if epoch.PackageDigest == nil || *epoch.PackageDigest == "" || epoch.SpecSHA256 == "" {
 		t.Fatalf("missing bound package identity: %#v", epoch)
 	}
-	if epoch.FinalizationKey != session.SessionID+":epoch:00000001:finalized" {
-		t.Fatalf("finalization key: %q", epoch.FinalizationKey)
-	}
-	if !epoch.FinalizationEventEmitted {
-		t.Fatal("finalization marker was not persisted")
+	if !epochSupportsFinalization(epoch) {
+		t.Fatalf("finalization capability: %#v", epoch.WorkerCapabilities)
 	}
 
 	assertSingleStoppedFinalization(t, store, session.SessionID, epoch)
@@ -137,12 +155,12 @@ func TestStopOpenEpochPreservesBoundIdentity(t *testing.T) {
 		"version":     oldVersion,
 		"spec_sha256": "sha256:old-spec",
 	}}
-	epoch := Epoch{
-		ID:        1,
-		StartedAt: "2026-08-14T11:59:00.000Z",
-		Runner:    &Runner{PID: 999999},
-	}
-	BindEpochFinalizationIdentity(manifest, &epoch)
+	epoch := NewEpoch(
+		manifest,
+		1,
+		"2026-08-14T11:59:00.000Z",
+		&Runner{PID: 999999},
+	)
 	manifest.Epochs = append(manifest.Epochs, epoch)
 	newVersion := 2
 	newRevision := "revision-new"
@@ -160,14 +178,6 @@ func TestStopOpenEpochPreservesBoundIdentity(t *testing.T) {
 
 	if _, err := store.Stop(session.SessionID); err != nil {
 		t.Fatal(err)
-	}
-	stoppedManifest, err := ReadManifest(store.manifestPath(session.SessionID))
-	if err != nil {
-		t.Fatal(err)
-	}
-	stoppedEpoch := stoppedManifest.LastEpoch()
-	if stoppedEpoch == nil || !stoppedEpoch.FinalizationEventEmitted {
-		t.Fatalf("Stop returned before repairing the dead worker outbox: %#v", stoppedEpoch)
 	}
 	events, err := store.Events(session.SessionID)
 	if err != nil {
@@ -222,11 +232,11 @@ func TestStopLegacyOpenEpochEmitsSeparateCurrentStopIdentity(t *testing.T) {
 		t.Fatalf("epochs: got %d want 2", len(updated.Epochs))
 	}
 	legacy := updated.Epochs[0]
-	if legacy.Result == nil || *legacy.Result != "stopped" || legacy.FinalizationKey != "" {
+	if legacy.Result == nil || *legacy.Result != "stopped" || epochSupportsFinalization(&legacy) {
 		t.Fatalf("legacy epoch was rebound: %#v", legacy)
 	}
 	synthetic := updated.Epochs[1]
-	if synthetic.FinalizationKey == "" || !synthetic.FinalizationEventEmitted {
+	if !epochSupportsFinalization(&synthetic) {
 		t.Fatalf("synthetic stop was not finalized: %#v", synthetic)
 	}
 	events, err := store.Events(session.SessionID)
@@ -254,14 +264,9 @@ func TestStopIdleControllerAppendsEpochWithoutRewritingHistory(t *testing.T) {
 	}
 	completed := "completed"
 	finishedAt := "2026-08-14T11:58:00.000Z"
-	epoch := Epoch{
-		ID:                       1,
-		StartedAt:                "2026-08-14T11:57:00.000Z",
-		FinishedAt:               &finishedAt,
-		Result:                   &completed,
-		FinalizationEventEmitted: true,
-	}
-	BindEpochFinalizationIdentity(manifest, &epoch)
+	epoch := NewEpoch(manifest, 1, "2026-08-14T11:57:00.000Z", nil)
+	epoch.FinishedAt = &finishedAt
+	epoch.Result = &completed
 	manifest.Epochs = append(manifest.Epochs, epoch)
 	if err := WriteManifest(store.manifestPath(session.SessionID), manifest); err != nil {
 		t.Fatal(err)
@@ -304,8 +309,8 @@ func TestSecondStopRepairsPersistedFinalizationOutbox(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !epochFinalizationPending(pending.LastEpoch()) {
-		t.Fatalf("stop did not persist repairable outbox: %#v", pending.LastEpoch())
+	if !epochNeedsFinalization(pending.LastEpoch()) {
+		t.Fatalf("stop did not persist repairable terminal epoch: %#v", pending.LastEpoch())
 	}
 	evidencePath := filepath.Join(t.TempDir(), "evidence.jsonl")
 	pending.Specs[0].EvidencePath = &evidencePath
@@ -346,7 +351,7 @@ func assertSingleStoppedFinalization(
 		t.Fatalf("epoch_finalized events: got %d want 1", len(finalized))
 	}
 	data := finalized[0].Data
-	if data["finalization_key"] != epoch.FinalizationKey || data["result"] != "stopped" {
+	if data["finalization_key"] != epochFinalizationKey(sessionID, epoch.ID) || data["result"] != "stopped" {
 		t.Fatalf("unexpected stopped finalization: %#v", data)
 	}
 	if data["checkpoint_saved"] != false || data["verifier_conceded"] != false {

--- a/internal/sessionapi/types.go
+++ b/internal/sessionapi/types.go
@@ -190,14 +190,20 @@ type CurrentSpec struct {
 
 // --------- Session types ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-// SessionSummary is the minimal identification of a session.
-type SessionSummary struct {
-	SessionID       string        `json:"session_id"`
-	SessionKind     *SessionKind  `json:"-"`
-	ParentSessionID *string       `json:"parent_session_id,omitempty"`
-	SpecName        *string       `json:"spec_name,omitempty"`
-	Status          SessionStatus `json:"status"`
-	CreatedAt       *string       `json:"created_at,omitempty"`
+type ReconciliationState string
+
+const (
+	ReconciliationPending  ReconciliationState = "pending"
+	ReconciliationAccepted ReconciliationState = "accepted"
+	ReconciliationFailed   ReconciliationState = "failed"
+)
+
+// SessionReconciliation projects the latest durable outcome for the current
+// desired spec generation.
+type SessionReconciliation struct {
+	PackageDigest string              `json:"package_digest,omitempty"`
+	State         ReconciliationState `json:"state"`
+	Error         string              `json:"error,omitempty"`
 }
 
 // Session is the full API representation returned by get/create/stop.
@@ -209,38 +215,39 @@ type Session struct {
 	Status          SessionStatus `json:"status"`
 	CreatedAt       *string       `json:"created_at,omitempty"`
 
-	Runtime                 SessionRuntime   `json:"runtime"`
-	Launcher                *string          `json:"launcher,omitempty"`
-	SessionSpecPath         *string          `json:"session_spec_path,omitempty"`
-	SessionDir              *string          `json:"session_dir,omitempty"`
-	ActiveWorkspacePath     *string          `json:"active_workspace_path,omitempty"`
-	ActiveWorkspaceExists   *bool            `json:"active_workspace_exists,omitempty"`
-	Config                  map[string]any   `json:"config"`
-	Workspace               *Workspace       `json:"workspace,omitempty"`
-	Provenance              map[string]any   `json:"provenance"`
-	Specs                   []SessionSpec    `json:"specs"`
-	Epochs                  []map[string]any `json:"epochs"`
-	CurrentEpoch            *int             `json:"current_epoch,omitempty"`
-	CurrentSpec             *CurrentSpec     `json:"current_spec,omitempty"`
-	CurrentRound            *int             `json:"current_round,omitempty"`
-	CurrentRole             *string          `json:"current_role,omitempty"`
-	FinishedAt              *string          `json:"finished_at,omitempty"`
-	Result                  *string          `json:"result,omitempty"`
-	Error                   *string          `json:"error,omitempty"`
-	TotalCostUSD            *float64         `json:"total_cost_usd,omitempty"`
-	TotalInputTokens        *int             `json:"total_input_tokens,omitempty"`
-	TotalOutputTokens       *int             `json:"total_output_tokens,omitempty"`
-	TotalCacheReadTokens    *int             `json:"total_cache_read_tokens,omitempty"`
-	TotalCacheCreateTokens  *int             `json:"total_cache_creation_tokens,omitempty"`
-	RoundCount              *int             `json:"round_count,omitempty"`
-	CompletionReason        *string          `json:"completion_reason,omitempty"`
-	VerifierConceded        *bool            `json:"verifier_conceded,omitempty"`
-	ServiceURL              *string          `json:"service_url,omitempty"`
-	DashboardURL            *string          `json:"dashboard_url,omitempty"`
-	DashboardDoc            *string          `json:"dashboard_doc,omitempty"`
-	CurrentSpecVersion      *int             `json:"current_spec_version,omitempty"`
-	SpecVersions            []map[string]any `json:"spec_versions"`
-	LatestDescendantSession *SessionSummary  `json:"latest_descendant_session,omitempty"`
+	Runtime                SessionRuntime   `json:"runtime"`
+	Launcher               *string          `json:"launcher,omitempty"`
+	SessionSpecPath        *string          `json:"session_spec_path,omitempty"`
+	SessionDir             *string          `json:"session_dir,omitempty"`
+	ActiveWorkspacePath    *string          `json:"active_workspace_path,omitempty"`
+	ActiveWorkspaceExists  *bool            `json:"active_workspace_exists,omitempty"`
+	Config                 map[string]any   `json:"config"`
+	Workspace              *Workspace       `json:"workspace,omitempty"`
+	Provenance             map[string]any   `json:"provenance"`
+	Specs                  []SessionSpec    `json:"specs"`
+	Epochs                 []map[string]any `json:"epochs"`
+	CurrentEpoch           *int             `json:"current_epoch,omitempty"`
+	CurrentSpec            *CurrentSpec     `json:"current_spec,omitempty"`
+	CurrentRound           *int             `json:"current_round,omitempty"`
+	CurrentRole            *string          `json:"current_role,omitempty"`
+	FinishedAt             *string          `json:"finished_at,omitempty"`
+	Result                 *string          `json:"result,omitempty"`
+	Error                  *string          `json:"error,omitempty"`
+	TotalCostUSD           *float64         `json:"total_cost_usd,omitempty"`
+	TotalInputTokens       *int             `json:"total_input_tokens,omitempty"`
+	TotalOutputTokens      *int             `json:"total_output_tokens,omitempty"`
+	TotalCacheReadTokens   *int             `json:"total_cache_read_tokens,omitempty"`
+	TotalCacheCreateTokens *int             `json:"total_cache_creation_tokens,omitempty"`
+	RoundCount             *int             `json:"round_count,omitempty"`
+	CompletionReason       *string          `json:"completion_reason,omitempty"`
+	VerifierConceded       *bool            `json:"verifier_conceded,omitempty"`
+	ServiceURL             *string          `json:"service_url,omitempty"`
+	DashboardURL           *string          `json:"dashboard_url,omitempty"`
+	DashboardDoc           *string          `json:"dashboard_doc,omitempty"`
+	CurrentSpecVersion     *int             `json:"current_spec_version,omitempty"`
+	SpecVersions           []map[string]any `json:"spec_versions"`
+
+	Reconciliation *SessionReconciliation `json:"reconciliation,omitempty"`
 }
 
 // --------- Response types ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -262,6 +269,8 @@ type SessionListItem struct {
 	DashboardURL       *string        `json:"dashboard_url,omitempty"`
 	DashboardDoc       *string        `json:"dashboard_doc,omitempty"`
 	CurrentSpecVersion *int           `json:"current_spec_version,omitempty"`
+
+	Reconciliation *SessionReconciliation `json:"reconciliation,omitempty"`
 }
 
 // SessionListResponse wraps GET /api/sessions.
@@ -296,6 +305,7 @@ func SessionListItemFromSession(session Session) SessionListItem {
 		DashboardURL:       session.DashboardURL,
 		DashboardDoc:       session.DashboardDoc,
 		CurrentSpecVersion: session.CurrentSpecVersion,
+		Reconciliation:     session.Reconciliation,
 	}
 }
 
@@ -317,6 +327,7 @@ func (item SessionListItem) AsSession() Session {
 		DashboardURL:       item.DashboardURL,
 		DashboardDoc:       item.DashboardDoc,
 		CurrentSpecVersion: item.CurrentSpecVersion,
+		Reconciliation:     item.Reconciliation,
 	}
 }
 

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -411,12 +411,12 @@ func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid 
 		if logPath != "" {
 			runner.LogPath = logPath
 		}
-		epoch := sessionapi.Epoch{
-			ID:        epochID,
-			StartedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-			Runner:    &runner,
-		}
-		sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+		epoch := sessionapi.NewEpoch(
+			manifest,
+			epochID,
+			time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+			&runner,
+		)
 		m.Epochs = append(m.Epochs, epoch)
 		return nil
 	})

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -127,9 +127,6 @@ func TestStartEpochBindsProvidedRevisionIdentity(t *testing.T) {
 	if epoch.SpecSHA256 != "sha256:old-spec" {
 		t.Fatalf("spec sha: %q", epoch.SpecSHA256)
 	}
-	if epoch.FinalizationKey != "sess-controller:epoch:00000001:finalized" {
-		t.Fatalf("finalization key: %q", epoch.FinalizationKey)
-	}
 	if len(epoch.WorkerCapabilities) != 1 || epoch.WorkerCapabilities[0] != sessionapi.CapabilityEpochFinalizedEventsV1 {
 		t.Fatalf("worker capabilities: %#v", epoch.WorkerCapabilities)
 	}
@@ -138,19 +135,16 @@ func TestStartEpochBindsProvidedRevisionIdentity(t *testing.T) {
 func TestStartEpochDoesNotAppendAfterSessionStops(t *testing.T) {
 	sessionDir := t.TempDir()
 	manifest := &sessionapi.Manifest{
-		SessionID:   "sess-stopped",
-		SessionKind: sessionapi.KindController,
-		SpecName:    "controller",
+		SessionID:     "sess-stopped",
+		SessionKind:   sessionapi.KindController,
+		DesiredStatus: sessionapi.DesiredStatusStopped,
+		SpecName:      "controller",
 	}
 	stopped := "stopped"
 	finishedAt := "2026-08-14T12:00:00.000Z"
-	epoch := sessionapi.Epoch{
-		ID:         1,
-		StartedAt:  finishedAt,
-		FinishedAt: &finishedAt,
-		Result:     &stopped,
-	}
-	sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+	epoch := sessionapi.NewEpoch(manifest, 1, finishedAt, nil)
+	epoch.FinishedAt = &finishedAt
+	epoch.Result = &stopped
 	manifest.Epochs = append(manifest.Epochs, epoch)
 	if err := sessionapi.WriteManifest(manifestPath(sessionDir), manifest); err != nil {
 		t.Fatal(err)

--- a/internal/telosd/controller_reconciler.go
+++ b/internal/telosd/controller_reconciler.go
@@ -221,6 +221,11 @@ func (s *controllerReconciler) Stop(id string) (*sessionapi.Session, error) {
 			return nil, fmt.Errorf("stop session %s worker: %w", session.SessionID, err)
 		}
 	}
+	if session.SessionDir != nil && *session.SessionDir != "" {
+		if _, err := sessionapi.EmitPendingEpochFinalization(*session.SessionDir); err != nil {
+			return nil, fmt.Errorf("record session %s stop finalization: %w", session.SessionID, err)
+		}
+	}
 	return s.FileStore.Get(id)
 }
 

--- a/internal/telosd/controller_reconciler.go
+++ b/internal/telosd/controller_reconciler.go
@@ -167,35 +167,13 @@ func (s *controllerReconciler) apply(session *sessionapi.Session, wakeReason str
 }
 
 func (s *controllerReconciler) ensureRootWorkers(wakeReason string) error {
-	sessions, err := s.FileStore.ListRootWorkerSessions()
-	if err != nil {
-		return err
-	}
+	sessions, listErr := s.FileStore.ListRootWorkerSessions()
 	var errs []error
+	if listErr != nil {
+		errs = append(errs, listErr)
+	}
 	for i := range sessions {
 		session := &sessions[i]
-		if session.ParentSessionID != nil {
-			continue
-		}
-		if session.SessionKind == nil || *session.SessionKind != sessionapi.KindController {
-			continue
-		}
-		if session.Result != nil && *session.Result == "stopped" {
-			if session.SessionDir == nil || *session.SessionDir == "" {
-				continue
-			}
-			if _, err := sessionapi.RepairFinalizedEpochEvents(*session.SessionDir); err != nil {
-				errs = append(
-					errs,
-					fmt.Errorf(
-						"repair session %s finalization: %w",
-						session.SessionID,
-						err,
-					),
-				)
-			}
-			continue
-		}
 		if err := s.apply(session, wakeReason); err != nil {
 			errs = append(errs, err)
 		}
@@ -234,7 +212,7 @@ func startWakeReason(session *sessionapi.Session) string {
 }
 
 func (s *controllerReconciler) Stop(id string) (*sessionapi.Session, error) {
-	session, err := s.FileStore.Get(id)
+	session, err := s.FileStore.Stop(id)
 	if err != nil {
 		return nil, err
 	}
@@ -243,21 +221,7 @@ func (s *controllerReconciler) Stop(id string) (*sessionapi.Session, error) {
 			return nil, fmt.Errorf("stop session %s worker: %w", session.SessionID, err)
 		}
 	}
-	session, err = s.FileStore.Stop(id)
-	if err != nil {
-		return nil, err
-	}
-	if session.SessionDir != nil && *session.SessionDir != "" {
-		if _, err := sessionapi.RepairFinalizedEpochEvents(*session.SessionDir); err != nil {
-			return nil, fmt.Errorf(
-				"record session %s stop finalization: %w",
-				session.SessionID,
-				err,
-			)
-		}
-		return s.FileStore.Get(id)
-	}
-	return session, nil
+	return s.FileStore.Get(id)
 }
 
 func (s *controllerReconciler) applyCreateDefaults(req sessionapi.SessionCreateRequest) sessionapi.SessionCreateRequest {

--- a/internal/telosd/controller_reconciler_test.go
+++ b/internal/telosd/controller_reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -130,23 +131,20 @@ func TestRootWorkerReconciliationRepairsFinalizationOutboxAfterWorkerExit(t *tes
 	_, err = sessionapi.MutateManifest(
 		filepath.Join(*session.SessionDir, "session.json"),
 		func(manifest *sessionapi.Manifest) error {
-			manifest.Epochs = append(manifest.Epochs, sessionapi.Epoch{
-				ID:                 1,
-				StartedAt:          "2026-08-14T11:59:00.000Z",
-				FinishedAt:         &finishedAt,
-				Result:             &completed,
-				SpecName:           manifest.SpecName,
-				SpecVersion:        manifest.CurrentSpecVersion,
-				Revision:           manifest.CurrentRevision,
-				PackageDigest:      manifest.PackageDigest,
-				SpecSHA256:         "sha256:bound-spec",
-				CompletionReason:   &completionReason,
-				VerifierConceded:   &conceded,
-				CheckpointSaved:    &checkpointSaved,
-				RoundCount:         &rounds,
-				FinalizationKey:    session.SessionID + ":epoch:00000001:finalized",
-				WorkerCapabilities: []string{sessionapi.CapabilityEpochFinalizedEventsV1},
-			})
+			epoch := sessionapi.NewEpoch(
+				manifest,
+				1,
+				"2026-08-14T11:59:00.000Z",
+				nil,
+			)
+			epoch.FinishedAt = &finishedAt
+			epoch.Result = &completed
+			epoch.SpecSHA256 = "sha256:bound-spec"
+			epoch.CompletionReason = &completionReason
+			epoch.VerifierConceded = &conceded
+			epoch.CheckpointSaved = &checkpointSaved
+			epoch.RoundCount = &rounds
+			manifest.Epochs = append(manifest.Epochs, epoch)
 			return nil
 		},
 	)
@@ -161,6 +159,7 @@ func TestRootWorkerReconciliationRepairsFinalizationOutboxAfterWorkerExit(t *tes
 	if err := store.ensureRootWorkers("worker_supervision"); err != nil {
 		t.Fatal(err)
 	}
+	assertFinalizationEvidence(t, *session.SessionDir)
 	events, err := base.Events(session.SessionID)
 	if err != nil {
 		t.Fatal(err)
@@ -174,16 +173,9 @@ func TestRootWorkerReconciliationRepairsFinalizationOutboxAfterWorkerExit(t *tes
 	if finalized != 1 {
 		t.Fatalf("epoch_finalized events: got %d want 1", finalized)
 	}
-	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !manifest.LastEpoch().FinalizationEventEmitted {
-		t.Fatal("finalization outbox marker was not persisted")
-	}
 }
 
-func TestRootWorkerReconciliationRepairsStoppedSessionWithoutRestart(t *testing.T) {
+func TestRootWorkerReconciliationRepairsAndSkipsStoppedSession(t *testing.T) {
 	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
 	substrate := &recordingSubstrate{}
 	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
@@ -198,17 +190,14 @@ func TestRootWorkerReconciliationRepairsStoppedSessionWithoutRestart(t *testing.
 	_, err = sessionapi.MutateManifest(
 		filepath.Join(*session.SessionDir, "session.json"),
 		func(manifest *sessionapi.Manifest) error {
+			manifest.DesiredStatus = sessionapi.DesiredStatusStopped
 			finishedAt := "2026-08-14T12:00:00.000Z"
 			stopped := "stopped"
 			stoppedErr := "stopped by operator"
-			epoch := sessionapi.Epoch{
-				ID:         1,
-				StartedAt:  "2026-08-14T11:59:00.000Z",
-				FinishedAt: &finishedAt,
-				Result:     &stopped,
-				Error:      &stoppedErr,
-			}
-			sessionapi.BindEpochFinalizationIdentity(manifest, &epoch)
+			epoch := sessionapi.NewEpoch(manifest, 1, "2026-08-14T11:59:00.000Z", nil)
+			epoch.FinishedAt = &finishedAt
+			epoch.Result = &stopped
+			epoch.Error = &stoppedErr
 			manifest.Epochs = append(manifest.Epochs, epoch)
 			return nil
 		},
@@ -224,13 +213,7 @@ func TestRootWorkerReconciliationRepairsStoppedSessionWithoutRestart(t *testing.
 	if len(substrate.applies) != 0 {
 		t.Fatalf("stopped finalization repair restarted worker: %#v", substrate.applies)
 	}
-	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !manifest.LastEpoch().FinalizationEventEmitted {
-		t.Fatal("stopped finalization outbox marker was not persisted")
-	}
+	assertFinalizationEvidence(t, *session.SessionDir)
 	events, err := base.Events(session.SessionID)
 	if err != nil {
 		t.Fatal(err)
@@ -457,7 +440,7 @@ func TestControllerReconcilerRemovesSessionWhenWorkerApplyFails(t *testing.T) {
 	}
 }
 
-func TestControllerReconcilerLeavesFileStateRunningWhenWorkerStopFails(t *testing.T) {
+func TestControllerReconcilerPersistsStopIntentWhenWorkerStopFails(t *testing.T) {
 	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
 	substrate := &recordingSubstrate{stopErr: errors.New("worker stop failed")}
 	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
@@ -475,8 +458,68 @@ func TestControllerReconcilerLeavesFileStateRunningWhenWorkerStopFails(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if current.Status == sessionapi.StatusStopped {
-		t.Fatal("file state was marked stopped despite substrate stop failure")
+	if current.Status != sessionapi.StatusStopped {
+		t.Fatalf("status: got %s want %s", current.Status, sessionapi.StatusStopped)
+	}
+	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.DesiredStatus != sessionapi.DesiredStatusStopped {
+		t.Fatalf("desired status: got %q want stopped", manifest.DesiredStatus)
+	}
+}
+
+func TestStoppedFailedControllerIsNotResupervised(t *testing.T) {
+	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
+	substrate := &recordingSubstrate{}
+	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
+	markdown := "---\nversion: 0.1.0\nname: postgres\nplatform: cloud\n---\n# Postgres\n"
+
+	session, err := store.Create(sessionapi.SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed := "failed"
+	finishedAt := "2026-08-14T12:00:00.000Z"
+	_, err = sessionapi.MutateManifest(
+		filepath.Join(*session.SessionDir, "session.json"),
+		func(manifest *sessionapi.Manifest) error {
+			epoch := sessionapi.NewEpoch(manifest, 1, "2026-08-14T11:59:00.000Z", nil)
+			epoch.FinishedAt = &finishedAt
+			epoch.Result = &failed
+			manifest.Epochs = append(manifest.Epochs, epoch)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	substrate.applies = nil
+	if err := store.ensureRootWorkers("worker_supervision"); err != nil {
+		t.Fatal(err)
+	}
+	if len(substrate.applies) != 0 {
+		t.Fatalf("stopped failed controller was relaunched: %#v", substrate.applies)
+	}
+}
+
+func assertFinalizationEvidence(t *testing.T, sessionDir string) {
+	t.Helper()
+	manifest, err := sessionapi.ReadManifest(filepath.Join(sessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := os.ReadFile(*manifest.Specs[0].EvidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(evidence), `"event":"epoch_finalized"`) {
+		t.Fatalf("finalization was not repaired: %s", evidence)
 	}
 }
 

--- a/internal/telosd/controller_reconciler_test.go
+++ b/internal/telosd/controller_reconciler_test.go
@@ -20,6 +20,7 @@ type recordingSubstrate struct {
 	applyErr error
 	wakeErr  error
 	stopErr  error
+	stopHook func() error
 }
 
 type recordedApply struct {
@@ -64,10 +65,58 @@ func (s *recordingSubstrate) Wake(session *sessionapi.Session, wakeReason string
 
 func (s *recordingSubstrate) Stop(session *sessionapi.Session) error {
 	s.stops = append(s.stops, session.SessionID)
+	if s.stopHook != nil {
+		return s.stopHook()
+	}
 	if s.stopErr != nil {
 		return s.stopErr
 	}
 	return nil
+}
+
+func TestControllerStopRepairsAfterWorkerReleasesOwnership(t *testing.T) {
+	base := sessionapi.NewFileStore(t.TempDir(), sessionapi.RuntimeCloud)
+	substrate := &recordingSubstrate{}
+	store := newControllerReconciler(base, substrate, nil, cloudControllerDefaults())
+	markdown := "---\nversion: 0.1.0\nname: postgres\nplatform: cloud\n---\n# Postgres\n"
+	session, err := store.Create(sessionapi.SessionCreateRequest{SpecMarkdown: &markdown})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, err := sessionworker.AcquireOwnership(
+		*session.SessionDir,
+		filepath.Join(*session.SessionDir, "runner.log"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = owner.Release() })
+	substrate.stopHook = owner.Release
+	manifest, err := sessionapi.ReadManifest(filepath.Join(*session.SessionDir, "session.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = sessionapi.MutateManifest(
+		filepath.Join(*session.SessionDir, "session.json"),
+		func(current *sessionapi.Manifest) error {
+			epoch := sessionapi.NewEpoch(
+				manifest,
+				1,
+				"2026-08-14T12:00:00.000Z",
+				manifest.Runner,
+			)
+			current.Epochs = append(current.Epochs, epoch)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Stop(session.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	assertFinalizationEvidence(t, *session.SessionDir)
 }
 
 func TestControllerReconcilerAppliesAndStopsWorkers(t *testing.T) {


### PR DESCRIPTION
## Summary

- make durable `epoch_finalized` evidence the source of truth for runtime reconciliation outcomes
- expose one minimal reconciliation projection on existing session detail and list responses
- derive generation matching inside `telosd`, so Cloud does not duplicate epoch, verifier, checkpoint, revision, or stale-event semantics
- repair every missing terminal finalization after worker ownership is released, including historical crash gaps and controller stops
- remove the unused `SessionSummary.latest_descendant_session` surface

## Contract

```json
{
  "reconciliation": {
    "package_digest": "sha256:...",
    "state": "pending | accepted | failed",
    "error": "optional failure reason"
  }
}
```

The projection is always for the session's current desired spec generation:

- `pending`: no durable terminal outcome exists for the current generation, or a newer same-generation epoch is running
- `accepted`: the latest durable current-generation epoch completed because the verifier conceded and its checkpoint was saved
- `failed`: the latest durable current-generation epoch terminated without acceptance

Spec versions and epoch IDs remain internal. They prevent stale acceptance across changes and A → B → A rollbacks, but are not duplicated in the nested API surface. No new endpoint, cursor, acknowledgment row, reconciliation ID, or background processor is added.

Finalization repair reads existing evidence once, appends only missing deterministic keys, and preserves the highest epoch outcome even when an older crash gap is repaired later.

The Cloud consumer is [cloud#236](https://github.com/telos-org/cloud/pull/236).

## Delta against `master`

- 13 existing files changed; no new files
- production: +380 / -370 lines (net +10)
- tests: +344 / -134 lines
- total: +724 / -504 lines

## Verification

- `go vet ./...`
- `go test ./...`
