### PR TITLE
docs(readme): explain goal-oriented programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,25 +71,46 @@ After reviewing the plan, apply it:
 telos apply SPEC.md
 ```
 
-`apply` returns a session ID when the revision is accepted for work, not when it
-is complete. Follow the session and inspect its evidence:
+`apply` returns a session ID when the revision is accepted for work. The work
+then continues in the background.
+
+After applying, use `telos list` to find the session and `telos describe` to
+check its status:
+
+```console
+$ telos list
+NAME           STATUS  SESSION
+hello-service  ready   sess_123
+
+$ telos describe sess_123
+Name      hello-service
+Status    ready
+Session   sess_123
+Revision  sha256:abc123...
+Service   https://hello-service.example.com
+```
+
+The status is `working` while Telos reconciles the Goal. `ready` means the
+displayed revision is running and has passed every required rubric and
+independent verification. If a session needs attention or fails, `describe`
+also shows a `Reason`.
+
+Follow agent updates and verification evidence with:
 
 ```bash
-telos describe SESSION_ID
 telos logs SESSION_ID
 ```
 
-Ready means the running software produced from the exact specification and
-locked skill revisions passed every required rubric and independent
-verification.
-
-To change an existing Goal, edit `SPEC.md`, bump its version, and apply the new
+To update a live Goal, edit `SPEC.md`, bump its version, and apply the new
 revision to the same session:
 
 ```bash
 telos plan SPEC.md --session SESSION_ID
 telos apply SPEC.md --session SESSION_ID
 ```
+
+The agent system picks up the delta and incrementally reconciles the live
+software toward the new desired state.
 
 Read the [Telos documentation](https://usetelos.ai/docs) for the complete
 workflow.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # telos
 
-`telos` is a goal-oriented programming system.
+`telos` is a goal-oriented programming system. It turns a spec into running
+software, then verifies the result.
 
 ## Install
 
@@ -35,25 +36,28 @@ Cloud.
 
 The Goal specification (`SPEC.md`) is the main entrypoint to a `telos` program.
 
-Skills are modular libraries imported by a spec. Load them from a local path or
-pin them to an immutable registry version.
-
-An illustrative Goal spec:
+A minimal `SPEC.md`:
 
 ```markdown
 ---
 name: hello-service
 version: 0.1.0
 platform: cloud
-skills:
-  - skills/postgres
-  - "@scope/service-readiness:1.0.0*"
 ---
 
 # Goal
 
 Run an HTTP service with persistent Postgres storage. Keep `/healthz`
 available, preserve stored data across restarts, and return evidence for both.
+```
+
+Skills are modular libraries imported by a spec. Load them from a local path or
+pin them to an immutable registry version:
+
+```yaml
+skills:
+  - path/to/postgres-skill
+  - "@scope/service-readiness:1.0.0*"
 ```
 
 **A trailing `*` makes a skill a required rubric.** Use starred skills for
@@ -65,7 +69,7 @@ starred rubric in an independent evaluation before Ready.
 `telos apply` reconciles a persistent Goal toward the desired state in
 `SPEC.md`.
 
-First, preview the contract without changing the Goal or its target state:
+First, preview the spec without changing the Goal or its target state:
 
 ```bash
 telos plan SPEC.md
