### PR TITLE
feat(runtime): add checkpoint-safe snapshot coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ will help write the smallest verifiable `SPEC.md`, plan it, and choose a bounded
 Use `telos <command> --help` for the exact command surface of the installed
 release.
 
+## Managed Cloud snapshot safety
+
+A claimed Cloud runtime (`TELOS_SESSION_ID=sess_...`) advertises
+`checkpoint_safe_point` in the live `/api/healthz` `capabilities` list. The
+Cloud host can then call the authenticated, operator-only
+`POST /internal/checkpoint/prepare` and `POST /internal/checkpoint/resume`
+endpoints for that exact session claim.
+
+Prepare durably closes admission for session changes, bootstrap and worker
+supervision, and worker cycles before waiting for admitted work to finish.
+Every prepare and resume includes the same `operation_id`, so a late
+resume from an older snapshot cannot reopen work paused for a newer snapshot.
+A timeout or process restart leaves admission closed for that operation until
+its explicit, idempotent resume. Existing deployments gain this capability
+only when deliberately pinned to a runtime release that contains it.
+
+Checkpoint state uses durable files and fails closed if initialized state is
+missing, malformed, or replaced by a symbolic link. The runtime and other
+tools running as the same Unix user are still one trusted security boundary:
+these checks protect against corruption and accidental path replacement, not
+against a malicious program already running as that same user.
+
 ## Develop
 
 ```bash

--- a/internal/sessionapi/auth.go
+++ b/internal/sessionapi/auth.go
@@ -38,12 +38,13 @@ type Caller struct {
 type AccessAction string
 
 const (
-	ActionHealth            AccessAction = "health"
-	ActionCreateSession     AccessAction = "create_session"
-	ActionUpdateSessionSpec AccessAction = "update_session_spec"
-	ActionListSessions      AccessAction = "list_sessions"
-	ActionReadSession       AccessAction = "read_session"
-	ActionStopSession       AccessAction = "stop_session"
+	ActionHealth              AccessAction = "health"
+	ActionCreateSession       AccessAction = "create_session"
+	ActionUpdateSessionSpec   AccessAction = "update_session_spec"
+	ActionListSessions        AccessAction = "list_sessions"
+	ActionReadSession         AccessAction = "read_session"
+	ActionStopSession         AccessAction = "stop_session"
+	ActionCheckpointSafePoint AccessAction = "checkpoint_safe_point"
 )
 
 type AccessRequest struct {
@@ -171,6 +172,11 @@ func authorizeCaller(store *FileStore, caller Caller, req AccessRequest) error {
 		return requireSessionAccess(store, caller, req.SessionID, ScopeSessionsRead)
 	case ActionStopSession:
 		return requireSessionAccess(store, caller, req.SessionID, ScopeSessionsStop)
+	case ActionCheckpointSafePoint:
+		if caller.Role != RoleOperator {
+			return authError{status: http.StatusForbidden, detail: "operator access required"}
+		}
+		return nil
 	default:
 		return authError{status: http.StatusForbidden, detail: "unsupported session API action"}
 	}

--- a/internal/sessionapi/types.go
+++ b/internal/sessionapi/types.go
@@ -145,7 +145,10 @@ type SessionSpecResponse struct {
 }
 
 // RuntimeIdentity identifies the live telosd process serving the API.
-const CapabilityEpochFinalizedEventsV1 = "epoch-finalized-events-v1"
+const (
+	CapabilityEpochFinalizedEventsV1 = "epoch-finalized-events-v1"
+	CapabilityCheckpointSafePoint    = "checkpoint_safe_point"
+)
 
 type RuntimeIdentity struct {
 	Version      string   `json:"runtime_version,omitempty"`

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -37,8 +37,10 @@ func (o *Ownership) Release() error {
 }
 
 type StartOptions struct {
-	Runtime    sessionapi.SessionRuntime
-	WakeReason string
+	Runtime             sessionapi.SessionRuntime
+	WakeReason          string
+	CheckpointRoot      string
+	CheckpointSessionID string
 }
 
 func Start(sessionDir string, runtime sessionapi.SessionRuntime) error {
@@ -89,10 +91,7 @@ func EnsureStartedWithOptions(sessionDir string, opts StartOptions) error {
 		if err != nil {
 			return fmt.Errorf("read active worker identity: %w", err)
 		}
-		if runnerSupportsCapability(
-			manifest.Runner,
-			sessionapi.CapabilityEpochFinalizedEventsV1,
-		) {
+		if runnerSupportsRequiredCapabilities(manifest.Runner, opts) {
 			return nil
 		}
 		if manifest.OpenEpoch() != nil {
@@ -193,16 +192,83 @@ func runnerSupportsCapability(runner *sessionapi.Runner, capability string) bool
 	return false
 }
 
+// ActiveWorkerSupportsCapabilities reports whether a currently running worker
+// advertises every required capability. An inactive session is ready because
+// its next worker will be launched with the current StartOptions.
+func ActiveWorkerSupportsCapabilities(sessionDir string, capabilities ...string) (bool, error) {
+	alive, err := workerAlive(sessionDir)
+	if err != nil {
+		return false, err
+	}
+	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		return false, fmt.Errorf("read active worker identity: %w", err)
+	}
+	if !alive {
+		pid, recorded := manifest.Runner.ProcessID()
+		if !recorded {
+			return true, nil
+		}
+		stillRunning, err := processStillRunning(pid)
+		if err != nil {
+			return false, fmt.Errorf("inspect worker cleanup process %d: %w", pid, err)
+		}
+		// A legacy worker releases its runner lock just before clearing its
+		// manifest record. Keep preparation closed across that cleanup gap.
+		return !stillRunning, nil
+	}
+	for _, capability := range capabilities {
+		if !runnerSupportsCapability(manifest.Runner, capability) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func processStillRunning(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil || errors.Is(err, syscall.EPERM) {
+		return true, nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	return false, err
+}
+
+func runnerSupportsRequiredCapabilities(runner *sessionapi.Runner, opts StartOptions) bool {
+	if !runnerSupportsCapability(runner, sessionapi.CapabilityEpochFinalizedEventsV1) {
+		return false
+	}
+	if checkpointAdmissionConfigured(opts.CheckpointRoot, opts.CheckpointSessionID) {
+		return runnerSupportsCapability(runner, sessionapi.CapabilityCheckpointSafePoint)
+	}
+	return true
+}
+
+func checkpointAdmissionConfigured(root, sessionID string) bool {
+	return strings.TrimSpace(root) != "" && strings.TrimSpace(sessionID) != ""
+}
+
 func Env(sessionDir string, opts StartOptions) []string {
 	runtime := opts.Runtime
 	if runtime == "" {
 		runtime = sessionapi.RuntimeLocal
 	}
-	env := append(os.Environ(),
+	env := append(withoutCheckpointEnvironment(os.Environ()),
 		"TELOS_RUNTIME="+string(runtime),
 		"TELOS_SESSION_DIR="+filepath.Dir(sessionDir),
 		"TELOS_SESSION_ID="+filepath.Base(sessionDir),
 	)
+	if checkpointAdmissionConfigured(opts.CheckpointRoot, opts.CheckpointSessionID) {
+		env = append(env,
+			"TELOS_CHECKPOINT_ROOT="+opts.CheckpointRoot,
+			"TELOS_CHECKPOINT_SESSION_ID="+opts.CheckpointSessionID,
+		)
+	}
 	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
 	if err == nil {
 		if manifest.ParentSessionID != nil {
@@ -219,6 +285,18 @@ func Env(sessionDir string, opts StartOptions) []string {
 		)
 	}
 	return env
+}
+
+func withoutCheckpointEnvironment(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "TELOS_CHECKPOINT_ROOT=") ||
+			strings.HasPrefix(entry, "TELOS_CHECKPOINT_SESSION_ID=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 func Stop(sessionDir string) error {
@@ -427,14 +505,19 @@ func StartEpochWithRunner(sessionDir string, manifest *sessionapi.Manifest, pid 
 }
 
 func RunnerIdentity(pid int) sessionapi.Runner {
+	capabilities := []string{sessionapi.CapabilityEpochFinalizedEventsV1}
+	if checkpointAdmissionConfigured(
+		os.Getenv("TELOS_CHECKPOINT_ROOT"),
+		os.Getenv("TELOS_CHECKPOINT_SESSION_ID"),
+	) {
+		capabilities = append(capabilities, sessionapi.CapabilityCheckpointSafePoint)
+	}
 	return sessionapi.Runner{
-		Kind:      "local-subprocess",
-		PID:       pid,
-		PGID:      pid,
-		StartedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-		WorkerCapabilities: []string{
-			sessionapi.CapabilityEpochFinalizedEventsV1,
-		},
+		Kind:               "local-subprocess",
+		PID:                pid,
+		PGID:               pid,
+		StartedAt:          time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		WorkerCapabilities: capabilities,
 	}
 }
 

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -4,10 +4,39 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/telos-org/telos/internal/sessionapi"
 )
+
+func TestEnvPropagatesCheckpointAdmissionScope(t *testing.T) {
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "/stale-root")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "sess_stale")
+	sessionDir := t.TempDir()
+	env := Env(sessionDir, StartOptions{
+		Runtime:             sessionapi.RuntimeCloud,
+		CheckpointRoot:      "/telos-state",
+		CheckpointSessionID: "sess_deployment_123",
+	})
+	joined := strings.Join(env, "\n")
+	for _, want := range []string{
+		"TELOS_CHECKPOINT_ROOT=/telos-state",
+		"TELOS_CHECKPOINT_SESSION_ID=sess_deployment_123",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("worker environment missing %q", want)
+		}
+	}
+	if strings.Contains(joined, "/stale-root") || strings.Contains(joined, "sess_stale") {
+		t.Fatalf("worker environment retained stale checkpoint scope:\n%s", joined)
+	}
+
+	disabled := strings.Join(Env(sessionDir, StartOptions{Runtime: sessionapi.RuntimeCloud}), "\n")
+	if strings.Contains(disabled, "TELOS_CHECKPOINT_") {
+		t.Fatalf("worker environment retained checkpoint admission while disabled:\n%s", disabled)
+	}
+}
 
 func TestAcquireOwnershipIsExclusiveAndRecordsTopLevelRunner(t *testing.T) {
 	sessionDir := t.TempDir()
@@ -35,6 +64,63 @@ func TestAcquireOwnershipIsExclusiveAndRecordsTopLevelRunner(t *testing.T) {
 	}
 	if manifest.Runner == nil || manifest.Runner.PID != os.Getpid() {
 		t.Fatalf("top-level runner not recorded: %#v", manifest.Runner)
+	}
+}
+
+func TestActiveWorkerCapabilityReadiness(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &sessionapi.Manifest{
+		SessionID:   filepath.Base(sessionDir),
+		SessionKind: sessionapi.KindController,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "")
+	legacyOwner, err := AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ready, err := ActiveWorkerSupportsCapabilities(
+		sessionDir,
+		sessionapi.CapabilityCheckpointSafePoint,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ready {
+		t.Fatal("active legacy worker was accepted as checkpoint-aware")
+	}
+	if err := legacyOwner.Release(); err != nil {
+		t.Fatal(err)
+	}
+	ready, err = ActiveWorkerSupportsCapabilities(
+		sessionDir,
+		sessionapi.CapabilityCheckpointSafePoint,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ready {
+		t.Fatal("worker cleanup gap was accepted before its runner record was cleared")
+	}
+
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "/telos-state")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "sess_deployment_123")
+	checkpointOwner, err := AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer checkpointOwner.Release()
+	ready, err = ActiveWorkerSupportsCapabilities(
+		sessionDir,
+		sessionapi.CapabilityCheckpointSafePoint,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ready {
+		t.Fatal("active checkpoint-aware worker was rejected")
 	}
 }
 
@@ -76,6 +162,8 @@ func TestStartEpochWithRunnerPreservesOpenEpochRunner(t *testing.T) {
 }
 
 func TestStartEpochBindsProvidedRevisionIdentity(t *testing.T) {
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "")
 	sessionDir := t.TempDir()
 	oldVersion := 1
 	oldRevision := "0.1.0"
@@ -163,9 +251,41 @@ func TestStartEpochDoesNotAppendAfterSessionStops(t *testing.T) {
 }
 
 func TestRunnerIdentityAdvertisesFinalizationCapability(t *testing.T) {
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "")
 	runner := RunnerIdentity(42)
 	if !runnerSupportsCapability(&runner, sessionapi.CapabilityEpochFinalizedEventsV1) {
 		t.Fatalf("runner capabilities: %#v", runner.WorkerCapabilities)
+	}
+	if runnerSupportsCapability(&runner, sessionapi.CapabilityCheckpointSafePoint) {
+		t.Fatalf("unscoped worker advertised checkpoint participation: %#v", runner.WorkerCapabilities)
+	}
+}
+
+func TestRunnerIdentityAdvertisesCheckpointCapabilityOnlyWithCompleteScope(t *testing.T) {
+	t.Setenv("TELOS_CHECKPOINT_ROOT", "/telos-state")
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "")
+	partial := RunnerIdentity(42)
+	if runnerSupportsCapability(&partial, sessionapi.CapabilityCheckpointSafePoint) {
+		t.Fatalf("partially scoped worker advertised checkpoint participation: %#v", partial.WorkerCapabilities)
+	}
+
+	t.Setenv("TELOS_CHECKPOINT_SESSION_ID", "sess_deployment_123")
+	claimed := RunnerIdentity(42)
+	if !runnerSupportsCapability(&claimed, sessionapi.CapabilityCheckpointSafePoint) {
+		t.Fatalf("scoped worker capabilities: %#v", claimed.WorkerCapabilities)
+	}
+	if !runnerSupportsRequiredCapabilities(&claimed, StartOptions{
+		CheckpointRoot:      "/telos-state",
+		CheckpointSessionID: "sess_deployment_123",
+	}) {
+		t.Fatalf("scoped worker did not meet rollout requirements: %#v", claimed.WorkerCapabilities)
+	}
+	if runnerSupportsRequiredCapabilities(&partial, StartOptions{
+		CheckpointRoot:      "/telos-state",
+		CheckpointSessionID: "sess_deployment_123",
+	}) {
+		t.Fatal("legacy worker was accepted for checkpoint-aware rollout")
 	}
 }
 

--- a/internal/telosd/BUILD.bazel
+++ b/internal/telosd/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "telosd",
     srcs = [
+        "checkpoint_safe_point.go",
         "config.go",
         "controller_reconciler.go",
         "local_process_worker.go",
@@ -29,6 +30,7 @@ go_library(
 go_test(
     name = "telosd_test",
     srcs = [
+        "checkpoint_safe_point_test.go",
         "config_test.go",
         "controller_reconciler_test.go",
         "package_materializer_test.go",

--- a/internal/telosd/checkpoint_safe_point.go
+++ b/internal/telosd/checkpoint_safe_point.go
@@ -1,0 +1,832 @@
+package telosd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/telos-org/telos/internal/sessionapi"
+	"github.com/telos-org/telos/internal/sessionworker"
+)
+
+const (
+	checkpointSafePointCapability  = sessionapi.CapabilityCheckpointSafePoint
+	checkpointStateVersion         = 2
+	checkpointInitializationMarker = ".checkpoint-safe-point.initialized"
+	checkpointMaxMetadataBytes     = 4096
+	checkpointPrepareTimeout       = 30 * time.Second
+	checkpointPollInterval         = 100 * time.Millisecond
+	checkpointRootEnv              = "TELOS_CHECKPOINT_ROOT"
+	checkpointSessionEnv           = "TELOS_CHECKPOINT_SESSION_ID"
+)
+
+var (
+	errCheckpointAdmissionClosed    = errors.New("checkpoint admission is closed")
+	errCheckpointWorkersNotReady    = errors.New("checkpoint workers are not ready")
+	errCheckpointOperationMismatch  = errors.New("checkpoint operation does not own admission")
+	errCheckpointOperationCompleted = errors.New("checkpoint operation already completed")
+	checkpointSessionIDRE           = regexp.MustCompile(`^sess_[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+	checkpointOperationIDRE         = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+)
+
+type checkpointState struct {
+	Version     int    `json:"version"`
+	SessionID   string `json:"session_id"`
+	OperationID string `json:"operation_id"`
+	Status      string `json:"status"`
+}
+
+type checkpointInitialization struct {
+	Version   int    `json:"version"`
+	SessionID string `json:"session_id"`
+}
+
+type checkpointSafePoint struct {
+	storageRoot    string
+	root           string
+	sessionID      string
+	prepareTimeout time.Duration
+	pollInterval   time.Duration
+	prepareCheck   func() error
+}
+
+// One lease represents one admitted API create/update or one complete worker
+// cycle. A worker cycle includes every agent turn and tool subprocess it starts.
+type checkpointLease struct {
+	path string
+	file *os.File
+}
+
+func newCheckpointSafePoint(root, sessionID string) (*checkpointSafePoint, error) {
+	root = strings.TrimSpace(root)
+	sessionID = strings.TrimSpace(sessionID)
+	if root == "" {
+		return nil, errors.New("checkpoint state root is required")
+	}
+	if !checkpointSessionIDRE.MatchString(sessionID) {
+		return nil, fmt.Errorf("invalid checkpoint session ID %q", sessionID)
+	}
+	manager := &checkpointSafePoint{
+		storageRoot:    filepath.Clean(root),
+		root:           filepath.Join(root, "checkpoint-safe-point"),
+		sessionID:      sessionID,
+		prepareTimeout: checkpointPrepareTimeout,
+		pollInterval:   checkpointPollInterval,
+	}
+	if err := requireDirectoryNoFollow(manager.storageRoot); err != nil {
+		return nil, fmt.Errorf("validate checkpoint storage root: %w", err)
+	}
+	markerExists, err := pathExistsNoFollow(manager.markerPath())
+	if err != nil {
+		return nil, fmt.Errorf("inspect checkpoint initialization marker: %w", err)
+	}
+	stateRootExists, err := pathExistsNoFollow(manager.root)
+	if err != nil {
+		return nil, fmt.Errorf("inspect checkpoint state root: %w", err)
+	}
+	switch {
+	case markerExists:
+		if !stateRootExists {
+			return nil, errors.New("checkpoint state root is missing after initialization")
+		}
+		err = manager.validatePersistedStorage()
+	case stateRootExists:
+		err = errors.New("checkpoint state exists without a durable initialization marker")
+	default:
+		err = manager.initializeStorage()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+func checkpointSafePointForConfig(cfg Config) (*checkpointSafePoint, error) {
+	if cfg.Mode != ModeCloud {
+		return nil, nil
+	}
+	sessionID := strings.TrimSpace(os.Getenv("TELOS_SESSION_ID"))
+	if sessionID == "" {
+		return nil, nil
+	}
+	safePoint, err := newCheckpointSafePoint(cfg.Root, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	safePoint.prepareCheck = func() error {
+		return checkpointWorkersReady(SessionsRoot(cfg.Root))
+	}
+	return safePoint, nil
+}
+
+func checkpointWorkersReady(sessionsRoot string) error {
+	entries, err := os.ReadDir(sessionsRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("list checkpoint workers: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ready, err := sessionworker.ActiveWorkerSupportsCapabilities(
+			filepath.Join(sessionsRoot, entry.Name()),
+			sessionapi.CapabilityCheckpointSafePoint,
+		)
+		if err != nil {
+			return fmt.Errorf("inspect checkpoint worker %s: %w", entry.Name(), err)
+		}
+		if !ready {
+			return fmt.Errorf("%w: %s", errCheckpointWorkersNotReady, entry.Name())
+		}
+	}
+	return nil
+}
+
+func checkpointSafePointForWorker() (*checkpointSafePoint, error) {
+	root := strings.TrimSpace(os.Getenv(checkpointRootEnv))
+	sessionID := strings.TrimSpace(os.Getenv(checkpointSessionEnv))
+	if root == "" && sessionID == "" {
+		return nil, nil
+	}
+	return newCheckpointSafePoint(root, sessionID)
+}
+
+func (s *checkpointSafePoint) statePath() string {
+	return filepath.Join(s.root, "state.json")
+}
+
+func (s *checkpointSafePoint) markerPath() string {
+	return filepath.Join(s.storageRoot, checkpointInitializationMarker)
+}
+
+func (s *checkpointSafePoint) lockPath() string {
+	return filepath.Join(s.root, "state.lock")
+}
+
+func (s *checkpointSafePoint) leasesDir() string {
+	return filepath.Join(s.root, "leases")
+}
+
+func (s *checkpointSafePoint) initializeStorage() error {
+	if err := os.Mkdir(s.root, 0o700); err != nil {
+		return fmt.Errorf("create checkpoint state root: %w", err)
+	}
+	if err := requireDirectoryNoFollow(s.root); err != nil {
+		return err
+	}
+	if err := os.Mkdir(s.leasesDir(), 0o700); err != nil {
+		return fmt.Errorf("create checkpoint leases: %w", err)
+	}
+	if err := requireDirectoryNoFollow(s.leasesDir()); err != nil {
+		return err
+	}
+	lock, err := openRegularFileNoFollow(s.lockPath(), os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("create checkpoint lock: %w", err)
+	}
+	if err := lock.Close(); err != nil {
+		return err
+	}
+	if err := s.withLock(func() error { return s.writeStateLocked("open", "") }); err != nil {
+		return err
+	}
+	return s.writeInitializationMarker()
+}
+
+func (s *checkpointSafePoint) validatePersistedStorage() error {
+	markerData, err := readRegularFileNoFollow(s.markerPath(), checkpointMaxMetadataBytes)
+	if err != nil {
+		return fmt.Errorf("read checkpoint initialization marker: %w", err)
+	}
+	var marker checkpointInitialization
+	if err := json.Unmarshal(markerData, &marker); err != nil {
+		return fmt.Errorf("parse checkpoint initialization marker: %w", err)
+	}
+	if marker.Version != checkpointStateVersion || marker.SessionID != s.sessionID {
+		return errors.New("checkpoint initialization marker does not match this runtime")
+	}
+	for _, directory := range []string{s.root, s.leasesDir()} {
+		if err := requireDirectoryNoFollow(directory); err != nil {
+			return err
+		}
+	}
+	for _, file := range []string{s.lockPath(), s.statePath()} {
+		if err := requireRegularFileNoFollow(file); err != nil {
+			return err
+		}
+	}
+	return s.withLock(func() error {
+		_, err := s.readStateLocked()
+		return err
+	})
+}
+
+func (s *checkpointSafePoint) writeInitializationMarker() error {
+	data, err := json.Marshal(checkpointInitialization{
+		Version: checkpointStateVersion, SessionID: s.sessionID,
+	})
+	if err != nil {
+		return err
+	}
+	marker, err := openRegularFileNoFollow(
+		s.markerPath(),
+		os.O_CREATE|os.O_EXCL|os.O_WRONLY,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("create checkpoint initialization marker: %w", err)
+	}
+	if _, err := marker.Write(data); err != nil {
+		marker.Close()
+		return err
+	}
+	if err := marker.Sync(); err != nil {
+		marker.Close()
+		return err
+	}
+	if err := marker.Close(); err != nil {
+		return err
+	}
+	parent, err := openDirectoryNoFollow(s.storageRoot)
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	return parent.Sync()
+}
+
+// Checkpoint files are shared only by mutually trusted telosd processes under
+// one Unix UID. These checks prevent accidental path substitution; they do not
+// claim to isolate malicious tools running as that same trusted UID.
+func pathExistsNoFollow(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func openDirectoryNoFollow(path string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("path is not a trusted directory: %s", path)
+	}
+	file, err := os.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_CLOEXEC|syscall.O_DIRECTORY|syscall.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !opened.IsDir() {
+		file.Close()
+		return nil, fmt.Errorf("opened path is not a directory: %s", path)
+	}
+	return file, nil
+}
+
+func requireDirectoryNoFollow(path string) error {
+	directory, err := openDirectoryNoFollow(path)
+	if err != nil {
+		return err
+	}
+	return directory.Close()
+}
+
+func openRegularFileNoFollow(path string, flags int, mode os.FileMode) (*os.File, error) {
+	file, err := os.OpenFile(path, flags|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, mode)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, fmt.Errorf("path is not a regular file: %s", path)
+	}
+	return file, nil
+}
+
+func requireRegularFileNoFollow(path string) error {
+	file, err := openRegularFileNoFollow(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func readRegularFileNoFollow(path string, limit int64) ([]byte, error) {
+	file, err := openRegularFileNoFollow(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > limit {
+		return nil, fmt.Errorf("metadata file exceeds %d bytes", limit)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("metadata file exceeds %d bytes", limit)
+	}
+	return data, nil
+}
+
+func (s *checkpointSafePoint) withLock(fn func() error) error {
+	if err := requireDirectoryNoFollow(s.root); err != nil {
+		return fmt.Errorf("validate checkpoint state root: %w", err)
+	}
+	lock, err := openRegularFileNoFollow(s.lockPath(), os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open checkpoint lock: %w", err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock checkpoint state: %w", err)
+	}
+	defer func() {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+	}()
+	return fn()
+}
+
+func (s *checkpointSafePoint) readStateLocked() (checkpointState, error) {
+	data, err := readRegularFileNoFollow(s.statePath(), checkpointMaxMetadataBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return checkpointState{}, errors.New("checkpoint state is missing")
+	}
+	if err != nil {
+		return checkpointState{}, fmt.Errorf("read checkpoint state: %w", err)
+	}
+	var state checkpointState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return checkpointState{}, fmt.Errorf("parse checkpoint state: %w", err)
+	}
+	if state.Version != checkpointStateVersion || state.SessionID != s.sessionID {
+		return checkpointState{}, errors.New("checkpoint state does not match this runtime")
+	}
+	if state.Status != "open" && state.Status != "preparing" && state.Status != "prepared" {
+		return checkpointState{}, fmt.Errorf("invalid checkpoint state %q", state.Status)
+	}
+	if state.OperationID != "" && !checkpointOperationIDRE.MatchString(state.OperationID) {
+		return checkpointState{}, errors.New("checkpoint state has an invalid operation ID")
+	}
+	if state.Status != "open" && state.OperationID == "" {
+		return checkpointState{}, errors.New("closed checkpoint state has no operation owner")
+	}
+	return state, nil
+}
+
+func (s *checkpointSafePoint) writeStateLocked(status, operationID string) error {
+	data, err := json.Marshal(checkpointState{
+		Version: checkpointStateVersion, SessionID: s.sessionID, OperationID: operationID, Status: status,
+	})
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(s.root, ".state-*")
+	if err != nil {
+		return fmt.Errorf("create checkpoint state: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if info, err := tmp.Stat(); err != nil || !info.Mode().IsRegular() {
+		tmp.Close()
+		if err != nil {
+			return err
+		}
+		return errors.New("checkpoint temporary state is not a regular file")
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	stateExists, err := pathExistsNoFollow(s.statePath())
+	if err != nil {
+		return err
+	}
+	if stateExists {
+		if err := requireRegularFileNoFollow(s.statePath()); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(tmpPath, s.statePath()); err != nil {
+		return fmt.Errorf("replace checkpoint state: %w", err)
+	}
+	dir, err := openDirectoryNoFollow(s.root)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func (s *checkpointSafePoint) acquire() (*checkpointLease, error) {
+	var lease *checkpointLease
+	err := s.withLock(func() error {
+		state, err := s.readStateLocked()
+		if err != nil {
+			return err
+		}
+		if state.Status != "open" {
+			return errCheckpointAdmissionClosed
+		}
+		if err := requireDirectoryNoFollow(s.leasesDir()); err != nil {
+			return fmt.Errorf("validate checkpoint leases directory: %w", err)
+		}
+		var nonce [12]byte
+		if _, err := rand.Read(nonce[:]); err != nil {
+			return fmt.Errorf("create checkpoint lease ID: %w", err)
+		}
+		path := filepath.Join(s.leasesDir(), fmt.Sprintf("%d-%s.lease", os.Getpid(), hex.EncodeToString(nonce[:])))
+		file, err := openRegularFileNoFollow(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("create checkpoint lease: %w", err)
+		}
+		if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			file.Close()
+			os.Remove(path)
+			return fmt.Errorf("lock checkpoint lease: %w", err)
+		}
+		lease = &checkpointLease{path: path, file: file}
+		return nil
+	})
+	return lease, err
+}
+
+func (l *checkpointLease) release() {
+	if l == nil {
+		return
+	}
+	if l.file != nil {
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+		l.file = nil
+	}
+	if l.path != "" {
+		_ = os.Remove(l.path)
+		l.path = ""
+	}
+}
+
+func (s *checkpointSafePoint) prepare(ctx context.Context, operationID string) (string, int, error) {
+	operationID = strings.TrimSpace(operationID)
+	if !checkpointOperationIDRE.MatchString(operationID) {
+		return "error", 0, errors.New("invalid checkpoint operation ID")
+	}
+	if err := s.withLock(func() error {
+		state, err := s.readStateLocked()
+		if err != nil {
+			return err
+		}
+		switch state.Status {
+		case "open":
+			if state.OperationID == operationID {
+				return errCheckpointOperationCompleted
+			}
+			if s.prepareCheck != nil {
+				if err := s.prepareCheck(); err != nil {
+					return err
+				}
+			}
+			return s.writeStateLocked("preparing", operationID)
+		case "preparing", "prepared":
+			if state.OperationID != operationID {
+				return errCheckpointOperationMismatch
+			}
+			return nil
+		default:
+			return fmt.Errorf("invalid checkpoint state %q", state.Status)
+		}
+	}); err != nil {
+		return "error", 0, err
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, s.prepareTimeout)
+	defer cancel()
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+	for {
+		status, count, err := s.tryFinishPrepare(operationID)
+		if err != nil || status == "prepared" {
+			return status, count, err
+		}
+		select {
+		case <-deadlineCtx.Done():
+			return "timeout", count, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *checkpointSafePoint) tryFinishPrepare(operationID string) (string, int, error) {
+	status := "preparing"
+	count := 0
+	err := s.withLock(func() error {
+		state, err := s.readStateLocked()
+		if err != nil {
+			return err
+		}
+		if state.OperationID != operationID {
+			return errCheckpointOperationMismatch
+		}
+		if state.Status == "open" {
+			return errCheckpointOperationCompleted
+		}
+		if state.Status == "prepared" {
+			status = "prepared"
+			return nil
+		}
+		count, err = s.activeLeasesLocked()
+		if err != nil || count != 0 {
+			return err
+		}
+		if s.prepareCheck != nil {
+			if err := s.prepareCheck(); err != nil {
+				return err
+			}
+		}
+		if err := s.writeStateLocked("prepared", operationID); err != nil {
+			return err
+		}
+		status = "prepared"
+		return nil
+	})
+	return status, count, err
+}
+
+func (s *checkpointSafePoint) activeLeasesLocked() (int, error) {
+	if err := requireDirectoryNoFollow(s.leasesDir()); err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir(s.leasesDir())
+	if err != nil {
+		return 0, err
+	}
+	active := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".lease") {
+			continue
+		}
+		path := filepath.Join(s.leasesDir(), entry.Name())
+		file, err := openRegularFileNoFollow(path, os.O_RDWR, 0)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return 0, fmt.Errorf("open checkpoint lease: %w", err)
+		}
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+			_ = file.Close()
+			_ = os.Remove(path)
+			continue
+		}
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			active++
+			continue
+		}
+		return 0, fmt.Errorf("inspect checkpoint lease: %w", err)
+	}
+	return active, nil
+}
+
+func (s *checkpointSafePoint) resume(operationID string) error {
+	operationID = strings.TrimSpace(operationID)
+	if !checkpointOperationIDRE.MatchString(operationID) {
+		return errors.New("invalid checkpoint operation ID")
+	}
+	return s.withLock(func() error {
+		state, err := s.readStateLocked()
+		if err != nil {
+			return err
+		}
+		if state.OperationID != operationID {
+			return errCheckpointOperationMismatch
+		}
+		if state.Status == "open" {
+			return nil
+		}
+		return s.writeStateLocked("open", operationID)
+	})
+}
+
+func withCheckpointLease(safePoint *checkpointSafePoint, work func() error) error {
+	if safePoint == nil {
+		return work()
+	}
+	lease, err := safePoint.acquire()
+	if err != nil {
+		return err
+	}
+	defer lease.release()
+	return work()
+}
+
+type checkpointStore struct {
+	sessionapi.Store
+	safePoint *checkpointSafePoint
+}
+
+func (s checkpointStore) Create(req sessionapi.SessionCreateRequest) (*sessionapi.Session, error) {
+	lease, err := s.safePoint.acquire()
+	if err != nil {
+		if errors.Is(err, errCheckpointAdmissionClosed) {
+			return nil, fmt.Errorf("checkpoint preparation has closed new work: %w", sessionapi.ErrConflict)
+		}
+		return nil, err
+	}
+	defer lease.release()
+	return s.Store.Create(req)
+}
+
+func (s checkpointStore) UpdateSpec(name string, req sessionapi.SessionSpecUpdateRequest) (*sessionapi.SessionSpecUpdateResponse, error) {
+	lease, err := s.safePoint.acquire()
+	if err != nil {
+		if errors.Is(err, errCheckpointAdmissionClosed) {
+			return nil, fmt.Errorf("checkpoint preparation has closed new work: %w", sessionapi.ErrConflict)
+		}
+		return nil, err
+	}
+	defer lease.release()
+	return s.Store.UpdateSpec(name, req)
+}
+
+func (s checkpointStore) Stop(id string) (*sessionapi.Session, error) {
+	lease, err := s.safePoint.acquire()
+	if err != nil {
+		if errors.Is(err, errCheckpointAdmissionClosed) {
+			return nil, fmt.Errorf("checkpoint preparation has closed new work: %w", sessionapi.ErrConflict)
+		}
+		return nil, err
+	}
+	defer lease.release()
+	return s.Store.Stop(id)
+}
+
+type checkpointHandler struct {
+	safePoint  *checkpointSafePoint
+	authorizer sessionapi.Authorizer
+}
+
+type checkpointRequest struct {
+	SessionID   string `json:"session_id"`
+	OperationID string `json:"operation_id"`
+}
+
+type checkpointResponse struct {
+	Status      string `json:"status"`
+	SessionID   string `json:"session_id"`
+	OperationID string `json:"operation_id"`
+	InFlight    int    `json:"in_flight"`
+}
+
+func registerCheckpointRoutes(mux *http.ServeMux, safePoint *checkpointSafePoint, authorizer sessionapi.Authorizer) {
+	h := checkpointHandler{safePoint: safePoint, authorizer: authorizer}
+	mux.HandleFunc("POST /internal/checkpoint/prepare", h.prepare)
+	mux.HandleFunc("POST /internal/checkpoint/resume", h.resume)
+}
+
+func (h checkpointHandler) prepare(w http.ResponseWriter, r *http.Request) {
+	req, ok := h.authorizeRequest(w, r)
+	if !ok {
+		return
+	}
+	status, inFlight, err := h.safePoint.prepare(r.Context(), req.OperationID)
+	if err != nil {
+		switch {
+		case errors.Is(err, errCheckpointWorkersNotReady):
+			writeCheckpointError(w, http.StatusConflict, "checkpoint_workers_not_ready", "runtime workers are still upgrading for checkpoint safety", true)
+		case errors.Is(err, errCheckpointOperationMismatch):
+			writeCheckpointError(w, http.StatusConflict, "checkpoint_operation_mismatch", "another checkpoint operation owns runtime admission", false)
+		case errors.Is(err, errCheckpointOperationCompleted):
+			writeCheckpointError(w, http.StatusConflict, "checkpoint_operation_completed", "this checkpoint operation already completed", false)
+		default:
+			writeCheckpointError(w, http.StatusInternalServerError, "checkpoint_prepare_failed", "checkpoint preparation failed", true)
+		}
+		return
+	}
+	if status == "timeout" {
+		writeCheckpointError(w, http.StatusConflict, "checkpoint_prepare_timeout", "runtime work did not drain before the checkpoint deadline", true)
+		return
+	}
+	writeCheckpointJSON(w, http.StatusOK, checkpointResponse{
+		Status: status, SessionID: req.SessionID, OperationID: req.OperationID, InFlight: inFlight,
+	})
+}
+
+func (h checkpointHandler) resume(w http.ResponseWriter, r *http.Request) {
+	req, ok := h.authorizeRequest(w, r)
+	if !ok {
+		return
+	}
+	if err := h.safePoint.resume(req.OperationID); err != nil {
+		if errors.Is(err, errCheckpointOperationMismatch) {
+			writeCheckpointError(w, http.StatusConflict, "checkpoint_operation_mismatch", "another checkpoint operation owns runtime admission", false)
+			return
+		}
+		writeCheckpointError(w, http.StatusInternalServerError, "checkpoint_resume_failed", "checkpoint admission could not be reopened", true)
+		return
+	}
+	writeCheckpointJSON(w, http.StatusOK, checkpointResponse{
+		Status: "resumed", SessionID: req.SessionID, OperationID: req.OperationID,
+	})
+}
+
+func (h checkpointHandler) authorizeRequest(w http.ResponseWriter, r *http.Request) (checkpointRequest, bool) {
+	var req checkpointRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil ||
+		!checkpointSessionIDRE.MatchString(req.SessionID) ||
+		!checkpointOperationIDRE.MatchString(req.OperationID) {
+		writeCheckpointError(w, http.StatusBadRequest, "invalid_request", "invalid request body", false)
+		return checkpointRequest{}, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeCheckpointError(w, http.StatusBadRequest, "invalid_request", "invalid request body", false)
+		return checkpointRequest{}, false
+	}
+	_, err := h.authorizer.Caller(r, sessionapi.AccessRequest{
+		Action: sessionapi.ActionCheckpointSafePoint, SessionID: req.SessionID,
+	})
+	if err != nil {
+		if status, detail, ok := sessionapi.AuthHTTPError(err); ok {
+			code := "access_denied"
+			if status == http.StatusUnauthorized {
+				code = "unauthorized"
+			} else if status == http.StatusForbidden {
+				code = "forbidden"
+			}
+			writeCheckpointError(w, status, code, detail, false)
+			return checkpointRequest{}, false
+		}
+		writeCheckpointError(w, http.StatusInternalServerError, "authorization_failed", "authorization failed", true)
+		return checkpointRequest{}, false
+	}
+	if req.SessionID != h.safePoint.sessionID {
+		writeCheckpointError(w, http.StatusConflict, "checkpoint_session_mismatch", "runtime session does not match", false)
+		return checkpointRequest{}, false
+	}
+	return req, true
+}
+
+func writeCheckpointJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeCheckpointError(w http.ResponseWriter, status int, code, message string, retryable bool) {
+	writeCheckpointJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code": code, "message": message, "retryable": retryable,
+		},
+	})
+}

