### PR TITLE
Allow Pi provider-only model overrides

### DIFF
--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -362,6 +362,9 @@ func validatePiModel(model string) error {
 	if !configured {
 		return nil
 	}
+	if len(provider.Models) == 0 {
+		return nil
+	}
 	for _, configuredModel := range provider.Models {
 		if configuredModel.ID == modelID {
 			return nil

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -258,6 +258,29 @@ func TestValidatePiModelAllowsBuiltInProviderWithoutConfig(t *testing.T) {
 	}
 }
 
+func TestValidatePiModelAllowsProviderOverrideWithoutModelCatalog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	modelsPath := filepath.Join(home, ".pi", "agent", "models.json")
+	if err := os.MkdirAll(filepath.Dir(modelsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	modelsJSON := `{
+  "providers": {
+    "openai-codex": {
+      "baseUrl": "https://gateway.example.test/chatgpt"
+    }
+  }
+}`
+	if err := os.WriteFile(modelsPath, []byte(modelsJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validatePiModel("openai-codex/gpt-5.6-sol"); err != nil {
+		t.Fatalf("provider overrides preserve Pi's built-in model catalog: %v", err)
+	}
+}
+
 func TestValidatePiModelMalformedConfigIsNonFatalForNonDefault(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Pi preserves its built-in model catalog when `models.json` only overrides provider settings such as `baseUrl` and `apiKey`. Telos currently rejects those valid configurations before Pi starts because it interprets an omitted model list as an empty authoritative catalog.

This keeps strict validation for explicit non-empty custom catalogs while deferring provider-only overrides to Pi.

Validation:
- `go test ./internal/cli`
- `go build ./...`
- `go vet ./...`

The full local suite otherwise passed except two pre-existing registry integration tests returning HTTP 404 (`TestPrepareRegistrySkillsCachesAndPinsExactVersion`, `TestCompilePlanSpecLeavesPersistentRegistryCacheUntouched`).