@@ -128,6 +132,8 @@ one piece of work that does not need the persistent lifecycle of `telos apply`.
 
 Local runs use the open source
 [pi coding agent](https://github.com/earendil-works/pi):
+
+For a spec with `platform: local`:
 
 ```bash
 npm install -g @earendil-works/pi-coding-agent

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ Revision  sha256:abc123...
 Service   https://hello-service.example.com
 ```
 
-The status is `working` while Telos reconciles the Goal. `ready` means the
-displayed revision is running and has passed every required rubric and
-independent verification. If a session needs attention or fails, `describe`
-also shows a `Reason`.
+Status values:
+
+- `working` — reconciliation is in progress.
+- `ready` — the displayed revision is running and verified.
+- `needs_attention` or `failed` — check `Reason` for details.
 
 Follow agent updates and verification evidence with:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ for local runs.
 
 ### Via your coding agent
 
-Give your coding agent the same setup prompt used on
-[usetelos.ai](https://usetelos.ai):
-
 ```text
 Set up Telos.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ telos login
 
 The installer supports macOS and Linux on amd64 and arm64.
 
-`telos login` signs in to Telos Cloud and is required for `telos apply`.
+`telos login` signs in to Telos Cloud and is required when `telos apply` targets
+Cloud.
 
 ## Get Started
 
@@ -36,6 +37,8 @@ The Goal specification (`SPEC.md`) is the main entrypoint to a `telos` program.
 
 Skills are modular libraries imported by a spec. Load them from a local path or
 pin them to an immutable registry version.
+
+An illustrative Goal spec:
 
 ```markdown
 ---
@@ -54,13 +57,13 @@ available, preserve stored data across restarts, and return evidence for both.
 ```
 
 **A trailing `*` makes a skill a required rubric.** Use starred skills for
-quality, process, or subjective requirements. Ready requires each one to pass
-an independent evaluation.
+quality, process, or subjective requirements. The revision must pass every
+starred rubric in an independent evaluation before Ready.
 
 ## Apply
 
-`telos apply` continuously reconciles a persistent Goal toward the desired
-state in `SPEC.md`.
+`telos apply` reconciles a persistent Goal toward the desired state in
+`SPEC.md`.
 
 First, preview the contract without changing the Goal or its target state:
 
@@ -93,7 +96,7 @@ Revision  sha256:abc123...
 Service   https://hello-service.example.com
 ```
 
-Status values:
+Common Cloud statuses:
 
 - `working` — reconciliation is in progress.
 - `ready` — the displayed revision is running and verified.
@@ -113,8 +116,7 @@ telos plan SPEC.md --session SESSION_ID
 telos apply SPEC.md --session SESSION_ID
 ```
 
-`telos` applies the delta and incrementally reconciles the live software toward
-the new desired state.
+`telos` reconciles the existing live software toward the new desired state.
 
 Read the [Telos documentation](https://usetelos.ai/docs) for the complete
 workflow.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 `telos` is a goal-oriented programming system.
 
 > Work with your coding agent to write and iterate on your Goal spec, and have
-> the agent drive the `telos` system for you.
+> the agent drive `telos` for you. The CLI is optimized for the agent
+> experience.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # telos
 
-`telos` is a goal-oriented programming system. You describe what should remain
-true; agents implement the current revision, and an independent verifier checks
-the result against the Goal.
-
 ## Install
 
 ### Via the CLI
@@ -20,11 +16,13 @@ The installer supports macOS and Linux on amd64 and arm64.
 Give your coding agent the same setup prompt used on
 [usetelos.ai](https://usetelos.ai):
 
-> Set up Telos.
->
-> - Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
-> - Run `telos login` to sign in to Telos Cloud.
-> - Read the installed `telos-cli` skill to get started.
+```text
+Set up Telos.
+
+- Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
+- Run `telos login` to sign in to Telos Cloud.
+- Read the installed `telos-cli` skill to get started.
+```
 
 ## Specifications
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Set up Telos.
 
 The Goal specification (`SPEC.md`) is the main entrypoint to a `telos` program.
 
-Skills are modular libraries imported by the specification. They package
-reusable instructions, references, scripts, and assets, and can be loaded from
-a local path or an immutable registry reference.
+Skills are modular libraries imported by a spec. Load them from a local path or
+pin them to an immutable registry version.
 
 ```markdown
 ---
@@ -114,8 +113,8 @@ telos plan SPEC.md --session SESSION_ID
 telos apply SPEC.md --session SESSION_ID
 ```
 
-The agent system picks up the delta and incrementally reconciles the live
-software toward the new desired state.
+`telos` applies the delta and incrementally reconciles the live software toward
+the new desired state.
 
 Read the [Telos documentation](https://usetelos.ai/docs) for the complete
 workflow.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Common Cloud statuses:
 - `ready` — the displayed revision is running and verified.
 - `needs_attention` or `failed` — check `Reason` for details.
 
-Follow agent updates and verification evidence with:
+Follow agent updates with:
 
 ```bash
 telos logs SESSION_ID

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ Skills are modular libraries imported by the specification. They package
 reusable instructions, references, scripts, and assets, and can be loaded from
 a local path or an immutable registry reference.
 
-Starred skills set quality, process, or other subjective bars. An independent
-evaluation uses them as required rubrics, and each must pass before the revision
-becomes Ready.
-
 ```markdown
 ---
 name: hello-service
@@ -57,6 +53,10 @@ skills:
 Run an HTTP service with persistent Postgres storage. Keep `/healthz`
 available, preserve stored data across restarts, and return evidence for both.
 ```
+
+**A trailing `*` makes a skill a required rubric.** Use starred skills for
+quality, process, or subjective requirements. Ready requires each one to pass
+an independent evaluation.
 
 ## Apply
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telos
 
+`telos` is a goal-oriented programming system.
+
 ## Install
 
 ### Via the CLI
@@ -26,10 +28,16 @@ Set up Telos.
 
 ## Specifications
 
-`SPEC.md` is the main entrypoint to a `telos` program. Its frontmatter declares
-the program's name, version, target platform, and imported skills. Its body
-states the Goal: the observable outcome, important constraints, state that must
-survive, and evidence that counts as success.
+`SPEC.md` is the `main` entrypoint to a `telos` program. It declares the Goal,
+the target platform, and the evidence required for success.
+
+Skills are modular libraries imported by the specification. They package
+reusable instructions, references, scripts, and assets, and can be loaded from
+a local path or an immutable registry reference.
+
+A starred skill is also a required evaluation rubric. The verifier evaluates
+the result against every starred skill, and the revision cannot become Ready
+until all of them pass.
 
 ```markdown
 ---
@@ -47,15 +55,7 @@ Run an HTTP service with persistent Postgres storage. Keep `/healthz`
 available, preserve stored data across restarts, and return evidence for both.
 ```
 
-Skills are modular libraries for a Goal. Each skill is rooted at `SKILL.md` and
-can carry reusable instructions, references, scripts, and assets. A spec can
-import a skill from a relative path or by immutable registry reference.
-
-A trailing `*` makes the skill a required evaluation rubric. The verifier must
-evaluate the result against every starred skill, and the revision cannot become
-Ready while any required rubric fails.
-
-## Declarative application
+## Apply
 
 `telos apply` makes the approved specification the desired state of a
 persistent Goal. It hands the exact `SPEC.md` and its resolved skills to

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 `telos` is a goal-oriented programming system.
 
+**The expected workflow is human ↔ interactive coding agent ↔ `telos`. Your
+coding agent should drive the CLI; `telos` is optimized for the agent
+experience.**
+
 ## Install
 
 ### Via the CLI

--- a/README.md
+++ b/README.md
@@ -32,16 +32,15 @@ Set up Telos.
 >
 > The CLI is optimized for the agent experience.
 
-`SPEC.md` is the `main` entrypoint to a `telos` program. It declares the Goal,
-the target platform, and the evidence required for success.
+The Goal specification (`SPEC.md`) is the main entrypoint to a `telos` program.
 
 Skills are modular libraries imported by the specification. They package
 reusable instructions, references, scripts, and assets, and can be loaded from
 a local path or an immutable registry reference.
 
-A starred skill is also a required evaluation rubric. The verifier evaluates
-the result against every starred skill, and the revision cannot become Ready
-until all of them pass.
+Starred skills set quality, process, or other subjective bars. An independent
+evaluation uses them as required rubrics, and each must pass before the revision
+becomes Ready.
 
 ```markdown
 ---

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 ## Install
 
+### Via your coding agent
+
+```text
+Set up Telos.
+
+- Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
+- Run `telos login` to sign in to Telos Cloud.
+- Read the installed `telos-cli` skill to get started.
+```
+
 ### Via the CLI
 
 ```bash
@@ -14,16 +24,6 @@ telos login
 The installer supports macOS and Linux on amd64 and arm64.
 
 `telos login` signs in to Telos Cloud and is required for `telos apply`.
-
-### Via your coding agent
-
-```text
-Set up Telos.
-
-- Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
-- Run `telos login` to sign in to Telos Cloud.
-- Read the installed `telos-cli` skill to get started.
-```
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ available, preserve stored data across restarts, and return evidence for both.
 
 ## Apply
 
-`telos apply` makes the approved specification the desired state of a
-persistent Goal. It hands the exact `SPEC.md` and its resolved skills to
-background agents that implement, deploy, and verify the revision.
+`telos apply` continuously reconciles a persistent Goal toward the desired
+state in `SPEC.md`.
 
 First, preview the contract without changing the Goal or its target state:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ telos login
 
 The installer supports macOS and Linux on amd64 and arm64.
 
-`telos login` signs in to Telos Cloud and is required for `telos apply`, but not
-for local runs.
+`telos login` signs in to Telos Cloud and is required for `telos apply`.
 
 ### Via your coding agent
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # telos
 
-`telos` is a goal-oriented programming system. It turns a spec into running
-software.
+`telos` is a goal-oriented programming system.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `telos` is a goal-oriented programming system.
 
-> Telos works best as a collaboration between you, your coding agent, and
-> `telos`. You define the Goal and approve changes; your agent handles the CLI.
+> Work with your coding agent to write and iterate on your Goal spec, and have
+> the agent drive the `telos` system for you.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 `telos` is a goal-oriented programming system.
 
-> Work with your coding agent to write and iterate on your Goal spec, and have
-> the agent drive `telos` for you. The CLI is optimized for the agent
-> experience.
-
 ## Install
 
 ### Via the CLI
@@ -29,7 +25,12 @@ Set up Telos.
 - Read the installed `telos-cli` skill to get started.
 ```
 
-## Specifications
+## Get Started
+
+> Work with your coding agent to write and iterate on your Goal spec, and have
+> the agent drive `telos` for you.
+>
+> The CLI is optimized for the agent experience.
 
 `SPEC.md` is the `main` entrypoint to a `telos` program. It declares the Goal,
 the target platform, and the evidence required for success.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 `telos` is a goal-oriented programming system.
 
-**The expected workflow is human ↔ interactive coding agent ↔ `telos`. Your
-coding agent should drive the CLI; `telos` is optimized for the agent
-experience.**
+> Telos works best as a collaboration between you, your coding agent, and
+> `telos`. You define the Goal and approve changes; your agent handles the CLI.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Telos
+# telos
 
-**Declarative software.**
-
-Describe the software you want in `SPEC.md`. `telos apply` turns that contract
-into verified running software.
+`telos` is a goal-oriented programming system. You describe what should remain
+true; agents implement the current revision, and an independent verifier checks
+the result against the Goal.
 
 ## Install
+
+### Via the CLI
 
 ```bash
 curl -fsSL https://usetelos.ai/install.sh | sh
@@ -13,57 +14,94 @@ telos login
 ```
 
 The installer supports macOS and Linux on amd64 and arm64.
-It also installs the canonical
-[`@telos/telos-cli`](skills/telos-cli/SKILL.md) agent skill.
 
-## Prompt
+### Via your coding agent
 
-Give your coding agent an outcome:
+Give your coding agent the same setup prompt used on
+[usetelos.ai](https://usetelos.ai):
 
-> Use Telos for this Goal: &lt;what should remain true&gt;. Install and sign in if
-> needed. Draft the smallest verifiable `SPEC.md`, then show me `telos plan`.
-> After I approve, run `telos apply` and return the evidence when it reaches
-> Ready.
+> Set up Telos.
+>
+> - Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
+> - Run `telos login` to sign in to Telos Cloud.
+> - Read the installed `telos-cli` skill to get started.
 
-## Specification
+## Specifications
 
-A specification describes the outcome, important constraints, and evidence of
-success. It does not prescribe the implementation.
+`SPEC.md` is the main entrypoint to a `telos` program. Its frontmatter declares
+the program's name, version, target platform, and imported skills. Its body
+states the Goal: the observable outcome, important constraints, state that must
+survive, and evidence that counts as success.
 
 ```markdown
 ---
 name: hello-service
 version: 0.1.0
 platform: cloud
+skills:
+  - skills/postgres
+  - "@scope/service-readiness:1.0.0*"
 ---
 
 # Goal
 
-Run an HTTP service with persistent Postgres storage and a verified `/healthz`
-endpoint.
+Run an HTTP service with persistent Postgres storage. Keep `/healthz`
+available, preserve stored data across restarts, and return evidence for both.
 ```
 
-## Apply
+Skills are modular libraries for a Goal. Each skill is rooted at `SKILL.md` and
+can carry reusable instructions, references, scripts, and assets. A spec can
+import a skill from a relative path or by immutable registry reference.
+
+A trailing `*` makes the skill a required evaluation rubric. The verifier must
+evaluate the result against every starred skill, and the revision cannot become
+Ready while any required rubric fails.
+
+## Declarative application
+
+`telos apply` makes the approved specification the desired state of a
+persistent Goal. It hands the exact `SPEC.md` and its resolved skills to
+background agents that implement, deploy, and verify the revision.
+
+First, preview the contract without changing the Goal or its target state:
 
 ```bash
 telos plan SPEC.md
+```
+
+After reviewing the plan, apply it:
+
+```bash
 telos apply SPEC.md
+```
+
+`apply` returns a session ID when the revision is accepted for work, not when it
+is complete. Follow the session and inspect its evidence:
+
+```bash
 telos describe SESSION_ID
 telos logs SESSION_ID
 ```
 
-`plan` previews the contract without changing the Goal or target state. `apply`
-creates or updates a persistent Goal in Telos Cloud. Ready means the exact
-revision passed verification and is running.
+Ready means the running software produced from the exact specification and
+locked skill revisions passed every required rubric and independent
+verification.
+
+To change an existing Goal, edit `SPEC.md`, bump its version, and apply the new
+revision to the same session:
+
+```bash
+telos plan SPEC.md --session SESSION_ID
+telos apply SPEC.md --session SESSION_ID
+```
 
 Read the [Telos documentation](https://usetelos.ai/docs) for the complete
 workflow.
 
 ## Local runs
 
-`telos run` executes a bounded Goal and stops. For a human, it is an imperative
-tool for completing one piece of work within a limit. For an agent, it is a
-declarative subsystem for satisfying a bounded subgoal and returning evidence.
+`telos run` executes a bounded Goal in a local workspace and stops. Use it for
+one piece of work that does not need the persistent lifecycle of `telos apply`.
 
 Local runs use the open source
 [pi coding agent](https://github.com/earendil-works/pi):
@@ -74,17 +112,6 @@ pi # use /login to connect a model provider
 telos run SPEC.md --workspace . --until 3
 telos describe SESSION_ID
 telos logs SESSION_ID
-```
-
-Callers supply the Goal and observe its state and evidence through `describe`
-and `logs`; the implementation remains a black box.
-
-## Develop
-
-```bash
-go test ./...
-go build ./cmd/telos ./cmd/telosd
-bazel test //...
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # telos
 
 `telos` is a goal-oriented programming system. It turns a spec into running
-software, then verifies the result.
+software.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ telos login
 
 The installer supports macOS and Linux on amd64 and arm64.
 
+`telos login` signs in to Telos Cloud and is required for `telos apply`, but not
+for local runs.
+
 ### Via your coding agent
 
 Give your coding agent the same setup prompt used on
@@ -111,6 +114,8 @@ telos run SPEC.md --workspace . --until 3
 telos describe SESSION_ID
 telos logs SESSION_ID
 ```
+
+`--until 3` stops the run after at most three review cycles.
 
 ## License
 


### PR DESCRIPTION
## Summary

- introduce `telos` as a goal-oriented programming system
- split installation into direct CLI and coding-agent paths using the web setup prompt
- explain `SPEC.md` as the main entrypoint, skills as modular libraries, and starred skills as required evaluation rubrics
- document the declarative application lifecycle and keep bounded local runs secondary
- remove the development section

## Verification

- `git diff --check`
- documentation-only change; no runtime tests needed