--- a/internal/telosd/checkpoint_safe_point_test.go
+++ b/internal/telosd/checkpoint_safe_point_test.go
@@ -1,0 +1,1020 @@
+package telosd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/telos-org/telos/internal/sessionapi"
+)
+
+const (
+	testCheckpointSessionID   = "sess_deployment_123"
+	testCheckpointOperationID = "snap_operation_a"
+	testCheckpointOperationB  = "snap_operation_b"
+)
+
+func newTestCheckpointSafePoint(t *testing.T) *checkpointSafePoint {
+	t.Helper()
+	safePoint, err := newCheckpointSafePoint(t.TempDir(), testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safePoint.prepareTimeout = 75 * time.Millisecond
+	safePoint.pollInterval = time.Millisecond
+	return safePoint
+}
+
+func checkpointStatus(t *testing.T, safePoint *checkpointSafePoint) string {
+	t.Helper()
+	var status string
+	if err := safePoint.withLock(func() error {
+		state, err := safePoint.readStateLocked()
+		status = state.Status
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return status
+}
+
+func checkpointStateValue(t *testing.T, safePoint *checkpointSafePoint) checkpointState {
+	t.Helper()
+	var state checkpointState
+	if err := safePoint.withLock(func() error {
+		var err error
+		state, err = safePoint.readStateLocked()
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func TestCheckpointPrepareTimeoutDoesNotKillWorkAndRetryCompletes(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "timeout" || inFlight != 1 {
+		t.Fatalf("prepare: got status=%q in_flight=%d", status, inFlight)
+	}
+	if lease.file == nil {
+		t.Fatal("prepare timeout released or killed the admitted work lease")
+	}
+	if _, err := safePoint.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("new admission while preparing: got %v", err)
+	}
+
+	lease.release()
+	status, inFlight, err = safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "prepared" || inFlight != 0 {
+		t.Fatalf("retry prepare: got status=%q in_flight=%d", status, inFlight)
+	}
+}
+
+func TestCheckpointPrepareRejectsUnreadyWorkersWithoutClosingAdmission(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	safePoint.prepareCheck = func() error {
+		return errCheckpointWorkersNotReady
+	}
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if !errors.Is(err, errCheckpointWorkersNotReady) || status != "error" || inFlight != 0 {
+		t.Fatalf("prepare: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+	if got := checkpointStatus(t, safePoint); got != "open" {
+		t.Fatalf("rejected prepare closed admission: %q", got)
+	}
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatalf("admission after rejected prepare: %v", err)
+	}
+	lease.release()
+}
+
+func TestCheckpointPrepareRechecksWorkersBeforeCommittingPrepared(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	checks := 0
+	safePoint.prepareCheck = func() error {
+		checks++
+		if checks == 2 {
+			return errCheckpointWorkersNotReady
+		}
+		return nil
+	}
+
+	status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if !errors.Is(err, errCheckpointWorkersNotReady) || status != "preparing" {
+		t.Fatalf("prepare readiness race: status=%q err=%v", status, err)
+	}
+	if checks != 2 {
+		t.Fatalf("readiness checks: got %d want 2", checks)
+	}
+	state := checkpointStateValue(t, safePoint)
+	if state.Status != "preparing" || state.OperationID != testCheckpointOperationID {
+		t.Fatalf("readiness race committed prepared state: %#v", state)
+	}
+	if _, err := safePoint.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("readiness race reopened admission: %v", err)
+	}
+
+	safePoint.prepareCheck = func() error { return nil }
+	status, _, err = safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "prepared" {
+		t.Fatalf("same-owner retry: status=%q err=%v", status, err)
+	}
+}
+
+func TestCheckpointPrepareAndResumeAreIdempotentAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status != "prepared" || inFlight != 0 {
+			t.Fatalf("prepare %d: got status=%q in_flight=%d", i, status, inFlight)
+		}
+	}
+
+	restarted, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := restarted.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("restart admission: got %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := restarted.resume(testCheckpointOperationID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lease, err := restarted.acquire()
+	if err != nil {
+		t.Fatalf("admission after resume: %v", err)
+	}
+	lease.release()
+}
+
+func TestCheckpointOperationOwnershipRejectsDelayedResume(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	if status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil || status != "prepared" {
+		t.Fatalf("prepare A: status=%q err=%v", status, err)
+	}
+	if err := safePoint.resume(testCheckpointOperationID); err != nil {
+		t.Fatalf("resume A: %v", err)
+	}
+	if status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationB); err != nil || status != "prepared" {
+		t.Fatalf("prepare B: status=%q err=%v", status, err)
+	}
+	if err := safePoint.resume(testCheckpointOperationID); !errors.Is(err, errCheckpointOperationMismatch) {
+		t.Fatalf("stale resume A: got %v", err)
+	}
+	state := checkpointStateValue(t, safePoint)
+	if state.Status != "prepared" || state.OperationID != testCheckpointOperationB {
+		t.Fatalf("stale resume changed B ownership: %#v", state)
+	}
+	if _, err := safePoint.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("stale resume reopened admission: %v", err)
+	}
+	if err := safePoint.resume(testCheckpointOperationB); err != nil {
+		t.Fatalf("resume B: %v", err)
+	}
+}
+
+func TestCheckpointCompletedOwnerCannotPrepareAgain(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if err := safePoint.resume(testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); !errors.Is(err, errCheckpointOperationCompleted) {
+		t.Fatalf("completed operation prepared again: %v", err)
+	}
+	state := checkpointStateValue(t, safePoint)
+	if state.Status != "open" || state.OperationID != testCheckpointOperationID {
+		t.Fatalf("completed prepare changed state: %#v", state)
+	}
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatalf("completed prepare closed admission: %v", err)
+	}
+	lease.release()
+}
+
+func TestCheckpointSameOwnerIsIdempotentAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status, _, err := restarted.prepare(context.Background(), testCheckpointOperationID); err != nil || status != "prepared" {
+		t.Fatalf("retry prepare after restart: status=%q err=%v", status, err)
+	}
+	if err := restarted.resume(testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	restartedAgain, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := restartedAgain.resume(testCheckpointOperationID); err != nil {
+		t.Fatalf("retry resume after restart: %v", err)
+	}
+	state := checkpointStateValue(t, restartedAgain)
+	if state.Status != "open" || state.OperationID != testCheckpointOperationID {
+		t.Fatalf("resumed state: %#v", state)
+	}
+}
+
+func TestCheckpointPreparingStateSurvivesRestart(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safePoint.prepareTimeout = 20 * time.Millisecond
+	safePoint.pollInterval = time.Millisecond
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "timeout" {
+		t.Fatalf("prepare: status=%q err=%v", status, err)
+	}
+	lease.release()
+
+	restarted, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := restarted.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("restart admission: got %v", err)
+	}
+	status, _, err = restarted.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "prepared" {
+		t.Fatalf("restart prepare: status=%q err=%v", status, err)
+	}
+}
+
+func TestCheckpointLeaseDrainsAcrossWorkerProcessCrash(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safePoint.prepareTimeout = 50 * time.Millisecond
+	safePoint.pollInterval = time.Millisecond
+	readyPath := filepath.Join(root, "worker-ready")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCheckpointLeaseSubprocessHelper$")
+	cmd.Env = append(os.Environ(),
+		"TELOS_CHECKPOINT_TEST_HELPER=1",
+		"TELOS_CHECKPOINT_TEST_ROOT="+root,
+		"TELOS_CHECKPOINT_TEST_READY="+readyPath,
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("worker helper did not acquire lease: %s", output.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "timeout" || inFlight != 1 {
+		t.Fatalf("prepare with worker process: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("expected killed worker helper to exit unsuccessfully")
+	}
+	cmd.Process = nil
+
+	status, inFlight, err = safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "prepared" || inFlight != 0 {
+		t.Fatalf("prepare after worker crash: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+}
+
+func TestCheckpointLeaseSubprocessHelper(t *testing.T) {
+	if os.Getenv("TELOS_CHECKPOINT_TEST_HELPER") != "1" {
+		return
+	}
+	safePoint, err := newCheckpointSafePoint(os.Getenv("TELOS_CHECKPOINT_TEST_ROOT"), testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.release()
+	if err := os.WriteFile(os.Getenv("TELOS_CHECKPOINT_TEST_READY"), []byte("ready"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func TestCheckpointPrepareAtomicallyClosesConcurrentAdmission(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	safePoint.prepareTimeout = time.Second
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared := make(chan error, 1)
+	go func() {
+		status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+		if err == nil && status != "prepared" {
+			err = errors.New("prepare did not complete")
+		}
+		prepared <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for checkpointStatus(t, safePoint) != "preparing" {
+		if time.Now().After(deadline) {
+			t.Fatal("prepare did not close admission")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for i := 0; i < cap(errs); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := safePoint.acquire()
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if !errors.Is(err, errCheckpointAdmissionClosed) {
+			t.Fatalf("concurrent admission: got %v", err)
+		}
+	}
+	lease.release()
+	if err := <-prepared; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckpointWorkerCleanupRemainsInFlight(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupStarted := make(chan struct{})
+	cleanupRelease := make(chan struct{})
+	cleanupDone := make(chan struct{})
+	go func() {
+		finishCheckpointWork(lease, func() {
+			close(cleanupStarted)
+			<-cleanupRelease
+		})
+		close(cleanupDone)
+	}()
+	<-cleanupStarted
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "timeout" || inFlight != 1 {
+		t.Fatalf("prepare during cleanup: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+	close(cleanupRelease)
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("worker cleanup did not finish")
+	}
+	status, inFlight, err = safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "prepared" || inFlight != 0 {
+		t.Fatalf("prepare after cleanup: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+}
+
+func TestCheckpointRootReconciliationRemainsInFlight(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	workStarted := make(chan struct{})
+	workRelease := make(chan struct{})
+	workDone := make(chan error, 1)
+	go func() {
+		workDone <- withCheckpointLease(safePoint, func() error {
+			close(workStarted)
+			<-workRelease
+			return nil
+		})
+	}()
+	<-workStarted
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "timeout" || inFlight != 1 {
+		t.Fatalf("prepare during root reconciliation: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+	close(workRelease)
+	if err := <-workDone; err != nil {
+		t.Fatal(err)
+	}
+	status, inFlight, err = safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "prepared" || inFlight != 0 {
+		t.Fatalf("prepare after root reconciliation: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+}
+
+func TestCheckpointWorkerAdmissionWaitsForResumeAndCanStop(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	wake := make(chan os.Signal, 1)
+	stop := make(chan os.Signal, 1)
+	type result struct {
+		lease   *checkpointLease
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		lease, stopped, err := waitForCheckpointAdmission(safePoint, wake, stop)
+		resultCh <- result{lease: lease, stopped: stopped, err: err}
+	}()
+	select {
+	case got := <-resultCh:
+		t.Fatalf("worker admitted while prepared: %+v", got)
+	case <-time.After(20 * time.Millisecond):
+	}
+	if err := safePoint.resume(testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-resultCh:
+		if got.err != nil || got.stopped || got.lease == nil {
+			t.Fatalf("worker admission after resume: %+v", got)
+		}
+		got.lease.release()
+	case <-time.After(time.Second):
+		t.Fatal("worker did not resume admission")
+	}
+
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationB); err != nil {
+		t.Fatal(err)
+	}
+	stop <- os.Interrupt
+	lease, stopped, err := waitForCheckpointAdmission(safePoint, wake, stop)
+	if err != nil || !stopped || lease != nil {
+		t.Fatalf("stopped worker wait: lease=%v stopped=%v err=%v", lease, stopped, err)
+	}
+}
+
+func TestCheckpointRetryTimerRaceIsBounded(t *testing.T) {
+	const iterations = 5000
+	done := make(chan error, 1)
+	go func() {
+		for i := 0; i < iterations; i++ {
+			wake := make(chan os.Signal, 1)
+			wake <- syscall.SIGUSR1
+			if waitForCheckpointRetry(0, wake, nil) {
+				done <- errors.New("wake was treated as stop")
+				return
+			}
+		}
+		done <- nil
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timer/wake race blocked while draining a stopped Go 1.26 timer")
+	}
+
+	stop := make(chan os.Signal, 1)
+	stop <- os.Interrupt
+	if !waitForCheckpointRetry(time.Hour, nil, stop) {
+		t.Fatal("stop signal was not observed")
+	}
+}
+
+type blockingCheckpointStore struct {
+	sessionapi.Store
+	createStarted chan struct{}
+	createRelease chan struct{}
+	updateStarted chan struct{}
+	updateRelease chan struct{}
+	stopStarted   chan struct{}
+	stopRelease   chan struct{}
+}
+
+func (s *blockingCheckpointStore) Create(sessionapi.SessionCreateRequest) (*sessionapi.Session, error) {
+	close(s.createStarted)
+	<-s.createRelease
+	return &sessionapi.Session{SessionID: "sess_created"}, nil
+}
+
+func (s *blockingCheckpointStore) UpdateSpec(string, sessionapi.SessionSpecUpdateRequest) (*sessionapi.SessionSpecUpdateResponse, error) {
+	close(s.updateStarted)
+	<-s.updateRelease
+	return &sessionapi.SessionSpecUpdateResponse{}, nil
+}
+
+func (s *blockingCheckpointStore) Stop(string) (*sessionapi.Session, error) {
+	close(s.stopStarted)
+	<-s.stopRelease
+	return &sessionapi.Session{SessionID: "sess_stopped"}, nil
+}
+
+func TestCheckpointStoreCountsMutationsAsInFlight(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(checkpointStore, *blockingCheckpointStore) <-chan error
+		wait func(*blockingCheckpointStore)
+		done func(*blockingCheckpointStore)
+	}{
+		{
+			name: "create",
+			run: func(store checkpointStore, base *blockingCheckpointStore) <-chan error {
+				result := make(chan error, 1)
+				go func() { _, err := store.Create(sessionapi.SessionCreateRequest{}); result <- err }()
+				return result
+			},
+			wait: func(base *blockingCheckpointStore) { <-base.createStarted },
+			done: func(base *blockingCheckpointStore) { close(base.createRelease) },
+		},
+		{
+			name: "update",
+			run: func(store checkpointStore, base *blockingCheckpointStore) <-chan error {
+				result := make(chan error, 1)
+				go func() { _, err := store.UpdateSpec("demo", sessionapi.SessionSpecUpdateRequest{}); result <- err }()
+				return result
+			},
+			wait: func(base *blockingCheckpointStore) { <-base.updateStarted },
+			done: func(base *blockingCheckpointStore) { close(base.updateRelease) },
+		},
+		{
+			name: "stop",
+			run: func(store checkpointStore, base *blockingCheckpointStore) <-chan error {
+				result := make(chan error, 1)
+				go func() { _, err := store.Stop("demo"); result <- err }()
+				return result
+			},
+			wait: func(base *blockingCheckpointStore) { <-base.stopStarted },
+			done: func(base *blockingCheckpointStore) { close(base.stopRelease) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			safePoint := newTestCheckpointSafePoint(t)
+			base := &blockingCheckpointStore{
+				createStarted: make(chan struct{}), createRelease: make(chan struct{}),
+				updateStarted: make(chan struct{}), updateRelease: make(chan struct{}),
+				stopStarted: make(chan struct{}), stopRelease: make(chan struct{}),
+			}
+			result := tc.run(checkpointStore{Store: base, safePoint: safePoint}, base)
+			tc.wait(base)
+			status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+			if err != nil || status != "timeout" || inFlight != 1 {
+				t.Fatalf("prepare: status=%q in_flight=%d err=%v", status, inFlight, err)
+			}
+			tc.done(base)
+			if err := <-result; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCheckpointRoutesRequireOperatorAndExactRuntimeSession(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	store := sessionapi.NewFileStore(filepath.Join(t.TempDir(), "sessions"), sessionapi.RuntimeCloud)
+	access, err := sessionapi.NewScopedToken("sess_child", sessionapi.KindTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childDir := filepath.Join(store.Root, "sess_child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := sessionapi.Manifest{SessionID: "sess_child", SessionKind: sessionapi.KindTask, Access: access}
+	if err := sessionapi.WriteManifest(filepath.Join(childDir, "session.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerCheckpointRoutes(mux, safePoint, sessionapi.NewBearerAuthorizer(store, "operator-secret"))
+
+	tests := []struct {
+		name      string
+		token     string
+		sessionID string
+		want      int
+		wantCode  string
+	}{
+		{name: "missing auth before scope check", sessionID: "sess_other", want: http.StatusUnauthorized, wantCode: "unauthorized"},
+		{name: "invalid token", token: "wrong", sessionID: testCheckpointSessionID, want: http.StatusUnauthorized, wantCode: "unauthorized"},
+		{name: "task token", token: access.APIToken, sessionID: testCheckpointSessionID, want: http.StatusForbidden, wantCode: "forbidden"},
+		{name: "wrong runtime session", token: "operator-secret", sessionID: "sess_other", want: http.StatusConflict, wantCode: "checkpoint_session_mismatch"},
+		{name: "operator", token: "operator-secret", sessionID: testCheckpointSessionID, want: http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(checkpointRequest{
+				SessionID:   tc.sessionID,
+				OperationID: testCheckpointOperationID,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/internal/checkpoint/prepare", bytes.NewReader(body))
+			if tc.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.token)
+			}
+			res := httptest.NewRecorder()
+			mux.ServeHTTP(res, req)
+			if res.Code != tc.want {
+				t.Fatalf("status: got %d want %d body=%s", res.Code, tc.want, res.Body.String())
+			}
+			if tc.wantCode != "" {
+				var body struct {
+					Error struct {
+						Code      string `json:"code"`
+						Message   string `json:"message"`
+						Retryable bool   `json:"retryable"`
+					} `json:"error"`
+				}
+				if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+					t.Fatal(err)
+				}
+				if body.Error.Code != tc.wantCode || body.Error.Message == "" || body.Error.Retryable {
+					t.Fatalf("typed error: %#v", body.Error)
+				}
+			} else {
+				var body checkpointResponse
+				if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+					t.Fatal(err)
+				}
+				if body.Status != "prepared" || body.SessionID != testCheckpointSessionID ||
+					body.OperationID != testCheckpointOperationID || body.InFlight != 0 {
+					t.Fatalf("prepare response: %#v", body)
+				}
+			}
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		body, _ := json.Marshal(checkpointRequest{
+			SessionID:   testCheckpointSessionID,
+			OperationID: testCheckpointOperationID,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/internal/checkpoint/resume", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer operator-secret")
+		res := httptest.NewRecorder()
+		mux.ServeHTTP(res, req)
+		if res.Code != http.StatusOK {
+			t.Fatalf("resume %d: status=%d body=%s", i, res.Code, res.Body.String())
+		}
+		var response checkpointResponse
+		if err := json.Unmarshal(res.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		if response.Status != "resumed" || response.SessionID != testCheckpointSessionID ||
+			response.OperationID != testCheckpointOperationID {
+			t.Fatalf("resume response %d: %#v", i, response)
+		}
+	}
+}
+
+func TestCheckpointRouteRejectsStaleResumeWithoutReopening(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if err := safePoint.resume(testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationB); err != nil {
+		t.Fatal(err)
+	}
+	store := sessionapi.NewFileStore(filepath.Join(t.TempDir(), "sessions"), sessionapi.RuntimeCloud)
+	mux := http.NewServeMux()
+	registerCheckpointRoutes(mux, safePoint, sessionapi.NewBearerAuthorizer(store, "operator-secret"))
+	body, _ := json.Marshal(checkpointRequest{
+		SessionID:   testCheckpointSessionID,
+		OperationID: testCheckpointOperationID,
+	})
+	request := httptest.NewRequest(http.MethodPost, "/internal/checkpoint/resume", bytes.NewReader(body))
+	request.Header.Set("Authorization", "Bearer operator-secret")
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("stale resume status=%d body=%s", response.Code, response.Body.String())
+	}
+	var failure struct {
+		Error struct {
+			Code      string `json:"code"`
+			Retryable bool   `json:"retryable"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &failure); err != nil {
+		t.Fatal(err)
+	}
+	if failure.Error.Code != "checkpoint_operation_mismatch" || failure.Error.Retryable {
+		t.Fatalf("stale resume failure: %#v", failure.Error)
+	}
+	state := checkpointStateValue(t, safePoint)
+	if state.Status != "prepared" || state.OperationID != testCheckpointOperationB {
+		t.Fatalf("stale route resume changed state: %#v", state)
+	}
+}
+
+func TestCheckpointPrepareTimeoutIsTypedAndRetryable(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	lease, err := safePoint.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.release()
+
+	store := sessionapi.NewFileStore(filepath.Join(t.TempDir(), "sessions"), sessionapi.RuntimeCloud)
+	mux := http.NewServeMux()
+	registerCheckpointRoutes(mux, safePoint, sessionapi.NewBearerAuthorizer(store, "operator-secret"))
+	body, _ := json.Marshal(checkpointRequest{
+		SessionID:   testCheckpointSessionID,
+		OperationID: testCheckpointOperationID,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/internal/checkpoint/prepare", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer operator-secret")
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	if res.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+	var response struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			Retryable bool   `json:"retryable"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Error.Code != "checkpoint_prepare_timeout" ||
+		!response.Error.Retryable || response.Error.Message == "" {
+		t.Fatalf("typed timeout error: %#v", response.Error)
+	}
+	if got := checkpointStatus(t, safePoint); got != "preparing" {
+		t.Fatalf("timeout reopened checkpoint admission: %q", got)
+	}
+}
+
+func TestCheckpointSafePointCapabilityRequiresCloudClaimAndPersistence(t *testing.T) {
+	t.Setenv("TELOS_SESSION_ID", "")
+	local, err := checkpointSafePointForConfig(Config{Mode: ModeLocal, Root: t.TempDir()})
+	if err != nil || local != nil {
+		t.Fatalf("local safe point: manager=%v err=%v", local, err)
+	}
+	cloud, err := checkpointSafePointForConfig(Config{Mode: ModeCloud, Root: t.TempDir()})
+	if err != nil || cloud != nil {
+		t.Fatalf("unclaimed cloud safe point: manager=%v err=%v", cloud, err)
+	}
+	t.Setenv("TELOS_SESSION_ID", testCheckpointSessionID)
+	cloud, err = checkpointSafePointForConfig(Config{Mode: ModeCloud, Root: t.TempDir()})
+	if err != nil || cloud == nil {
+		t.Fatalf("claimed cloud safe point: manager=%v err=%v", cloud, err)
+	}
+	if _, err := os.Stat(cloud.statePath()); err != nil {
+		t.Fatalf("durable open state was not initialized: %v", err)
+	}
+	capabilities := setRuntimeCapability(
+		[]string{"existing", checkpointSafePointCapability},
+		checkpointSafePointCapability,
+		true,
+	)
+	if len(capabilities) != 2 || capabilities[1] != checkpointSafePointCapability {
+		t.Fatalf("capabilities: %#v", capabilities)
+	}
+	disabled := setRuntimeCapability(capabilities, checkpointSafePointCapability, false)
+	if len(disabled) != 1 || disabled[0] != "existing" {
+		t.Fatalf("disabled capabilities: %#v", disabled)
+	}
+}
+
+func TestCheckpointCapabilityUsesCanonicalHealthPayload(t *testing.T) {
+	store := sessionapi.NewFileStore(filepath.Join(t.TempDir(), "sessions"), sessionapi.RuntimeCloud)
+	mux := http.NewServeMux()
+	runtime := sessionapi.RuntimeIdentity{
+		Version:      "v0.1.4",
+		TelosdDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Capabilities: setRuntimeCapability(
+			[]string{sessionapi.CapabilityEpochFinalizedEventsV1},
+			checkpointSafePointCapability,
+			true,
+		),
+	}
+	sessionapi.RegisterRoutes(mux, store, sessionapi.AllowAllAuthorizer{}, runtime)
+	request := httptest.NewRequest(http.MethodGet, "/api/healthz", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	capabilities, ok := body["capabilities"].([]any)
+	if !ok || len(capabilities) != 2 ||
+		capabilities[0] != sessionapi.CapabilityEpochFinalizedEventsV1 ||
+		capabilities[1] != sessionapi.CapabilityCheckpointSafePoint {
+		t.Fatalf("canonical capabilities: %#v", body["capabilities"])
+	}
+	if _, stale := body["runtime_capabilities"]; stale {
+		t.Fatalf("health payload revived stale runtime_capabilities key: %#v", body)
+	}
+}
+
+func TestCheckpointSafePointRejectsMismatchedPersistedClaim(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newCheckpointSafePoint(root, "sess_different"); err == nil {
+		t.Fatal("expected persisted deployment claim mismatch to fail closed")
+	}
+}
+
+func TestCheckpointStateLossFailsAdmissionClosed(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	if err := os.Remove(safePoint.statePath()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := safePoint.acquire(); err == nil {
+		t.Fatal("expected missing durable state to refuse admission")
+	}
+	status, _, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err == nil || status != "error" {
+		t.Fatalf("prepare with missing durable state: status=%q err=%v", status, err)
+	}
+}
+
+func TestCheckpointStateLossFailsClosedAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(safePoint.statePath()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newCheckpointSafePoint(root, testCheckpointSessionID); err == nil {
+		t.Fatal("restart recreated missing checkpoint state and reopened admission")
+	}
+}
+
+func TestCheckpointInitializationMarkerSurvivesSubdirectoryLoss(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markerInfo, err := os.Lstat(safePoint.markerPath())
+	if err != nil {
+		t.Fatalf("initialization marker: %v", err)
+	}
+	if !markerInfo.Mode().IsRegular() || filepath.Dir(safePoint.markerPath()) != root {
+		t.Fatalf("initialization marker is not a regular file outside state dir: %s (%s)", safePoint.markerPath(), markerInfo.Mode())
+	}
+	if err := os.RemoveAll(safePoint.root); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newCheckpointSafePoint(root, testCheckpointSessionID); err == nil {
+		t.Fatal("missing checkpoint directory was recreated despite durable marker")
+	}
+}
+
+func TestCheckpointPartialInitializationFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(safePoint.markerPath()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newCheckpointSafePoint(root, testCheckpointSessionID); err == nil {
+		t.Fatal("existing state directory without marker was treated as fresh initialization")
+	}
+}
+
+func TestCheckpointMalformedStateFailsClosedAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(safePoint.statePath(), []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newCheckpointSafePoint(root, testCheckpointSessionID); err == nil {
+		t.Fatal("malformed state was accepted across restart")
+	}
+}
+
+func TestCheckpointStorageRejectsSymlinks(t *testing.T) {
+	for _, name := range []string{"marker", "state", "lock", "directory"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			safePoint, err := newCheckpointSafePoint(root, testCheckpointSessionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(root, "untrusted-target")
+			if name == "directory" {
+				if err := os.Mkdir(target, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.RemoveAll(safePoint.root); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, safePoint.root); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.WriteFile(target, []byte("untrusted"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				path := safePoint.statePath()
+				if name == "marker" {
+					path = safePoint.markerPath()
+				} else if name == "lock" {
+					path = safePoint.lockPath()
+				}
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := newCheckpointSafePoint(root, testCheckpointSessionID); err == nil {
+				t.Fatalf("%s symlink was accepted", name)
+			}
+		})
+	}
+}

--- a/internal/telosd/local_process_worker.go
+++ b/internal/telosd/local_process_worker.go
@@ -2,19 +2,31 @@ package telosd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/telos-org/telos/internal/sessionapi"
 	"github.com/telos-org/telos/internal/sessionworker"
 )
 
-type localProcessSubstrate struct{}
+type localProcessSubstrate struct {
+	checkpointRoot      string
+	checkpointSessionID string
+}
 
 func newLocalProcessSubstrate() localProcessSubstrate {
 	return localProcessSubstrate{}
 }
 
-func newSessionSubstrate(Config) (sessionSubstrate, error) {
-	return newLocalProcessSubstrate(), nil
+func newSessionSubstrate(cfg Config) (sessionSubstrate, error) {
+	substrate := newLocalProcessSubstrate()
+	if cfg.Mode == ModeCloud {
+		if sessionID := strings.TrimSpace(os.Getenv("TELOS_SESSION_ID")); sessionID != "" {
+			substrate.checkpointRoot = cfg.Root
+			substrate.checkpointSessionID = sessionID
+		}
+	}
+	return substrate, nil
 }
 
 func (s localProcessSubstrate) Apply(session *sessionapi.Session, wakeReason string) error {
@@ -26,8 +38,10 @@ func (s localProcessSubstrate) Apply(session *sessionapi.Session, wakeReason str
 		return fmt.Errorf("session %s has no session_dir", session.SessionID)
 	}
 	return sessionworker.EnsureStartedWithOptions(sessionDir, sessionworker.StartOptions{
-		Runtime:    sessionapi.RuntimeCloud,
-		WakeReason: wakeReason,
+		Runtime:             sessionapi.RuntimeCloud,
+		WakeReason:          wakeReason,
+		CheckpointRoot:      s.checkpointRoot,
+		CheckpointSessionID: s.checkpointSessionID,
 	})
 }
 

--- a/internal/telosd/local_process_worker_test.go
+++ b/internal/telosd/local_process_worker_test.go
@@ -43,6 +43,8 @@ done
   echo "TELOS_SESSION_ID=$TELOS_SESSION_ID"
   echo "TELOS_API_TOKEN=$TELOS_API_TOKEN"
   echo "TELOS_WAKE_REASON=$TELOS_WAKE_REASON"
+  echo "TELOS_CHECKPOINT_ROOT=$TELOS_CHECKPOINT_ROOT"
+  echo "TELOS_CHECKPOINT_SESSION_ID=$TELOS_CHECKPOINT_SESSION_ID"
 } > "$session_dir/worker.env"
 `), 0o755); err != nil {
 		t.Fatal(err)
@@ -56,7 +58,10 @@ done
 		t.Fatalf("Create: %v", err)
 	}
 
-	substrate := newLocalProcessSubstrate()
+	substrate := localProcessSubstrate{
+		checkpointRoot:      dir,
+		checkpointSessionID: "sess_deployment_123",
+	}
 	if err := substrate.Apply(session, "controller_started"); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -79,9 +84,27 @@ done
 		"TELOS_RUNTIME=cloud",
 		"TELOS_SESSION_ID=" + session.SessionID,
 		"TELOS_WAKE_REASON=controller_started",
+		"TELOS_CHECKPOINT_ROOT=" + dir,
+		"TELOS_CHECKPOINT_SESSION_ID=sess_deployment_123",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("worker env missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestNewSessionSubstrateScopesCheckpointAdmissionToClaimedCloudRuntime(t *testing.T) {
+	t.Setenv("TELOS_SESSION_ID", "sess_deployment_123")
+	root := t.TempDir()
+	substrate, err := newSessionSubstrate(Config{Mode: ModeCloud, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	local, ok := substrate.(localProcessSubstrate)
+	if !ok {
+		t.Fatalf("substrate: got %T", substrate)
+	}
+	if local.checkpointRoot != root || local.checkpointSessionID != "sess_deployment_123" {
+		t.Fatalf("checkpoint scope: root=%q session=%q", local.checkpointRoot, local.checkpointSessionID)
 	}
 }

--- a/internal/telosd/server.go
+++ b/internal/telosd/server.go
@@ -32,6 +32,15 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 	if err := os.MkdirAll(SessionsRoot(cfg.Root), 0o755); err != nil {
 		return fmt.Errorf("create sessions root: %w", err)
 	}
+	safePoint, err := checkpointSafePointForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("initialize checkpoint safe point: %w", err)
+	}
+	runtime.Capabilities = setRuntimeCapability(
+		runtime.Capabilities,
+		checkpointSafePointCapability,
+		safePoint != nil,
+	)
 
 	baseStore := storeForConfig(cfg)
 	store := sessionapi.Store(baseStore)
@@ -43,15 +52,23 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 		materializer := newApplyPackageMaterializer(baseStore.PackageRoot, cfg.Auth.Token)
 		reconciler := newControllerReconciler(baseStore, substrate, materializer, cloudControllerDefaults())
 		store = reconciler
-		if err := reconciler.ensureRootWorkers("server_started"); err != nil {
+		if err := withCheckpointLease(safePoint, func() error {
+			return reconciler.ensureRootWorkers("server_started")
+		}); err != nil && !errors.Is(err, errCheckpointAdmissionClosed) {
 			log.Printf("ensure root workers: %v", err)
 		}
-		startRootWorkerReconciler(ctx, reconciler)
-		startSessionBootstrapReconciler(ctx, store, materializer)
+		startRootWorkerReconciler(ctx, reconciler, safePoint)
+		startSessionBootstrapReconciler(ctx, store, materializer, safePoint)
+		if safePoint != nil {
+			store = checkpointStore{Store: store, safePoint: safePoint}
+		}
 	}
 	mux := http.NewServeMux()
 	authorizer := authorizerForConfig(cfg, baseStore)
 	sessionapi.RegisterRoutes(mux, store, authorizer, runtime)
+	if safePoint != nil {
+		registerCheckpointRoutes(mux, safePoint, authorizer)
+	}
 
 	var lastRequest atomic.Int64
 	lastRequest.Store(time.Now().UnixNano())
@@ -89,7 +106,24 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 	return nil
 }
 
-func startRootWorkerReconciler(ctx context.Context, reconciler *controllerReconciler) {
+func setRuntimeCapability(capabilities []string, capability string, enabled bool) []string {
+	result := make([]string, 0, len(capabilities)+1)
+	for _, existing := range capabilities {
+		if existing != capability {
+			result = append(result, existing)
+		}
+	}
+	if enabled {
+		result = append(result, capability)
+	}
+	return result
+}
+
+func startRootWorkerReconciler(
+	ctx context.Context,
+	reconciler *controllerReconciler,
+	safePoint *checkpointSafePoint,
+) {
 	go func() {
 		ticker := time.NewTicker(rootWorkerReconcileInterval)
 		defer ticker.Stop()
@@ -98,7 +132,9 @@ func startRootWorkerReconciler(ctx context.Context, reconciler *controllerReconc
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := reconciler.ensureRootWorkers("worker_supervision"); err != nil {
+				if err := withCheckpointLease(safePoint, func() error {
+					return reconciler.ensureRootWorkers("worker_supervision")
+				}); err != nil && !errors.Is(err, errCheckpointAdmissionClosed) {
 					log.Printf("ensure root workers: %v", err)
 				}
 			}

--- a/internal/telosd/session_bootstrap.go
+++ b/internal/telosd/session_bootstrap.go
@@ -2,6 +2,7 @@ package telosd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -26,17 +27,19 @@ const (
 
 type sessionBootstrapReconciler struct {
 	packageRoot     string
-	materializer    *applyPackageMaterializer
+	materializer    packageMaterializer
 	model           string
 	thinking        string
 	agentTimeoutSec *int
 	store           sessionapi.Store
+	safePoint       *checkpointSafePoint
 }
 
 func startSessionBootstrapReconciler(
 	ctx context.Context,
 	store sessionapi.Store,
 	materializer *applyPackageMaterializer,
+	safePoint *checkpointSafePoint,
 ) {
 	if os.Getenv("TELOS_SESSION_BOOTSTRAP_ENABLED") == "0" {
 		return
@@ -52,6 +55,7 @@ func startSessionBootstrapReconciler(
 		thinking:        cloudSessionThinking(),
 		agentTimeoutSec: cloudAgentTimeoutSec(),
 		store:           store,
+		safePoint:       safePoint,
 	}
 	if r.packageRoot == "" {
 		return
@@ -89,6 +93,18 @@ func bootstrapSessionFromEnv() (cloudBootstrapSession, bool) {
 }
 
 func (r sessionBootstrapReconciler) reconcile(sessions []cloudBootstrapSession) error {
+	var lease *checkpointLease
+	if r.safePoint != nil {
+		var err error
+		lease, err = r.safePoint.acquire()
+		if err != nil {
+			if errors.Is(err, errCheckpointAdmissionClosed) {
+				return fmt.Errorf("checkpoint preparation has closed bootstrap work: %w", sessionapi.ErrConflict)
+			}
+			return err
+		}
+		defer lease.release()
+	}
 	current, err := r.store.List()
 	if err != nil {
 		return fmt.Errorf("list local sessions: %w", err)
@@ -143,7 +159,8 @@ func (r sessionBootstrapReconciler) packagePathForDigest(digest string) (string,
 		if err == nil {
 			return path, nil
 		}
-		if r.materializer.bundleBase != "" {
+		concrete, ok := r.materializer.(*applyPackageMaterializer)
+		if !ok || concrete.bundleBase != "" {
 			return "", err
 		}
 	}

--- a/internal/telosd/session_bootstrap_test.go
+++ b/internal/telosd/session_bootstrap_test.go
@@ -2,11 +2,24 @@ package telosd
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/telos-org/telos/internal/sessionapi"
 )
+
+type blockingBootstrapMaterializer struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingBootstrapMaterializer) Ensure(context.Context, string) (string, error) {
+	close(m.started)
+	<-m.release
+	return "", errors.New("test materialization stopped")
+}
 
 type fakeReconcileStore struct {
 	sessions []sessionapi.Session
@@ -111,6 +124,45 @@ func TestSessionBootstrapReconcilerCreatesDesiredPackageSession(t *testing.T) {
 	}
 }
 
+func TestSessionBootstrapMaterializationParticipatesInCheckpointDrain(t *testing.T) {
+	safePoint := newTestCheckpointSafePoint(t)
+	materializer := &blockingBootstrapMaterializer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	reconciler := sessionBootstrapReconciler{
+		packageRoot:  t.TempDir(),
+		materializer: materializer,
+		store:        &fakeReconcileStore{},
+		safePoint:    safePoint,
+	}
+	reconcileDone := make(chan error, 1)
+	go func() {
+		reconcileDone <- reconciler.reconcile([]cloudBootstrapSession{{
+			CloudSessionID: testCheckpointSessionID,
+			Name:           "auth",
+			PackageDigest:  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}})
+	}()
+	select {
+	case <-materializer.started:
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap materializer did not start")
+	}
+
+	status, inFlight, err := safePoint.prepare(context.Background(), testCheckpointOperationID)
+	if err != nil || status != "timeout" || inFlight != 1 {
+		t.Fatalf("prepare: status=%q in_flight=%d err=%v", status, inFlight, err)
+	}
+	close(materializer.release)
+	if err := <-reconcileDone; err == nil {
+		t.Fatal("expected blocking test materializer error")
+	}
+	if _, err := reconciler.safePoint.acquire(); !errors.Is(err, errCheckpointAdmissionClosed) {
+		t.Fatalf("bootstrap admission after prepare timeout: got %v", err)
+	}
+}
+
 func TestSessionBootstrapMatchesCloudSessionNameBeforeSpecName(t *testing.T) {
 	digest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	specName := "auth-v2"
@@ -210,7 +262,7 @@ func TestSessionBootstrapCanBeDisabled(t *testing.T) {
 	t.Setenv("TELOS_PACKAGE_ROOT", t.TempDir())
 	store := &fakeReconcileStore{}
 
-	startSessionBootstrapReconciler(context.Background(), store, nil)
+	startSessionBootstrapReconciler(context.Background(), store, nil, nil)
 
 	if len(store.creates) != 0 || len(store.stops) != 0 {
 		t.Fatalf("expected disabled bootstrap to do nothing, creates=%#v stops=%#v", store.creates, store.stops)

--- a/internal/telosd/worker.go
+++ b/internal/telosd/worker.go
@@ -23,6 +23,10 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 	if err != nil {
 		return 1, err
 	}
+	safePoint, err := checkpointSafePointForWorker()
+	if err != nil {
+		return 1, fmt.Errorf("initialize checkpoint safe point: %w", err)
+	}
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(stop)
@@ -30,19 +34,46 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 	signal.Notify(wake, syscall.SIGUSR1)
 	defer signal.Stop(wake)
 
+	lease, stopped, err := waitForCheckpointAdmission(safePoint, wake, stop)
+	if err != nil {
+		return 1, err
+	}
+	if stopped {
+		return 0, nil
+	}
 	owner, err := sessionworker.AcquireOwnership(sessionDir, filepath.Join(sessionDir, "runner.log"))
 	if err != nil {
+		lease.release()
 		if errors.Is(err, sessionworker.ErrWorkerAlreadyRunning) {
 			return 0, nil
 		}
 		return 1, err
 	}
-	defer wakeParent(sessionDir)
-	defer clearRunner(sessionDir, os.Getpid())
-	defer owner.Release()
+	defer func() {
+		if lease == nil && safePoint != nil {
+			cleanupLease, _, cleanupErr := waitForCheckpointAdmission(safePoint, nil, nil)
+			if cleanupErr == nil {
+				lease = cleanupLease
+			}
+		}
+		finishCheckpointWork(lease, func() {
+			clearRunner(sessionDir, os.Getpid())
+			_ = owner.Release()
+			wakeParent(sessionDir)
+		})
+	}()
 
 	failures := 0
 	for {
+		if lease == nil {
+			lease, stopped, err = waitForCheckpointAdmission(safePoint, wake, stop)
+			if err != nil {
+				return 1, err
+			}
+			if stopped {
+				return 0, nil
+			}
+		}
 		manifest, err := LoadWorkerManifest(sessionDir)
 		if err != nil {
 			return 1, err
@@ -56,6 +87,8 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 			}
 			fmt.Fprintf(os.Stderr, "root session cycle failed: %v\n", err)
 			failures++
+			lease.release()
+			lease = nil
 			if waitForNextCycle(wake, stop, failureBackoff(failures)) {
 				return 0, nil
 			}
@@ -79,6 +112,8 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 			} else {
 				fmt.Fprintf(os.Stderr, "root session cycle failed: %s\n", result.GameResult)
 			}
+			lease.release()
+			lease = nil
 			if waitForNextCycle(wake, stop, failureBackoff(failures)) {
 				return 0, nil
 			}
@@ -96,12 +131,58 @@ func RunSessionWorker(sessionDir string, once bool) (int, error) {
 				if stopRequested(stop) {
 					return 0, nil
 				}
+				lease.release()
+				lease = nil
 				continue
 			}
 		}
+		lease.release()
+		lease = nil
 		if waitForNextCycle(wake, stop, controllerInterval(manifest.Interval)) {
 			return 0, nil
 		}
+	}
+}
+
+func finishCheckpointWork(lease *checkpointLease, cleanup func()) {
+	defer lease.release()
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+func waitForCheckpointAdmission(safePoint *checkpointSafePoint, wake, stop <-chan os.Signal) (*checkpointLease, bool, error) {
+	if safePoint == nil {
+		return nil, false, nil
+	}
+	for {
+		lease, err := safePoint.acquire()
+		if err == nil {
+			return lease, false, nil
+		}
+		if !errors.Is(err, errCheckpointAdmissionClosed) {
+			return nil, false, fmt.Errorf("acquire checkpoint work lease: %w", err)
+		}
+		if waitForCheckpointRetry(safePoint.pollInterval, wake, stop) {
+			return nil, true, nil
+		}
+	}
+}
+
+// Go 1.23 and later timer channels are synchronous. Stopping and then draining
+// a timer can therefore block forever if the timer became ready concurrently
+// but the signal case won the select.
+func waitForCheckpointRetry(delay time.Duration, wake, stop <-chan os.Signal) bool {
+	timer := time.NewTimer(delay)
+	select {
+	case <-timer.C:
+		return false
+	case <-wake:
+		timer.Stop()
+		return false
+	case <-stop:
+		timer.Stop()
+		return true
 	}
 }
 


### PR DESCRIPTION
## Summary

- add authenticated, operator-only checkpoint prepare and resume endpoints
- bind every pause to an exact session and operation owner
- drain session mutations, bootstrap, worker supervision, worker cycles, and terminal cleanup before reporting prepared
- persist fail-closed checkpoint ownership across restarts
- advertise checkpoint_safe_point through the canonical health capabilities list

## Occam boundary

This uses the existing telosd server, file-backed state, worker launcher, and authorization model. It adds no daemon, scheduler, ORM, or general job framework.

Checkpoint files and tools running under the same Unix UID remain one documented trusted boundary. The filesystem checks protect against crashes, loss, malformed state, and accidental path substitution; they do not claim isolation from a malicious same-UID process.

## Safety properties

- stale operation A cannot resume operation B
- a completed operation cannot pause the runtime again
- missing or malformed initialized state fails closed
- active legacy workers block preparation until upgraded or fully exited
- worker cleanup remains covered by its work lease
- worker readiness is checked again immediately before prepared
- Go 1.26 timer shutdown does not drain a stopped synchronous timer

## Validation

- go test ./... -count=1
- race tests for telosd, sessionworker, and sessionapi
- go vet ./...
- bazel test //...: 16 tests passed
- focused former-blocker tests repeated under the race detector
- independent Occam-focused adversarial review: approved

## Rollout dependency

Publish an immutable runtime release from this PR before enabling Cloud snapshot capture. Cloud must continue to gate capture on the live checkpoint_safe_point capability.