### PR TITLE
Expose Cloud readiness in the CLI

### DIFF
--- a/cmd/telos/delete.go
+++ b/cmd/telos/delete.go
@@ -93,7 +93,7 @@ func printCloudSessionDeleteReceipt(out io.Writer, session cloud.SessionRecord) 
 	}
 	printSummaryField(out, "Name", session.Name)
 	printSummaryField(out, "Target", "cloud")
-	printSummaryField(out, "Status", session.State)
+	printSummaryField(out, "Status", cloudSessionDisplayStatus(session))
 	printSummaryField(out, "Package", session.PackageRef)
 	printSummaryField(out, "Session", session.ID)
 }

--- a/cmd/telos/describe.go
+++ b/cmd/telos/describe.go
@@ -64,7 +64,7 @@ func getCloudSession(sessionID string) (*cloud.SessionRecord, error) {
 func printCloudSessionDescription(out io.Writer, session cloud.SessionRecord) {
 	printSummaryField(out, "Name", session.Name)
 	printSummaryField(out, "Target", "cloud")
-	printSummaryField(out, "Status", session.State)
+	printSummaryField(out, "Status", cloudSessionDisplayStatus(session))
 	printSummaryField(out, "Package", session.PackageRef)
 	printSummaryField(out, "Digest", session.PackageDigest)
 	printSummaryField(out, "Session", session.ID)
@@ -85,12 +85,23 @@ func printCloudSessionDescription(out io.Writer, session cloud.SessionRecord) {
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Lifecycle")
+	printDetailField(out, "state", session.State)
+	if session.StatusReason != "" {
+		printDetailField(out, "status reason", session.StatusReason)
+	}
 	printDetailField(out, "created", session.CreatedAt)
 	printDetailField(out, "updated", session.UpdatedAt)
 	if cloudSessionInProgress(session.State) {
 		fmt.Fprintln(out)
 		fmt.Fprintf(out, "Inspect   telos logs %s\n", session.ID)
 	}
+}
+
+func cloudSessionDisplayStatus(session cloud.SessionRecord) string {
+	if session.Status != "" {
+		return session.Status
+	}
+	return session.State
 }
 
 func cloudSessionInProgress(state string) bool {

--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -454,7 +454,7 @@ func printCloudSessionReceipt(out io.Writer, operation string, session *cloud.Se
 	fmt.Fprintf(out, "%s %s\n\n", operation, session.Name)
 	printSummaryField(out, "Name", session.Name)
 	printSummaryField(out, "Target", "cloud")
-	printSummaryField(out, "Status", session.State)
+	printSummaryField(out, "Status", cloudSessionDisplayStatus(*session))
 	printSummaryField(out, "Package", session.PackageRef)
 	printSummaryField(out, "Digest", session.PackageDigest)
 	printSummaryField(out, "Model", session.AgentModel)

--- a/cmd/telos/list.go
+++ b/cmd/telos/list.go
@@ -210,7 +210,7 @@ func listCloudSessions(jsonOut bool, limit int, wide bool) {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				session.Name,
 				"cloud",
-				session.State,
+				cloudSessionDisplayStatus(session),
 				session.PackageRef,
 				serviceURL,
 				dashboardURL,
@@ -221,7 +221,7 @@ func listCloudSessions(jsonOut bool, limit int, wide bool) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			session.Name,
 			"cloud",
-			session.State,
+			cloudSessionDisplayStatus(session),
 			serviceURL,
 			session.ID,
 		)

--- a/cmd/telos/list_test.go
+++ b/cmd/telos/list_test.go
@@ -82,6 +82,7 @@ func TestCmdListShowsCloudSessionsForConfiguredCloud(t *testing.T) {
 				"id":             "sess_123",
 				"name":           "auth",
 				"state":          "healthy",
+				"status":         "ready",
 				"package_ref":    "@telos/auth:1.0.0",
 				"package_digest": "sha256:abc",
 				"service_url":    "https://auth.example.com",
@@ -101,7 +102,7 @@ func TestCmdListShowsCloudSessionsForConfiguredCloud(t *testing.T) {
 		"NAME",
 		"PACKAGE",
 		"auth",
-		"healthy",
+		"ready",
 		"@telos/auth:1.0.0",
 		"sess_123",
 	} {
@@ -125,6 +126,8 @@ func TestCmdListJSONShowsCloudSessions(t *testing.T) {
 				"id":             "sess_123",
 				"name":           "auth",
 				"state":          "healthy",
+				"status":         "ready",
+				"status_reason":  "The agent finished and the verifier accepted the result.",
 				"package_ref":    "@telos/auth:1.0.0",
 				"package_digest": "sha256:abc",
 				"created_at":     "then",
@@ -150,7 +153,8 @@ func TestCmdListJSONShowsCloudSessions(t *testing.T) {
 		t.Fatalf("cloud list json sessions: %#v", body)
 	}
 	session, ok := sessions[0].(map[string]any)
-	if !ok || session["id"] != "sess_123" {
+	if !ok || session["id"] != "sess_123" || session["status"] != "ready" ||
+		session["status_reason"] != "The agent finished and the verifier accepted the result." {
 		t.Fatalf("cloud list json first session: %#v", sessions[0])
 	}
 }
@@ -163,6 +167,8 @@ func TestPrintCloudSessionDescriptionShowsProductSurfaces(t *testing.T) {
 		ID:             "sess_123",
 		Name:           "auth",
 		State:          "healthy",
+		Status:         "ready",
+		StatusReason:   "The agent finished and the verifier accepted the result.",
 		PackageRef:     "@telos/auth:1.0.0",
 		PackageDigest:  "sha256:abc",
 		RuntimeVersion: &runtime,
@@ -178,13 +184,15 @@ func TestPrintCloudSessionDescriptionShowsProductSurfaces(t *testing.T) {
 	for _, want := range []string{
 		"Name      auth",
 		"Target    cloud",
-		"Status    healthy",
+		"Status    ready",
 		"Package   @telos/auth:1.0.0",
 		"Session   sess_123",
 		"Service   https://auth.example.com",
 		"Dashboard https://dashboard.example.com",
 		"Runtime   0.1.0",
 		"Lifecycle",
+		"state          healthy",
+		"status reason  The agent finished and the verifier accepted the result.",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("cloud session description missing %q:\n%s", want, text)

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -56,6 +56,8 @@ type SessionRecord struct {
 	ID             string  `json:"id"`
 	Name           string  `json:"name"`
 	State          string  `json:"state"`
+	Status         string  `json:"status,omitempty"`
+	StatusReason   string  `json:"status_reason,omitempty"`
 	PackageRef     string  `json:"package_ref"`
 	PackageDigest  string  `json:"package_digest"`
 	RuntimeVersion *string `json:"runtime_version,omitempty"`

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -390,6 +390,7 @@ func TestClientListSessions(t *testing.T) {
 				"id":             "sess_123",
 				"name":           "auth",
 				"state":          "healthy",
+				"status":         "ready",
 				"package_ref":    "@telos/auth:1.2.3",
 				"package_digest": "sha256:abc",
 				"created_at":     "then",
@@ -404,7 +405,8 @@ func TestClientListSessions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSessions: %v", err)
 	}
-	if len(sessions) != 1 || sessions[0].ID != "sess_123" || sessions[0].Name != "auth" {
+	if len(sessions) != 1 || sessions[0].ID != "sess_123" ||
+		sessions[0].Name != "auth" || sessions[0].Status != "ready" {
 		t.Fatalf("sessions: got %+v", sessions)
 	}
 }
@@ -419,6 +421,8 @@ func TestClientGetSession(t *testing.T) {
 			"id":             "sess_123",
 			"name":           "auth",
 			"state":          "healthy",
+			"status":         "ready",
+			"status_reason":  "The agent finished and the verifier accepted the result.",
 			"package_ref":    "@telos/auth:1.2.3",
 			"package_digest": "sha256:abc",
 			"created_at":     "then",
@@ -432,7 +436,9 @@ func TestClientGetSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSession: %v", err)
 	}
-	if session.ID != "sess_123" || session.PackageRef != "@telos/auth:1.2.3" {
+	if session.ID != "sess_123" || session.PackageRef != "@telos/auth:1.2.3" ||
+		session.Status != "ready" ||
+		session.StatusReason != "The agent finished and the verifier accepted the result." {
 		t.Fatalf("session: got %+v", session)
 	}
 }

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -38,6 +38,12 @@ ready only after the runtime has reconciled the matching package digest and the
 verifier has accepted it. Do not interpret allocation success, an HTTP process
 starting, or stale events as goal acceptance.
 
+For an agent-readable acceptance check, require both fields:
+
+```bash
+telos describe SESSION_ID --json | jq -e '.status == "ready"'
+```
+
 To update an existing deployment, retrieve or edit its spec, bump the immutable
 package version, inspect the diff, and apply to the same session:
 


### PR DESCRIPTION
## Summary

- preserve Cloud `status` and `status_reason` in session records instead of dropping them
- show the product status in `telos list` and `telos describe`, while retaining lifecycle state as detail
- give coding agents an exact `.status == "ready"` acceptance check in the canonical skill

## Why

Cloud lifecycle can become `healthy` while telosd is still implementing or verifying. Agents need the first-class product status to distinguish a reachable service from verifier-accepted completion.

## Scope

Eight existing files, +43/-10. Two wire fields and one compatibility display helper; no new command, type hierarchy, service, or background mechanism.

## Verification

- `go test ./...`
- `go vet ./...`
- `bazel test //...`
- `bazel build //skills:telos_cli_bundle`
- focused Cloud/CLI tests
