### PR TITLE
docs(skill): document the lifecycle and inference, and rewrite the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,8 @@ workflow.
 `telos run` executes a bounded Goal in a local workspace and stops. Use it for
 one piece of work that does not need the persistent lifecycle of `telos apply`.
 
-Local runs use the open source
-[pi coding agent](https://github.com/earendil-works/pi):
-
-For a spec with `platform: local`:
+Local runs execute through [pi](https://github.com/earendil-works/pi), the open
+source coding agent Telos drives. For a spec with `platform: local`:
 
 ```bash
 npm install -g @earendil-works/pi-coding-agent

--- a/README.md
+++ b/README.md
@@ -26,28 +26,30 @@ The installer supports macOS and Linux on amd64 and arm64.
 `telos login` signs in to Telos Cloud and is required when `telos apply` targets
 Cloud.
 
-## Get Started
+## Get started
 
 > Work with your coding agent to write and iterate on your Goal spec, and have
 > the agent drive `telos` for you.
 >
 > The CLI is optimized for the agent experience.
 
-The Goal specification (`SPEC.md`) is the main entrypoint to a `telos` program.
+The Goal specification (`SPEC.md`) is the main entry point to a `telos`
+program. This example creates a persistent Cloud Goal; use an explicit context
+so the plan and the apply address the same workspace.
 
 A minimal `SPEC.md`:
 
 ```markdown
 ---
-name: hello-service
+name: reading-list
 version: 0.1.0
 platform: cloud
 ---
 
 # Goal
 
-Run an HTTP service with persistent Postgres storage. Keep `/healthz`
-available, preserve stored data across restarts, and return evidence for both.
+Run a public reading-list service. Books remain available when the application
+restarts, and the result includes evidence of the write–restart–read sequence.
 ```
 
 Skills are modular libraries imported by a spec. Load them from a local path or
@@ -61,7 +63,7 @@ skills:
 
 **A trailing `*` makes a skill a required rubric.** Use starred skills for
 quality, process, or subjective requirements. The revision must pass every
-starred rubric in an independent evaluation before Ready.
+starred rubric in an independent evaluation before `ready`.
 
 ## Apply
 
@@ -71,58 +73,65 @@ starred rubric in an independent evaluation before Ready.
 First, preview the spec without changing the Goal or its target state:
 
 ```bash
-telos plan SPEC.md
+telos plan SPEC.md --context personal
 ```
 
 After reviewing the plan, apply it:
 
 ```bash
-telos apply SPEC.md
+telos apply SPEC.md --context personal
 ```
 
 `apply` returns a session ID when the revision is accepted for work. The work
 then continues in the background.
 
 After applying, use `telos list` to find the session and `telos describe` to
-check its status:
+check its status. Once the public-route probe succeeds, `describe` also prints
+the Service URL:
 
 ```console
-$ telos list
+$ telos list --context personal
 NAME           STATUS  SESSION
-hello-service  ready   sess_123
+reading-list   ready   sess_123
 
-$ telos describe sess_123
-Name      hello-service
+$ telos describe sess_123 --context personal
+Name      reading-list
 Status    ready
 Session   sess_123
 Revision  sha256:abc123...
-Service   https://hello-service.example.com
+Context   personal
+Service   https://reading-list.example.com
 ```
 
 Common Cloud statuses:
 
 - `working` — reconciliation is in progress.
-- `ready` — the displayed revision is running and verified.
-- `needs_attention` or `failed` — check `Reason` for details.
+- `ready` — current managed runtimes completed reconciliation and the latest verification passed.
+- `needs_attention` — check `Reason` for the decision that stopped reconciliation.
+- `stopped` — the deployment was stopped or deleted.
+
+For a service, exercise the live behavior in the spec before treating the Goal
+as complete.
 
 Follow agent updates with:
 
 ```bash
-telos logs SESSION_ID
+telos logs SESSION_ID --context personal
 ```
 
 To update a live Goal, edit `SPEC.md`, bump its version, and apply the new
 revision to the same session:
 
 ```bash
-telos plan SPEC.md --session SESSION_ID
-telos apply SPEC.md --session SESSION_ID
+telos plan SPEC.md --session SESSION_ID --context personal
+telos apply SPEC.md --session SESSION_ID --context personal
 ```
 
 `telos` reconciles the existing live software toward the new desired state.
 
-Read the [Telos documentation](https://usetelos.ai/docs) for the complete
-workflow.
+Continue with the worked [persistent Goal](skills/telos-cli/references/use-telos.md)
+or read [the lifecycle](skills/telos-cli/references/lifecycle.md) to understand
+sessions, revisions, states, and evidence.
 
 ## Local runs
 
@@ -130,17 +139,17 @@ workflow.
 one piece of work that does not need the persistent lifecycle of `telos apply`.
 
 Local runs execute through [pi](https://github.com/earendil-works/pi), the open
-source coding agent Telos drives. For a spec with `platform: local`:
+source coding agent Telos drives. Install pi once, then open it to authenticate
+with `/login`:
 
 ```bash
 npm install -g @earendil-works/pi-coding-agent
-pi # use /login to connect a model provider
-telos run SPEC.md --workspace . --until 3
-telos describe SESSION_ID
-telos logs SESSION_ID
+pi
 ```
 
-`--until 3` stops the run after at most three review cycles.
+Exit pi after authentication. [Bounded runs](skills/telos-cli/references/bounded-runs.md)
+provides a complete local spec, an explicit stopping bound, and the commands to
+inspect and extract the accepted workspace checkpoint.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ First, preview the spec without changing the Goal or its target state:
 telos plan SPEC.md --context personal
 ```
 
-After reviewing the plan, apply it:
+After reviewing and approving the resolved action and context, apply it:
 
 ```bash
 telos apply SPEC.md --context personal
@@ -103,12 +103,9 @@ Context   personal
 Service   https://reading-list.example.com
 ```
 
-Common Cloud statuses:
-
-- `working` — reconciliation is in progress.
-- `ready` — current managed runtimes completed reconciliation and the latest verification passed.
-- `needs_attention` — check `Reason` for the decision that stopped reconciliation.
-- `stopped` — the deployment was stopped or deleted.
+Cloud reports `working`, `ready`, `needs_attention`, or `stopped`.
+[The lifecycle](skills/telos-cli/references/lifecycle.md) is authoritative for
+their revision, route-publication, and compatibility semantics.
 
 For a service, exercise the live behavior in the spec before treating the Goal
 as complete.

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -26,7 +26,9 @@ Read only the reference needed for the current task:
 
 - [Use Telos](references/use-telos.md) for the concise end-to-end workflow
 - [Goals and specifications](references/goals.md)
+- [The Goal lifecycle](references/lifecycle.md) for states, revisions, and evidence
 - [Telos Cloud](references/cloud.md)
+- [Models and inference](references/inference.md)
 - [Packages and skills](references/packages-and-skills.md)
 - [Nested Goals](references/nested-goals.md)
 - [Troubleshooting](references/troubleshooting.md)

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -88,6 +88,12 @@ declarative subgoal. Inspect it with the same `describe` and `logs` commands.
   public behavior when the contract exposes it.
 - Do not expose tokens, runtime allocation IDs, provider details, or other
   control-plane internals in user-facing artifacts.
+- Do not pipe and execute the installer when the user only asked for advice.
+  Show the command; run it when installation is part of the authorized task.
+- Launch the fewest child Goals needed and inspect their results before
+  creating more. Avoid recursive fan-out.
+- Give child work an observable deliverable and a finite cycle, time, or cost
+  bound. The parent integrates and verifies what a child returns.
 
 ## Handoff
 

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telos-cli
-description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, cloud login and context, session inspection, publishing or pulling packages and skills, nested child goals, and Telos troubleshooting.
+description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud login and context, session inspection, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
 metadata:
   registry: "@telos/telos-cli"
   quickstart_prompt: "assets/quickstart-prompt.txt"
@@ -10,14 +10,16 @@ metadata:
 
 # Telos CLI
 
-Telos turns a `SPEC.md` into either a persistent Goal or a bounded run. The
-spec is the executable contract: it describes the outcome and its evidence,
-while Telos implements and verifies a revision that satisfies it.
+Telos works from a `SPEC.md`: an authored contract for an observable outcome
+and the evidence that proves it. `apply` gives that outcome a persistent Cloud
+identity; `run` executes bounded local work. See
+[The Goal lifecycle](references/lifecycle.md) for the relationship between a
+Goal, its spec, revisions, session, and deployment.
 
-## Start with the live system
+## Before you act
 
-Read the repository's `AGENTS.md` and inspect the relevant code before drafting
-the Goal. Then check the installed CLI:
+Read the repository's `AGENTS.md`, inspect the relevant code, and check the
+installed CLI before drafting the Goal:
 
 ```bash
 telos --version
@@ -25,7 +27,7 @@ telos <command> --help
 ```
 
 If Telos is absent, read [Install Telos](references/install.md). Cloud work also
-needs an authenticated account and an explicit target:
+needs an authenticated account and a confirmed context:
 
 ```bash
 telos login
@@ -34,75 +36,95 @@ telos config
 
 Choose the lifecycle that matches the requested outcome:
 
-| Lifecycle | Command | Use it for |
+| Lifecycle | Command | Result |
 | --- | --- | --- |
-| Persistent Goal | `telos apply` | Software that should retain identity and evolve across revisions. |
-| Bounded run | `telos run` | One piece of work that ends at a cycle, time, or cost limit. |
-
-Read the reference that matches the task:
-
-- [Use Telos](references/use-telos.md) for the end-to-end workflow
-- [Goals and specifications](references/goals.md) for writing `SPEC.md`
-- [The Goal lifecycle](references/lifecycle.md) for states, revisions, and evidence
-- [Telos Cloud](references/cloud.md) for contexts and managed deployments
-- [Models and inference](references/inference.md) for Cloud and local model selection
-- [Packages and skills](references/packages-and-skills.md) for the registry
-- [Nested Goals](references/nested-goals.md) for bounded child work
-- [Troubleshooting](references/troubleshooting.md) for failed or stalled work
+| Persistent Goal | `telos apply` | One Cloud session and deployment that evolve across revisions. |
+| Bounded run | `telos run` | A local session that stops at its cycle, time, or cost bound. |
 
 ## Apply a persistent Goal
 
-Write the smallest spec that states the observable outcome, important
-constraints, and evidence of success. Preview the contract before applying it:
+Before authoring a Cloud Goal, read [Telos Cloud](references/cloud.md) and
+confirm that its delivery, storage, and external-service needs fit the managed
+runtime.
+
+1. Write the smallest `platform: cloud` spec that states the outcome,
+   meaningful constraints, and observable acceptance evidence.
+2. Choose the Cloud context explicitly and preview without changing remote
+   state. Replace `CONTEXT` with `personal` or the intended `@team-handle`:
+
+   ```bash
+   telos plan SPEC.md --context CONTEXT
+   ```
+
+3. Confirm that the plan shows the intended target and context, then apply it:
+
+   ```bash
+   telos apply SPEC.md --context CONTEXT
+   ```
+
+4. Capture the session ID and revision digest from the receipt. Observe that
+   session until the same revision becomes `ready`, or until its state and
+   reason require a decision:
+
+   ```bash
+   telos describe SESSION_ID --context CONTEXT --json
+   telos logs SESSION_ID --context CONTEXT
+   ```
+
+5. Verify the live behavior promised by the spec. Submission, a running
+   process, and old green evidence are not completion of the current revision.
+
+Revise the same Goal by editing `SPEC.md`, bumping its version, and applying to
+the existing session:
 
 ```bash
-telos plan SPEC.md
-telos apply SPEC.md
+telos plan SPEC.md --session SESSION_ID --context CONTEXT
+telos apply SPEC.md --session SESSION_ID --context CONTEXT
 ```
 
-`apply` returns a session ID as soon as Cloud accepts the revision. Follow that
-session until the matching revision becomes `ready`, or until the displayed
-state and reason call for a new decision:
-
-```bash
-telos describe SESSION_ID --json
-telos logs SESSION_ID
-```
-
-When the Goal exposes a service, verify the live service as well as the Telos
-state. A later revision uses the same session:
-
-```bash
-telos plan SPEC.md --session SESSION_ID
-telos apply SPEC.md --session SESSION_ID
-```
+[Use Telos](references/use-telos.md) follows this loop with one service.
+[The Goal lifecycle](references/lifecycle.md) gives a bounded observation
+pattern and explains every reported state.
 
 ## Run bounded work
 
-`run` executes one Goal in a local workspace and stops at its bound:
+`run` requires a `platform: local` spec and a cycle, time, or cost bound suited
+to the task:
 
 ```bash
-telos run SPEC.md --workspace . --until 3
+telos run REPORT_SPEC.md --workspace . --until 3
 ```
 
-Inside a Telos session, the same command creates a bounded child Goal. Its
-session is inspected with `describe` and `logs` like any other run.
+Read [Bounded runs](references/bounded-runs.md) for the complete local workflow.
+Inside a Telos session, the same command creates a linked child session; see
+[Nested Goals](references/nested-goals.md).
 
 ## Command effects
 
-- `plan`, `list`, `describe`, and `logs` inspect state.
-- `get` and `pull` materialize local files. `login`, `logout`, and
-  `config --context` change local authentication or configuration.
-- `run`, `apply`, `push`, and `delete` change execution or registry state and
-  may spend resources. Their target and mutation must be part of the user's
-  request.
-- Package versions are immutable; changed content receives a new version.
-- Completion is an observed state, not a successful submission. For managed
-  Goals, it is `ready` for the current revision plus any live behavior promised
-  by the spec.
+| Effect | Commands |
+| --- | --- |
+| Inspect state | `plan`, `list`, `describe`, `logs` |
+| Materialize files or change local configuration | `get`, `pull`, `login`, `logout`, `config --context`, `config --model` |
+| Start bounded local execution | `run` |
+| Publish, update, spend, or stop remote work | `apply`, `push`, `delete` |
+
+Resolve the target and context before a remote mutation. Package versions are
+immutable, so changed content receives a new version.
 
 ## Return the result
 
-Report the spec, target, session ID, current revision and state, and the
-evidence that supports the result. Distinguish work that was planned, applied,
+Report the spec, target, context, session ID, current revision and state, and
+the evidence behind the result. Distinguish work that was planned, applied,
 published, updated, or deleted.
+
+## References
+
+- [Use Telos](references/use-telos.md) — one persistent Goal from first plan through revision
+- [Write a SPEC.md](references/goals.md) — contract shape and expressive boundary
+- [The Goal lifecycle](references/lifecycle.md) — identity, states, revisions, and evidence
+- [Bounded runs](references/bounded-runs.md) — local work with an explicit stopping bound
+- [Telos Cloud](references/cloud.md) — contexts and managed-runtime preflight
+- [Models and inference](references/inference.md) — Cloud and local model selection
+- [Packages and skills](references/packages-and-skills.md) — immutable registry artifacts and rubrics
+- [Nested Goals](references/nested-goals.md) — bounded child work
+- [Troubleshooting](references/troubleshooting.md) — symptom-led diagnosis

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -131,6 +131,7 @@ published, updated, or deleted.
 - [Use Telos](references/use-telos.md) — one persistent Goal from first plan through revision
 - [Write a SPEC.md](references/goals.md) — contract shape and expressive boundary
 - [The Goal lifecycle](references/lifecycle.md) — identity, states, revisions, and evidence
+- [Glossary](references/glossary.md) — canonical Telos product vocabulary
 - [Bounded runs](references/bounded-runs.md) — local work with an explicit stopping bound
 - [Telos Cloud](references/cloud.md) — contexts and managed-runtime preflight
 - [Models and inference](references/inference.md) — Cloud and local model selection

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -10,6 +10,9 @@ metadata:
 
 # Telos CLI
 
+This skill is the public operating contract for Telos. Its linked references
+form the user-facing documentation surface.
+
 Telos works from a `SPEC.md`: an authored contract for an observable outcome
 and the evidence that proves it. `apply` gives that outcome a persistent Cloud
 identity; `run` executes bounded local work. See

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -41,6 +41,14 @@ Choose the lifecycle that matches the requested outcome:
 | Persistent Goal | `telos apply` | One Cloud session and deployment that evolve across revisions. |
 | Bounded run | `telos run` | A local session that stops at its cycle, time, or cost bound. |
 
+## Authorization
+
+Before `run`, `apply`, `push`, or `delete`, present the resolved action and
+target to the user and obtain approval. Include the spec and workspace for a
+run, the session and context for an apply or delete, and the scope and package
+version for a push. `run` and `apply` may spend money. Never infer a session,
+context, scope, package version, or destructive target.
+
 ## Apply a persistent Goal
 
 Before authoring a Cloud Goal, read [Telos Cloud](references/cloud.md) and
@@ -56,7 +64,8 @@ runtime.
    telos plan SPEC.md --context CONTEXT
    ```
 
-3. Confirm that the plan shows the intended target and context, then apply it:
+3. Confirm that the plan shows the intended target and context. Present that
+   resolved Cloud mutation to the user, obtain approval, then apply it:
 
    ```bash
    telos apply SPEC.md --context CONTEXT
@@ -89,7 +98,8 @@ pattern and explains every reported state.
 ## Run bounded work
 
 `run` requires a `platform: local` spec and a cycle, time, or cost bound suited
-to the task:
+to the task. Resolve the source workspace and bounds, then obtain user approval
+before starting it:
 
 ```bash
 telos run REPORT_SPEC.md --workspace . --until 3
@@ -105,11 +115,10 @@ Inside a Telos session, the same command creates a linked child session; see
 | --- | --- |
 | Inspect state | `plan`, `list`, `describe`, `logs` |
 | Materialize files or change local configuration | `get`, `pull`, `login`, `logout`, `config --context`, `config --model` |
-| Start bounded local execution | `run` |
-| Publish, update, spend, or stop remote work | `apply`, `push`, `delete` |
+| Start bounded local execution; may spend money | `run` |
+| Publish or change remote state; `apply` may spend money | `apply`, `push`, `delete` |
 
-Resolve the target and context before a remote mutation. Package versions are
-immutable, so changed content receives a new version.
+Package versions are immutable, so changed content receives a new version.
 
 ## Return the result
 

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -10,92 +10,99 @@ metadata:
 
 # Telos CLI
 
-Use Telos behind the user's interactive coding agent. `SPEC.md` is the Goal's
-executable contract. Keep the user in control of intent and mutations; let
-Telos implement and verify the current revision.
+Telos turns a `SPEC.md` into either a persistent Goal or a bounded run. The
+spec is the executable contract: it describes the outcome and its evidence,
+while Telos implements and verifies a revision that satisfies it.
 
-## Begin with the live system
+## Start with the live system
 
-1. Read the repository's `AGENTS.md` and inspect the relevant code.
-2. Run `telos --version` and `telos <command> --help`. If Telos is absent, read
-   [Install Telos](references/install.md).
-3. For Cloud work, run `telos login` and confirm the target with `telos config`.
-4. Decide whether the Goal is persistent (`apply`) or bounded (`run`).
+Read the repository's `AGENTS.md` and inspect the relevant code before drafting
+the Goal. Then check the installed CLI:
 
-Read only the reference needed for the current task:
+```bash
+telos --version
+telos <command> --help
+```
 
-- [Use Telos](references/use-telos.md) for the concise end-to-end workflow
-- [Goals and specifications](references/goals.md)
+If Telos is absent, read [Install Telos](references/install.md). Cloud work also
+needs an authenticated account and an explicit target:
+
+```bash
+telos login
+telos config
+```
+
+Choose the lifecycle that matches the requested outcome:
+
+| Lifecycle | Command | Use it for |
+| --- | --- | --- |
+| Persistent Goal | `telos apply` | Software that should retain identity and evolve across revisions. |
+| Bounded run | `telos run` | One piece of work that ends at a cycle, time, or cost limit. |
+
+Read the reference that matches the task:
+
+- [Use Telos](references/use-telos.md) for the end-to-end workflow
+- [Goals and specifications](references/goals.md) for writing `SPEC.md`
 - [The Goal lifecycle](references/lifecycle.md) for states, revisions, and evidence
-- [Telos Cloud](references/cloud.md)
-- [Models and inference](references/inference.md)
-- [Packages and skills](references/packages-and-skills.md)
-- [Nested Goals](references/nested-goals.md)
-- [Troubleshooting](references/troubleshooting.md)
+- [Telos Cloud](references/cloud.md) for contexts and managed deployments
+- [Models and inference](references/inference.md) for Cloud and local model selection
+- [Packages and skills](references/packages-and-skills.md) for the registry
+- [Nested Goals](references/nested-goals.md) for bounded child work
+- [Troubleshooting](references/troubleshooting.md) for failed or stalled work
 
 ## Apply a persistent Goal
 
-Draft the smallest `SPEC.md` that states the observable outcome, important
-constraints, and evidence of success. Avoid prescribing ordinary implementation
-choices.
-
-Plan first:
+Write the smallest spec that states the observable outcome, important
+constraints, and evidence of success. Preview the contract before applying it:
 
 ```bash
 telos plan SPEC.md
-```
-
-Review the contract with the user. After approval:
-
-```bash
 telos apply SPEC.md
 ```
 
-Poll the returned session with a bounded timeout until the exact revision is
-Ready:
+`apply` returns a session ID as soon as Cloud accepts the revision. Follow that
+session until the matching revision becomes `ready`, or until the displayed
+state and reason call for a new decision:
 
 ```bash
 telos describe SESSION_ID --json
+telos logs SESSION_ID
 ```
 
-Ready means the exact revision passed verification and is running. Once it is
-Ready, collect a finite evidence snapshot with `telos logs SESSION_ID` and show
-the user the result. Stop polling on a terminal failure or when the timeout
-expires.
+When the Goal exposes a service, verify the live service as well as the Telos
+state. A later revision uses the same session:
+
+```bash
+telos plan SPEC.md --session SESSION_ID
+telos apply SPEC.md --session SESSION_ID
+```
 
 ## Run bounded work
 
-Use `run` for one-off work or a child Goal that should stop at a clear limit:
+`run` executes one Goal in a local workspace and stops at its bound:
 
 ```bash
 telos run SPEC.md --workspace . --until 3
 ```
 
-For a human it is bounded imperative work. For an agent it is a bounded
-declarative subgoal. Inspect it with the same `describe` and `logs` commands.
+Inside a Telos session, the same command creates a bounded child Goal. Its
+session is inspected with `describe` and `logs` like any other run.
 
-## Guardrails
+## Command effects
 
-- `plan`, `list`, `describe`, and `logs` do not change the Goal or target state.
+- `plan`, `list`, `describe`, and `logs` inspect state.
 - `get` and `pull` materialize local files. `login`, `logout`, and
-  `config --context` update local credentials or configuration.
-- `run`, `apply`, `push`, and `delete` mutate execution or registry state and
-  may spend resources. Confirm the target and authorization first.
-- Never guess a session, organization, package version, or deployment target.
-- Package versions are immutable. Publish a new version for changed bytes.
-- Do not report completion until the observed session state confirms acceptance
-  of the exact current revision. For managed Goals, require `ready` and probe
-  public behavior when the contract exposes it.
-- Do not expose tokens, runtime allocation IDs, provider details, or other
-  control-plane internals in user-facing artifacts.
-- Do not pipe and execute the installer when the user only asked for advice.
-  Show the command; run it when installation is part of the authorized task.
-- Launch the fewest child Goals needed and inspect their results before
-  creating more. Avoid recursive fan-out.
-- Give child work an observable deliverable and a finite cycle, time, or cost
-  bound. The parent integrates and verifies what a child returns.
+  `config --context` change local authentication or configuration.
+- `run`, `apply`, `push`, and `delete` change execution or registry state and
+  may spend resources. Their target and mutation must be part of the user's
+  request.
+- Package versions are immutable; changed content receives a new version.
+- Completion is an observed state, not a successful submission. For managed
+  Goals, it is `ready` for the current revision plus any live behavior promised
+  by the spec.
 
-## Handoff
+## Return the result
 
-Report the spec, target, session ID, commands run, observed state, and evidence.
-Say plainly what was planned, published, launched, updated, or deleted.
+Report the spec, target, session ID, current revision and state, and the
+evidence that supports the result. Distinguish work that was planned, applied,
+published, updated, or deleted.

--- a/skills/telos-cli/references/bounded-runs.md
+++ b/skills/telos-cli/references/bounded-runs.md
@@ -1,0 +1,72 @@
+---
+title: Bounded runs
+description: Run a local Goal to a cycle, time, or cost bound and inspect its evidence.
+group: Concepts
+---
+
+# Bounded runs
+
+Use `telos run` for work with a natural stopping point: an analysis, migration,
+focused implementation, or other result that does not need a persistent Cloud
+deployment.
+
+Create `REPORT_SPEC.md`:
+
+```markdown
+---
+name: compatibility-report
+version: 0.1.0
+platform: local
+---
+
+# Goal
+
+Compare the current API responses with the v1 fixtures. Write
+`COMPATIBILITY.md` with every incompatible change and the fixture and response
+that prove it.
+
+# Acceptance
+
+- `COMPATIBILITY.md` covers every v1 fixture.
+- Each incompatibility cites both the fixture and observed response.
+```
+
+Preview the contract, then run it in the current repository for at most three
+review cycles:
+
+```bash
+telos plan REPORT_SPEC.md
+telos run REPORT_SPEC.md --workspace . --until 3
+```
+
+`--until` also accepts a duration such as `30m`; `--max-cost-usd` adds a spend
+bound. Choose bounds that give the task room to finish while keeping its
+stopping condition explicit.
+
+`--workspace .` selects the current repository as source. Telos clones a clean
+Git repository—or snapshots a non-Git directory—into an isolated session
+workspace. The run does not edit the source checkout directly.
+
+The receipt contains a new run session. Inspect its state and evidence:
+
+```bash
+telos describe SESSION_ID
+telos logs SESSION_ID
+```
+
+After completion, `telos describe SESSION_ID --json` exposes the accepted
+workspace checkpoint as `specs[0].workspace_path`. Extract that `tar.gz` into a
+chosen result directory:
+
+```bash
+mkdir -p telos-result
+tar -xzf WORKSPACE_PATH -C telos-result
+```
+
+`telos-result/COMPATIBILITY.md` is the material deliverable. `describe` and
+`logs` provide its session state and evidence.
+
+A bounded session can complete, fail, stop at its bound, or become stale. It
+does not create or update a persistent Cloud Goal. [Models and inference](inference.md)
+explains local `pi` selection. When a running Telos agent creates this session
+as a child, the additional lineage rules are in [Nested Goals](nested-goals.md).

--- a/skills/telos-cli/references/bounded-runs.md
+++ b/skills/telos-cli/references/bounded-runs.md
@@ -32,20 +32,37 @@ that prove it.
 ```
 
 Preview the contract, then run it in the current repository for at most three
-review cycles:
+review cycles. Resolve the spec, source checkout, and bounds, and obtain the
+user's approval before starting the run:
 
 ```bash
 telos plan REPORT_SPEC.md
 telos run REPORT_SPEC.md --workspace . --until 3
 ```
 
-`--until` also accepts a duration such as `30m`; `--max-cost-usd` adds a spend
-bound. Choose bounds that give the task room to finish while keeping its
-stopping condition explicit.
+`--until` also accepts a duration such as `30m`. A top-level local run has a
+default `$20` cost ceiling. An explicit `--max-cost-usd` takes precedence over
+`TELOS_MAX_COST_USD`, which takes precedence over that default. Choose bounds
+that give the task room to finish while keeping its stopping condition
+explicit.
+
+## Prepare the source checkout
 
 `--workspace .` selects the current repository as source. Telos clones a clean
 Git repository—or snapshots a non-Git directory—into an isolated session
 workspace. The run does not edit the source checkout directly.
+
+For Git sources, the worktree must have no tracked or untracked changes apart
+from Telos's own `.telos` marker. Git submodules and Git LFS are not included in
+the isolated workspace; Telos rejects repositories that use either rather than
+starting from incomplete source.
+
+By default, the first local run creates `.telos` in the source checkout as a
+symlink to the external session store. The marker lets later `list`, `describe`,
+`logs`, and `delete` commands find sessions for that checkout. It is not the
+active workspace and is excluded from cleanliness checks and snapshots. Setting
+`TELOS_SESSION_DIR` selects a session store explicitly and suppresses the
+marker.
 
 The receipt contains a new run session. Inspect its state and evidence:
 

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -10,8 +10,7 @@ telos config --context @team-handle
 telos list --context @team-handle
 ```
 
-Use `personal` to return to the personal context. Never guess the target from a
-repository name or prior session. For one invocation, `--context` takes
+Use `personal` to return to the personal context. For one invocation, `--context` takes
 precedence over `TELOS_CONTEXT` and stored configuration without mutating either.
 
 A persistent Cloud Goal declares `platform: cloud` in its spec and is launched

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -1,57 +1,64 @@
 # Telos Cloud
 
-Authenticate once, inspect the active target, and select a team only when the
-user intends one:
+Telos Cloud gives a persistent Goal a managed runtime, stable session identity,
+and a public service surface when the Goal exposes one.
+
+## Choose the context
+
+`telos config` shows the active account, context, and default model:
 
 ```bash
 telos login
 telos config
+```
+
+The personal workspace is named `personal`. Team workspaces use their handle:
+
+```bash
 telos config --context @team-handle
 telos list --context @team-handle
 ```
 
-Use `personal` to return to the personal context. For one invocation, `--context` takes
-precedence over `TELOS_CONTEXT` and stored configuration without mutating either.
+`telos config --context personal` returns to the personal workspace. A
+command-level `--context` overrides `TELOS_CONTEXT` and stored configuration
+for that invocation without changing either.
 
-A persistent Cloud Goal declares `platform: cloud` in its spec and is launched
-with:
+## Apply a Cloud Goal
+
+A managed spec declares `platform: cloud`:
 
 ```bash
 telos plan SPEC.md
 telos apply SPEC.md
 ```
 
-`apply` publishes the exact package and creates the managed deployment. Record
-the returned revision digest and session ID.
-
-Inspect Cloud state with:
+`apply` publishes the immutable spec package and creates a deployment for it.
+The receipt identifies the context, revision digest, and session to follow:
 
 ```bash
-telos list --cloud
 telos describe SESSION_ID
 telos logs SESSION_ID
 ```
 
-A deployment becomes `ready` only after the matching revision has been
-reconciled and accepted. Do not interpret allocation success, an HTTP process
-starting, or stale events as Goal acceptance. `Ready` is revision scoped: it
-confirms the current package, not a future drift check or repair.
+The deployment becomes `ready` when the displayed revision has been
+reconciled and accepted. [The Goal lifecycle](lifecycle.md) describes every
+state and the evidence behind it.
 
-For an agent-readable acceptance check:
+## Revise it
 
-```bash
-telos describe SESSION_ID --json | jq -e '.status == "ready"'
-```
-
-To update an existing deployment, retrieve or edit its spec, bump the immutable
-package version, inspect the diff, and apply to the same session:
+Retrieve the current spec when it is not already available locally:
 
 ```bash
 telos get SESSION_ID --output SPEC.md
+```
+
+Edit the contract, bump its version, and compare it with the deployed package:
+
+```bash
 telos plan SPEC.md --session SESSION_ID
 telos apply SPEC.md --session SESSION_ID
 ```
 
-Deletion is consequential. Confirm the exact session and preservation intent
-before `telos delete SESSION_ID`; do not use existing deployments as rollout
-canaries.
+The new package is immutable, while the Goal keeps the same session and
+history. `telos delete SESSION_ID` stops the deployment when deleting it is
+part of the requested lifecycle.

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -1,64 +1,79 @@
+---
+title: Telos Cloud
+description: Choose a Cloud context and confirm that a Goal fits the managed runtime before applying it.
+group: Platform
+---
+
 # Telos Cloud
 
-Telos Cloud gives a persistent Goal a managed runtime, stable session identity,
-and a public service surface when the Goal exposes one.
+Telos Cloud gives a persistent Goal a managed deployment, a stable session, and
+a public HTTPS route when the Goal exposes a service. Each environment contains
+an agent workspace and a Kubernetes namespace where the application runs.
+
+A CLI **context** selects the personal or team Cloud workspace that owns the
+deployment. Inside an environment, **workspace** means the agent's retained
+filesystem. The two uses are related but not interchangeable.
 
 ## Choose the context
 
-`telos config` shows the active account, context, and default model:
+`telos config` shows the active account, context, and machine-local default
+model:
 
 ```bash
 telos login
 telos config
 ```
 
-The personal workspace is named `personal`. Team workspaces use their handle:
+The personal context is `personal`. Team contexts use their handle:
 
 ```bash
 telos config --context @team-handle
 telos list --context @team-handle
 ```
 
-`telos config --context personal` returns to the personal workspace. A
+`telos config --context personal` returns to the personal context. A
 command-level `--context` overrides `TELOS_CONTEXT` and stored configuration
-for that invocation without changing either.
+for that invocation without changing either. Carry the chosen context through
+`plan`, `apply`, `describe`, `logs`, and `delete` so each action has one visible
+target.
 
-## Apply a Cloud Goal
+## Preflight the managed runtime
 
-A managed spec declares `platform: cloud`:
+A spec describes desired behavior; it cannot add a missing platform surface.
+Before applying, identify how the implementation will fit these current Cloud
+capabilities:
 
-```bash
-telos plan SPEC.md
-telos apply SPEC.md
-```
+| Need | Current Cloud path |
+| --- | --- |
+| Deliver a workload | Use a digest-pinned published image, a repository's existing image publication workflow, or a read-only ConfigMap for a small interpreted service. |
+| Keep application data | Mount a persistent volume claim. Its lifecycle is bound to the claim and Cloud environment. |
+| Fetch build dependencies | Docker Hub images, PyPI packages, npm packages, and Telos artifacts have built-in read access. |
+| Reach another public API from the agent | Attach an operator-managed HTTPS integration with rules for the required request. |
+| Reach another service from the deployed application | No general managed credential connector is currently injected into Kubernetes workloads. |
 
-`apply` publishes the immutable spec package and creates a deployment for it.
-The receipt identifies the context, revision digest, and session to follow:
+The Cloud agent receives the full `telos-cloud` operating skill inside the
+environment. It explains delivery, persistence, networking, and verification
+in detail.
 
-```bash
-telos describe SESSION_ID
-telos logs SESSION_ID
-```
+The current CLI cannot bind an integration atomically with a new deployment.
+When the first reconciliation needs credentialed agent-time access, use a
+creation surface that binds the integration before the environment's initial
+agent claim, or treat that Goal as unsupported by the CLI path.
 
-The deployment becomes `ready` when the displayed revision has been
-reconciled and accepted. [The Goal lifecycle](lifecycle.md) describes every
-state and the evidence behind it.
+AWS and HMAC signing policies can be attached later and consumed by a later
+revision because they add request credentials at the outbound boundary. Static
+replacement is different: its agent placeholder is delivered only in the
+initial claim, so a post-creation attachment cannot retrofit it into the
+existing agent environment. A missing image path or workload connector is
+likewise a platform constraint, not something `SPEC.md` can create.
 
-## Revise it
+## Apply and observe
 
-Retrieve the current spec when it is not already available locally:
+Use the workflow in [Use Telos](use-telos.md), passing the same explicit context
+through every Cloud command. `apply` publishes an immutable spec package and
+creates the deployment. The receipt identifies the context, revision digest,
+and stable session to follow.
 
-```bash
-telos get SESSION_ID --output SPEC.md
-```
-
-Edit the contract, bump its version, and compare it with the deployed package:
-
-```bash
-telos plan SPEC.md --session SESSION_ID
-telos apply SPEC.md --session SESSION_ID
-```
-
-The new package is immutable, while the Goal keeps the same session and
-history. `telos delete SESSION_ID` stops the deployment when deleting it is
-part of the requested lifecycle.
+[The Goal lifecycle](lifecycle.md) owns state, revision, observation, and
+deletion semantics. [Models and inference](inference.md) explains how the new
+session receives its Cloud model selection.

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -40,8 +40,9 @@ target.
 ## Preflight the managed runtime
 
 A spec describes desired behavior; it cannot add a missing platform surface.
-Before applying, identify how the implementation will fit these current Cloud
-capabilities:
+Public egress is default-deny: Cloud provides the common read paths below, and
+other agent requests need a matching integration. Before applying, identify
+how the implementation will fit these current Cloud capabilities:
 
 | Need | Current Cloud path |
 | --- | --- |

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -55,17 +55,16 @@ The Cloud agent receives the full `telos-cloud` operating skill inside the
 environment. It explains delivery, persistence, networking, and verification
 in detail.
 
-The current CLI cannot bind an integration atomically with a new deployment.
-When the first reconciliation needs credentialed agent-time access, use a
-creation surface that binds the integration before the environment's initial
-agent claim, or treat that Goal as unsupported by the CLI path.
+## Current integration limits
 
-AWS and HMAC signing policies can be attached later and consumed by a later
-revision because they add request credentials at the outbound boundary. Static
-replacement is different: its agent placeholder is delivered only in the
-initial claim, so a post-creation attachment cannot retrofit it into the
-existing agent environment. A missing image path or workload connector is
-likewise a platform constraint, not something `SPEC.md` can create.
+| Limit | Consequence |
+| --- | --- |
+| CLI creation | The CLI cannot attach an integration before the first reconciliation. Use a creation surface that binds it before the initial agent claim, or treat that dependency as unsupported by the CLI path. |
+| AWS and HMAC signing | A later attachment can sign requests for a later revision because no agent placeholder is required. |
+| Static replacement | Its placeholder is delivered only in the initial claim. A post-creation attachment cannot add it to the existing agent environment. |
+
+A missing image path or workload connector is likewise a platform constraint,
+not something `SPEC.md` can create.
 
 ## Apply and observe
 

--- a/skills/telos-cli/references/glossary.md
+++ b/skills/telos-cli/references/glossary.md
@@ -1,0 +1,89 @@
+---
+title: Glossary
+description: Read the canonical vocabulary for Goals, revisions, execution, and evidence.
+group: Reference
+---
+
+# Glossary
+
+Telos uses a small set of terms to distinguish what you ask for, what executes,
+and what proves the result. They appear here in the order a reader encounters
+them in the product.
+
+## Goal
+
+The outcome Telos works to make true. A persistent Cloud Goal keeps one
+identity while its contract and implementation evolve through revisions.
+
+## `SPEC.md`
+
+The authored contract for a Goal. Its frontmatter selects execution inputs;
+its Markdown body describes the outcome, meaningful constraints, and evidence
+of success.
+
+## Revision
+
+One immutable version of a compiled Goal contract. A revision is identified by
+its digest and does not change after publication.
+
+## Session
+
+The CLI handle and history for execution. A persistent Goal keeps one session
+across revisions; every bounded run receives a new session.
+
+## Deployment
+
+The managed Cloud object for a persistent Goal. It owns the current revision,
+environment, public routes, and reported state.
+
+## Reconciliation
+
+The asynchronous process that moves a deployment toward its current revision
+and verifies the result. An `apply` receipt confirms acceptance for work, not
+completed reconciliation.
+
+## Evidence
+
+The observations that demonstrate a revision satisfies its contract: for
+example, test results, workload state, or exercised live behavior. Activity
+logs can contain evidence, but activity alone is not proof of completion.
+
+## Context
+
+The personal or team Cloud workspace that owns a deployment. A context is an
+explicit CLI target; it is distinct from the filesystem workspace inside an
+execution environment.
+
+## Workspace
+
+The filesystem where an agent works. Cloud retains its Goal workspace across
+attempts and revisions; a local run receives an isolated workspace derived
+from its selected source checkout.
+
+## Bounded run
+
+A local execution that stops at a cycle, time, or cost bound. It produces a
+session and evidence without creating a persistent Cloud deployment.
+
+## Package
+
+An immutable compiled spec with its locked skill dependencies. Registry
+packages can be addressed by a human-readable ref or an exact digest.
+
+## Digest
+
+The content identity of immutable bytes, written as `sha256:...`. Revision and
+package digests let receipts, status, and evidence refer to the same input.
+
+## Skill
+
+A reusable instruction and capability bundle imported by a spec. Registry
+skills are versioned and immutable.
+
+## Rubric
+
+A skill that also participates in acceptance. A trailing `*` on a skill ref
+asks an independent verifier to use that skill when judging the revision.
+
+For the relationships between Goal, revision, session, and deployment, continue
+with [The Goal lifecycle](lifecycle.md).

--- a/skills/telos-cli/references/goals.md
+++ b/skills/telos-cli/references/goals.md
@@ -37,7 +37,6 @@ Goal uses them:
 | `version` | Required semantic version for this immutable revision. Bump it when the contract changes. |
 | `platform` | `cloud` for a managed persistent Goal or `local` for a bounded run. Omitted values currently resolve to Cloud; explicit is clearer. |
 | `skills` | A path or YAML list of paths and exact registry refs. Relative paths resolve from the spec directory. A trailing `*` makes a skill an acceptance rubric. |
-| `extends` | A relative path to a parent spec. It reuses lineage and namespace and can seed a local child workspace from a completed parent; it does not insert the parent's Markdown into the child prompt. Restate every obligation the child must satisfy. |
 | `interval` | A positive duration ending in `s`, `m`, or `h`, such as `30m` or `6h`, carried as the contract's reconciliation interval. |
 | `tags` | A YAML list of string labels. The default is an empty list. |
 
@@ -47,7 +46,6 @@ For example:
 skills:
   - path/to/local-skill
   - "@scope/readiness:1.0.0*"
-extends: ../foundation/SPEC.md
 interval: 6h
 tags:
   - production

--- a/skills/telos-cli/references/goals.md
+++ b/skills/telos-cli/references/goals.md
@@ -1,12 +1,16 @@
-# Goals, specs, and execution modes
+---
+title: Write a SPEC.md
+description: Express a Goal as an observable contract and choose the execution lifecycle it needs.
+group: Concepts
+---
 
-A Goal is the outcome that should remain true. `SPEC.md` expresses that Goal as
-an executable contract. Sessions and agents are replaceable attempts to satisfy
-the current revision of the contract.
+# Write a `SPEC.md`
 
-## Write the contract
+A Goal is the outcome that should remain true. `SPEC.md` is its authored
+contract: frontmatter tells Telos how to run it, while the Markdown body tells
+agents what to make true and how success can be observed.
 
-A new `SPEC.md` should usually have this shape:
+## Start with a complete minimal contract
 
 ```markdown
 ---
@@ -17,53 +21,75 @@ platform: cloud
 
 # Goal
 
-State the observable outcome, what existing behavior or state must survive,
-and the evidence that proves success.
+State the observable outcome and the behavior that must remain true.
+
+# Acceptance
+
+- Name the evidence that demonstrates the outcome.
 ```
 
-Use a DNS-compatible lowercase name and semantic version. Set `platform` to
-`local` for work on the current machine or repository, and `cloud` for a
-managed deployment.
+This file is valid as written. Add the other frontmatter fields only when the
+Goal uses them:
 
-Keep the goal declarative. Specify stable interfaces, security boundaries,
-persistence, compatibility, and failure behavior when they matter. Avoid a
-step-by-step implementation recipe.
+| Field | Meaning |
+| --- | --- |
+| `name` | Required lowercase, DNS-compatible identity. Keep it stable across revisions. |
+| `version` | Required semantic version for this immutable revision. Bump it when the contract changes. |
+| `platform` | `cloud` for a managed persistent Goal or `local` for a bounded run. Omitted values currently resolve to Cloud; explicit is clearer. |
+| `skills` | A path or YAML list of paths and exact registry refs. Relative paths resolve from the spec directory. A trailing `*` makes a skill an acceptance rubric. |
+| `extends` | A relative path to a parent spec. It reuses lineage and namespace and can seed a local child workspace from a completed parent; it does not insert the parent's Markdown into the child prompt. Restate every obligation the child must satisfy. |
+| `interval` | A positive duration ending in `s`, `m`, or `h`, such as `30m` or `6h`, carried as the contract's reconciliation interval. |
+| `tags` | A YAML list of string labels. The default is an empty list. |
 
-## Choose apply or run
+For example:
 
-Use `telos apply` for a persistent Goal that should retain identity across
-implementation attempts and spec revisions. Cloud specs are started and
-updated with `apply`.
-
-Use `telos run` as the bounded execution subsystem. For a human, it performs
-one imperative piece of work within a limit. For an agent, it satisfies a
-bounded declarative subgoal and returns evidence. Give it an explicit cycle,
-time, or cost bound when practical.
-
-Before launch:
-
-```bash
-telos plan SPEC.md
+```yaml
+skills:
+  - path/to/local-skill
+  - "@scope/readiness:1.0.0*"
+extends: ../foundation/SPEC.md
+interval: 6h
+tags:
+  - production
 ```
 
-For an existing controller, compare the proposed contract to the deployed one:
+The body is Markdown, not a fixed form schema. `# Goal` and `# Acceptance` are
+useful conventions rather than specially parsed fields. Add sections for
+interfaces, compatibility, data lifecycle, security boundaries, failure
+behavior, or evidence when they change what a correct result means.
 
-```bash
-telos plan SPEC.md --session SESSION_ID
-telos apply SPEC.md --session SESSION_ID
+## Express the contract, not an implementation recipe
+
+A useful spec names observable behavior and leaves implementation choices open
+where several designs would satisfy it. For example:
+
+```markdown
+# Goal
+
+Run a public reading-list service. Books remain available when the application
+restarts.
+
+# Acceptance
+
+- Add a book, restart the application, and retrieve the same book.
 ```
 
-## Observe acceptance
+That contract permits the agent to choose an appropriate framework and
+datastore. A framework, schema, deployment shape, or compatibility requirement
+belongs in the spec when it is itself part of the promised outcome.
 
-The command returning a session ID means the work was accepted, not completed.
-Use:
+A spec can select a lifecycle, import capabilities and rubrics, and describe
+the desired state. It does not grant credentials, network access, registry
+permissions, or a platform capability. Confirm those surfaces separately
+before applying a Cloud Goal; [Telos Cloud](cloud.md) describes that preflight.
 
-```bash
-telos describe SESSION_ID
-telos logs SESSION_ID
-```
+## Choose `apply` or `run`
 
-Require the observed session state to confirm acceptance of the current
-revision. For a managed Goal, require Cloud to report `ready`. For a service,
-also probe its public behavior. Tests or logs do not substitute for the live
-contract they claim to verify.
+| Need | Spec | Command |
+| --- | --- | --- |
+| A managed outcome that keeps its identity and evolves | `platform: cloud` | `telos apply` |
+| One local result with a stopping bound | `platform: local` | `telos run` |
+
+Follow [Use Telos](use-telos.md) for a persistent service or
+[Bounded runs](bounded-runs.md) for a local result. The identity created by each
+path is explained in [The Goal lifecycle](lifecycle.md).

--- a/skills/telos-cli/references/inference.md
+++ b/skills/telos-cli/references/inference.md
@@ -1,83 +1,95 @@
 ---
 title: Models and inference
-description: Choose managed Telos inference or connect an existing ChatGPT or Grok subscription.
+description: Choose managed inference or a connected subscription for Cloud, and choose a pi model for local runs.
 group: Platform
 ---
 
 # Models and inference
 
-Every Cloud Goal runs on an inference connection. Telos supplies one by
-default; the user can instead connect a subscription they already pay for.
+Cloud Goals and local runs select models at different execution boundaries.
+Cloud resolves a managed tier or a subscription connection. Local runs pass a
+provider and model directly to `pi`.
 
-## Managed tiers
+## Cloud Goals
 
-Two managed models need no setup and bill through Telos:
+Every new Cloud Goal receives an inference selection. Telos provides two
+managed tiers:
 
 ```bash
 telos apply SPEC.md --model telos/default
 telos apply SPEC.md --model telos/max
 ```
 
-`telos/default` is what a Goal uses when nothing selects a model.
+`telos/default` is the standard managed tier. `telos/max` selects the larger
+managed tier. Both are operated and billed by Telos, so they need no separate
+provider setup.
 
-## A user's own subscription
+A Cloud selection is made when the session is created. Later revisions keep
+the session's existing inference configuration.
 
-Telos can drive an existing ChatGPT account (OpenAI Codex models) or Grok
-account (xAI models) instead. Work then bills against that subscription rather
-than Telos.
+### Connected subscriptions
 
-**Connecting is a browser action, and an agent cannot do it.** There is no
-`telos` command that connects a subscription. When a user wants one, stop and
-tell them to connect it in the Telos app; then continue.
-
-Once connected, `telos config` lists it:
+Cloud can also use a ChatGPT or Grok subscription connected in the Telos app.
+Once connected, it appears in `telos config`:
 
 ```console
 $ telos config
 Config file     ~/.telos/config.yaml
 Endpoint        https://api.usetelos.ai
 Authentication  valid
-Context         @telos
+Context         personal
 Default model   workspace default
 Subscriptions
-  ChatGPT  chatgpt-codex    connected
+  MyChatGPT  chatgpt-codex  alice@example.com  connected
 ```
 
-The columns are connection name, provider, account, and status. **The first
-column is the name to use** — it is a label the user chose, not the provider
-id. Select a model on that connection as `<connection-name>/<model-name>`:
+The first value is the connection name chosen by the user. Combine that name
+with a model as `<connection-name>/<model-name>`:
 
 ```bash
-telos apply SPEC.md --model ChatGPT/gpt-5.5
+telos apply SPEC.md --model MyChatGPT/gpt-5.5
 ```
 
-The connection must report `connected`. A name that does not match, or matches
-more than one connection, is an error rather than a fallback.
+The selected connection must exist exactly once and report `connected`.
+Connection creation and browser authorization happen in the Telos app; the CLI
+uses connections that are already available.
 
-## Where a model is chosen
+### Cloud selection order
 
-`--model` accepts exactly three forms: `telos/default`, `telos/max`, or
-`<connection-name>/<model-name>`. Anything else is rejected.
+For a new Cloud session, Telos resolves the model in this order:
 
-Resolution order, highest first:
+1. `--model` on `telos apply`
+2. `TELOS_MODEL`
+3. the stored value set by `telos config --model`
+4. the standard managed tier
 
-1. `--model` on `telos apply` or `telos run`
-2. `$TELOS_MODEL`
-3. the stored default from `telos config --model`
-4. `telos/default`
+The Cloud forms are `telos/default`, `telos/max`, and
+`<connection-name>/<model-name>`.
 
-Set the stored default for new Cloud deployments with:
+Set or clear the stored Cloud default with:
 
 ```bash
 telos config --model telos/max
-telos config --model ""      # clear it
+telos config --model ""
 ```
 
-Read the current value from the `Default model` row of `telos config`;
-`workspace default` there means nothing is stored and rule 4 applies.
+`telos config` prints `workspace default` when no value is stored.
 
 ## Local runs
 
-`telos run` on a `platform: local` spec uses the `pi` runtime and the model
-provider authenticated on that machine. Managed Cloud deployments never use a
-workstation's local model credentials.
+A `platform: local` spec runs through the `pi` coding agent installed on the
+same machine:
+
+```bash
+telos run SPEC.md --workspace . --model openai-codex/gpt-5.5
+```
+
+Local model names use pi's `<provider>/<model-id>` form. Selection order is:
+
+1. `--model` on `telos run`
+2. `TELOS_MODEL`
+3. `openai-codex/gpt-5.5`
+
+The stored Cloud default from `telos config --model` does not participate in
+local selection. Provider authentication comes from the local pi installation;
+run `pi` and use `/login` to configure it.

--- a/skills/telos-cli/references/inference.md
+++ b/skills/telos-cli/references/inference.md
@@ -1,0 +1,83 @@
+---
+title: Models and inference
+description: Choose managed Telos inference or connect an existing ChatGPT or Grok subscription.
+group: Platform
+---
+
+# Models and inference
+
+Every Cloud Goal runs on an inference connection. Telos supplies one by
+default; the user can instead connect a subscription they already pay for.
+
+## Managed tiers
+
+Two managed models need no setup and bill through Telos:
+
+```bash
+telos apply SPEC.md --model telos/default
+telos apply SPEC.md --model telos/max
+```
+
+`telos/default` is what a Goal uses when nothing selects a model.
+
+## A user's own subscription
+
+Telos can drive an existing ChatGPT account (OpenAI Codex models) or Grok
+account (xAI models) instead. Work then bills against that subscription rather
+than Telos.
+
+**Connecting is a browser action, and an agent cannot do it.** There is no
+`telos` command that connects a subscription. When a user wants one, stop and
+tell them to connect it in the Telos app; then continue.
+
+Once connected, `telos config` lists it:
+
+```console
+$ telos config
+Config file     ~/.telos/config.yaml
+Endpoint        https://api.usetelos.ai
+Authentication  valid
+Context         @telos
+Default model   workspace default
+Subscriptions
+  ChatGPT  chatgpt-codex    connected
+```
+
+The columns are connection name, provider, account, and status. **The first
+column is the name to use** — it is a label the user chose, not the provider
+id. Select a model on that connection as `<connection-name>/<model-name>`:
+
+```bash
+telos apply SPEC.md --model ChatGPT/gpt-5.5
+```
+
+The connection must report `connected`. A name that does not match, or matches
+more than one connection, is an error rather than a fallback.
+
+## Where a model is chosen
+
+`--model` accepts exactly three forms: `telos/default`, `telos/max`, or
+`<connection-name>/<model-name>`. Anything else is rejected.
+
+Resolution order, highest first:
+
+1. `--model` on `telos apply` or `telos run`
+2. `$TELOS_MODEL`
+3. the stored default from `telos config --model`
+4. `telos/default`
+
+Set the stored default for new Cloud deployments with:
+
+```bash
+telos config --model telos/max
+telos config --model ""      # clear it
+```
+
+Read the current value from the `Default model` row of `telos config`;
+`workspace default` there means nothing is stored and rule 4 applies.
+
+## Local runs
+
+`telos run` on a `platform: local` spec uses the `pi` runtime and the model
+provider authenticated on that machine. Managed Cloud deployments never use a
+workstation's local model credentials.

--- a/skills/telos-cli/references/inference.md
+++ b/skills/telos-cli/references/inference.md
@@ -6,28 +6,25 @@ group: Platform
 
 # Models and inference
 
-Cloud Goals and local runs select models at different execution boundaries.
-Cloud resolves a managed tier or a subscription connection. Local runs pass a
-provider and model directly to `pi`.
+Cloud Goals and local runs select models at different points:
+
+| Execution | Selection |
+| --- | --- |
+| New Cloud session | Telos resolves a managed tier or connected subscription and retains it across revisions. |
+| Local run | The local `pi` installation receives a provider and model for that run. |
 
 ## Cloud Goals
 
-Every new Cloud Goal receives an inference selection. Telos provides two
-managed tiers:
+Telos provides two managed tiers:
 
 ```bash
-telos apply SPEC.md --model telos/default
-telos apply SPEC.md --model telos/max
+telos apply SPEC.md --model telos/default --context CONTEXT
+telos apply SPEC.md --model telos/max --context CONTEXT
 ```
 
 `telos/default` is the standard managed tier. `telos/max` selects the larger
 managed tier. Both are operated and billed by Telos, so they need no separate
 provider setup.
-
-A Cloud selection is made when the session is created. Later revisions keep
-the session's existing inference configuration.
-
-### Connected subscriptions
 
 Cloud can also use a ChatGPT or Grok subscription connected in the Telos app.
 Once connected, it appears in `telos config`:
@@ -43,37 +40,48 @@ Subscriptions
   MyChatGPT  chatgpt-codex  alice@example.com  connected
 ```
 
-The first value is the connection name chosen by the user. Combine that name
-with a model as `<connection-name>/<model-name>`:
+The first value is the user-chosen connection name. Combine it with a model as
+`<connection-name>/<model-name>`:
 
 ```bash
-telos apply SPEC.md --model MyChatGPT/gpt-5.5
+telos apply SPEC.md --model MyChatGPT/gpt-5.5 --context CONTEXT
 ```
 
 The selected connection must exist exactly once and report `connected`.
 Connection creation and browser authorization happen in the Telos app; the CLI
-uses connections that are already available.
+uses connections already available to the selected context.
 
 ### Cloud selection order
 
-For a new Cloud session, Telos resolves the model in this order:
+A Cloud inference selection is fixed when the session is created. The CLI
+resolves an explicit selection in this order:
 
 1. `--model` on `telos apply`
 2. `TELOS_MODEL`
-3. the stored value set by `telos config --model`
-4. the standard managed tier
+3. the machine-local value set by `telos config --model`
+
+If all three are empty, the CLI sends no selection and Cloud uses the chosen
+context's workspace inference preference. A workspace with no saved preference
+uses the standard managed tier.
 
 The Cloud forms are `telos/default`, `telos/max`, and
 `<connection-name>/<model-name>`.
 
-Set or clear the stored Cloud default with:
+Set or clear the machine-local default with:
 
 ```bash
 telos config --model telos/max
 telos config --model ""
 ```
 
-`telos config` prints `workspace default` when no value is stored.
+This value is not scoped per context. Clearing it means “defer to the workspace
+preference.” The `workspace default` label printed by `telos config` does not
+identify the model or subscription that the workspace will choose.
+
+Later revisions keep the session's existing inference configuration. Applying
+with `--session` rejects an effective model selection from `--model` or
+`TELOS_MODEL`; the stored machine-local default is ignored for the update. An
+explicit `--model ""` clears a non-empty environment override for that command.
 
 ## Local runs
 
@@ -81,7 +89,7 @@ A `platform: local` spec runs through the `pi` coding agent installed on the
 same machine:
 
 ```bash
-telos run SPEC.md --workspace . --model openai-codex/gpt-5.5
+telos run REPORT_SPEC.md --workspace . --model openai-codex/gpt-5.5
 ```
 
 Local model names use pi's `<provider>/<model-id>` form. Selection order is:

--- a/skills/telos-cli/references/install.md
+++ b/skills/telos-cli/references/install.md
@@ -31,7 +31,3 @@ Local runs use the `pi` coding-agent runtime. If it is absent, follow the
 installer's current setup message and authenticate the intended model provider
 before launching a local goal. Managed Cloud deployments do not use the
 workstation's local model credentials.
-
-Do not silently pipe and execute a remote installer when the user only asked
-for advice. Show the command, or run it when installation is part of the
-authorized task.

--- a/skills/telos-cli/references/install.md
+++ b/skills/telos-cli/references/install.md
@@ -1,33 +1,46 @@
+---
+title: Install Telos
+description: Install the CLI, verify the release, and prepare Cloud or local authentication.
+group: Getting started
+---
+
 # Install Telos
 
 The default installer resolves the current promoted release:
 
 ```bash
 curl -fsSL https://usetelos.ai/install.sh | sh
-```
-
-Then verify the installed binary:
-
-```bash
 telos --version
 telos --help
 ```
 
-The installer places `telos` and `telosd` in `${TELOS_INSTALL_DIR:-$HOME/.local/bin}`
-and installs this skill under
+It installs `telos` and `telosd` under
+`${TELOS_INSTALL_DIR:-$HOME/.local/bin}` and this skill under
 `${TELOS_AGENT_SKILLS_DIR:-$HOME/.agents/skills}/telos-cli`.
 
-To install an exact prior release through the website installer, prefix the
-shell receiving the pipe:
+For Cloud work, sign in and confirm the target context:
+
+```bash
+telos login
+telos config
+```
+
+Then continue with [Use Telos](use-telos.md).
+
+For a local run, install `pi` if the installer reports it missing and
+authenticate the intended provider with `pi` → `/login`. Then follow
+[Bounded runs](bounded-runs.md). Managed Cloud deployments do not use the
+workstation's local model credentials.
+
+## Install an exact release
+
+Prefix the shell receiving the installer pipe:
 
 ```bash
 curl -fsSL https://usetelos.ai/install.sh | TELOS_INSTALL_VERSION=v0.1.2 sh
 ```
 
+## Repair the command path
+
 If the shell cannot find `telos`, add `$HOME/.local/bin` to `PATH` or set
 `TELOS_INSTALL_DIR` before installing.
-
-Local runs use the `pi` coding-agent runtime. If it is absent, follow the
-installer's current setup message and authenticate the intended model provider
-before launching a local goal. Managed Cloud deployments do not use the
-workstation's local model credentials.

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -1,0 +1,124 @@
+---
+title: The Goal lifecycle
+description: What a Goal's states mean, how it moves between them, and what Ready proves.
+group: Concepts
+---
+
+# The Goal lifecycle
+
+A Goal outlives every attempt to satisfy it. Sessions, agents, and revisions
+are replaceable; the Goal and its session ID are not. This page is the state
+model behind that.
+
+## The shape of a revision
+
+```
+edit SPEC.md ─▶ telos plan ─▶ telos apply ─▶ working ─▶ ready
+                                                │
+                                                └─▶ needs_attention
+```
+
+`apply` returns as soon as the work is accepted, not when it is done. The
+session ID it prints is stable for the life of the Goal. Every later revision
+reuses it with `--session`.
+
+## Deployment status
+
+A managed Goal reports one of four states. `telos describe SESSION_ID` shows
+it, and `--json` exposes it as `status`.
+
+| Status | Meaning |
+| --- | --- |
+| `working` | Preparing the runtime, implementing the spec, or verifying it. |
+| `ready` | The current spec was accepted and its latest verification passed. |
+| `needs_attention` | A run failed, verification was rejected, or the session stopped unexpectedly. Read the reason. |
+| `stopped` | The deployment was stopped or deleted. |
+
+Each status carries a human-readable reason. While `working`, that reason
+distinguishes preparing the runtime from implementing the spec from verifying
+it, so a stalled Goal can be told apart from a busy one.
+
+`needs_attention` is not a transient state to wait out. It means the platform
+has stopped making progress and wants a decision.
+
+## What Ready proves
+
+`ready` is scoped to an exact revision digest. It means *this* package was
+reconciled and accepted — not that the Goal is healthy in general, and not
+that a future drift check has run.
+
+```bash
+telos describe SESSION_ID --json | jq -e '.status == "ready"'
+```
+
+`jq` is not part of the Telos install; use `--json` with whatever the machine
+already has.
+
+Do not read acceptance from anything else. Allocation succeeding, a process
+starting, a green test in the logs, and a stale event from a previous revision
+are all compatible with a Goal that never became `ready`. When the contract
+exposes public behaviour, probe that too — the live surface is the claim, and
+tests are not a substitute for it.
+
+## Revising a Goal
+
+Update the spec, bump its version, and re-plan against the durable session.
+This is the only form of `plan` that produces a reviewable diff:
+
+```console
+$ telos plan SPEC.md --session sess_c7d2f0a4e8
+Session   sess_c7d2f0a4e8
+Current   sha256:8f21c47a...
+Version   1.1.3 -> 1.2.0
+
++ 30 days of uptime history render for each service.
+```
+
+A first `plan`, with no `--session`, has nothing to compare against and prints
+only the spec's identity and hash. Then:
+
+```bash
+telos apply SPEC.md --session sess_c7d2f0a4e8
+```
+
+Work is incremental. The session, its history, and the service URL stay
+stable while agents reconcile the change.
+
+## Session states
+
+Underneath a deployment, the runtime tracks its own session status: `pending`,
+`running`, `completed`, `failed`, `stopped`, or `stale`. The last four are
+terminal — no further progress will happen without a new revision.
+
+Each revision also carries a reconciliation state for its exact package
+digest: `pending`, `accepted`, or `failed`. `accepted` for the current digest
+is what makes a deployment `ready`.
+
+`telos list --wide` shows sessions across a context; `--cloud` and `--local`
+narrow it.
+
+## Reading the evidence
+
+```bash
+telos logs SESSION_ID
+```
+
+**`logs` shows the 50 most recent activity rows by default.** A truncated
+window is the usual reason an agent concludes the wrong thing about a run.
+
+- `--tail N` for a different window
+- `--all` for every row
+- `--raw` for the underlying transcript and evidence events
+- `--json` for newline-delimited events
+
+## Stopping
+
+Deletion is consequential and is not a way to retry. Confirm the session and
+what should be preserved first, then:
+
+```bash
+telos delete SESSION_ID
+```
+
+Never leave a Goal in `needs_attention` and create a second deployment beside
+it. Diagnose the first.

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -9,6 +9,9 @@ group: Concepts
 Telos separates the outcome you author from the immutable revisions and
 execution that make it true.
 
+The [Glossary](glossary.md) defines the wider Telos vocabulary. These five
+objects form the persistent lifecycle:
+
 | Term | Public meaning |
 | --- | --- |
 | Goal | The durable outcome and identity that persist across spec revisions. |

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -1,124 +1,128 @@
 ---
 title: The Goal lifecycle
-description: What a Goal's states mean, how it moves between them, and what Ready proves.
+description: Follow a Goal through revisions, understand its states, and read the evidence behind Ready.
 group: Concepts
 ---
 
 # The Goal lifecycle
 
-A Goal outlives every attempt to satisfy it. Sessions, agents, and revisions
-are replaceable; the Goal and its session ID are not. This page is the state
-model behind that.
+A persistent Goal has one stable session and a sequence of immutable revisions.
+Each revision is another attempt to make the contract in `SPEC.md` true.
 
-## The shape of a revision
-
-```
-edit SPEC.md ─▶ telos plan ─▶ telos apply ─▶ working ─▶ ready
-                                                │
-                                                └─▶ needs_attention
+```text
+SPEC.md ── plan ── apply ── working ── ready
+                                  └── needs_attention
 ```
 
-`apply` returns as soon as the work is accepted, not when it is done. The
-session ID it prints is stable for the life of the Goal. Every later revision
-reuses it with `--session`.
+`apply` returns when Cloud accepts the revision for work. Reconciliation then
+continues in the background, and `describe` shows what happened next.
 
-## Deployment status
-
-A managed Goal reports one of four states. `telos describe SESSION_ID` shows
-it, and `--json` exposes it as `status`.
-
-| Status | Meaning |
-| --- | --- |
-| `working` | Preparing the runtime, implementing the spec, or verifying it. |
-| `ready` | The current spec was accepted and its latest verification passed. |
-| `needs_attention` | A run failed, verification was rejected, or the session stopped unexpectedly. Read the reason. |
-| `stopped` | The deployment was stopped or deleted. |
-
-Each status carries a human-readable reason. While `working`, that reason
-distinguishes preparing the runtime from implementing the spec from verifying
-it, so a stalled Goal can be told apart from a busy one.
-
-`needs_attention` is not a transient state to wait out. It means the platform
-has stopped making progress and wants a decision.
-
-## What Ready proves
-
-`ready` is scoped to an exact revision digest. It means *this* package was
-reconciled and accepted — not that the Goal is healthy in general, and not
-that a future drift check has run.
+## Read the current state
 
 ```bash
-telos describe SESSION_ID --json | jq -e '.status == "ready"'
+telos describe SESSION_ID
 ```
 
-`jq` is not part of the Telos install; use `--json` with whatever the machine
-already has.
+A managed Goal reports one of four states:
 
-Do not read acceptance from anything else. Allocation succeeding, a process
-starting, a green test in the logs, and a stale event from a previous revision
-are all compatible with a Goal that never became `ready`. When the contract
-exposes public behaviour, probe that too — the live surface is the claim, and
-tests are not a substitute for it.
+| State | What it tells you |
+| --- | --- |
+| `working` | Cloud is preparing the runtime, implementing the spec, or verifying the result. |
+| `ready` | The displayed revision was reconciled and its latest verification passed. |
+| `needs_attention` | Reconciliation stopped after a failed run, rejected verification, or unexpected session stop. The reason describes the next decision. |
+| `stopped` | The deployment was stopped or deleted. |
 
-## Revising a Goal
+The accompanying reason makes `working` and `needs_attention` more specific.
+It distinguishes runtime preparation from implementation and verification, and
+it preserves the failure that ended an unsuccessful attempt.
 
-Update the spec, bump its version, and re-plan against the durable session.
-This is the only form of `plan` that produces a reviewable diff:
+## Ready belongs to a revision
+
+The revision digest in `describe` is part of the result:
+
+```console
+$ telos describe sess_c7d2f0a4e8
+Name      reading-list
+Status    ready
+Session   sess_c7d2f0a4e8
+Revision  sha256:8f21c47a91ee1438e724bdb55edc81af864db782c29dfb10870e8cdb304f6e1a
+Context   personal
+Service   https://reading-list-c7d2f0a4e8.usetelos.ai
+```
+
+This says that the displayed package was accepted. A later edit, a previous
+green event, or a running process is a different fact. For automation,
+`telos describe SESSION_ID --json` exposes both `status` and
+`package_digest` without parsing the table.
+
+When a Goal publishes a service, the service itself completes the evidence:
+exercise the behavior named in the spec after the matching revision is
+`ready`.
+
+## Move the Goal forward
+
+Edit `SPEC.md`, bump its version, and compare it with the deployed revision:
 
 ```console
 $ telos plan SPEC.md --session sess_c7d2f0a4e8
+Spec      reading-list
+Target    cloud
+Context   personal
 Session   sess_c7d2f0a4e8
-Current   sha256:8f21c47a...
-Version   1.1.3 -> 1.2.0
+Current   @alice/reading-list:0.1.0
+Path      /Users/alice/reading-list/SPEC.md
+Namespace ns-reading-list
+Hash      9e8d86776e85ffbc
+Version   0.1.0 -> 0.2.0
 
-+ 30 days of uptime history render for each service.
+--- deployed/SPEC.md
++++ proposed/SPEC.md
+@@ -1,6 +1,6 @@
+ ---
+ name: reading-list
+-version: 0.1.0
++version: 0.2.0
+ platform: cloud
+ ---
 ```
 
-A first `plan`, with no `--session`, has nothing to compare against and prints
-only the spec's identity and hash. Then:
+`Current` is the immutable package reference deployed in the session. The
+unified diff that follows is the contract change Cloud will reconcile.
 
 ```bash
 telos apply SPEC.md --session sess_c7d2f0a4e8
 ```
 
-Work is incremental. The session, its history, and the service URL stay
-stable while agents reconcile the change.
+The session ID and its history remain stable while the new revision moves
+through the lifecycle.
 
-## Session states
-
-Underneath a deployment, the runtime tracks its own session status: `pending`,
-`running`, `completed`, `failed`, `stopped`, or `stale`. The last four are
-terminal — no further progress will happen without a new revision.
-
-Each revision also carries a reconciliation state for its exact package
-digest: `pending`, `accepted`, or `failed`. `accepted` for the current digest
-is what makes a deployment `ready`.
-
-`telos list --wide` shows sessions across a context; `--cloud` and `--local`
-narrow it.
-
-## Reading the evidence
+## Read the work behind the state
 
 ```bash
 telos logs SESSION_ID
 ```
 
-**`logs` shows the 50 most recent activity rows by default.** A truncated
-window is the usual reason an agent concludes the wrong thing about a run.
+The default view contains the 50 most recent activity rows. Choose a larger or
+more structured view when the question requires it:
 
-- `--tail N` for a different window
-- `--all` for every row
-- `--raw` for the underlying transcript and evidence events
-- `--json` for newline-delimited events
+| View | Command |
+| --- | --- |
+| Last N activity rows | `telos logs SESSION_ID --tail N` |
+| Complete activity history | `telos logs SESSION_ID --all` |
+| Underlying transcript and evidence events | `telos logs SESSION_ID --raw` |
+| Newline-delimited event records | `telos logs SESSION_ID --json` |
 
-## Stopping
+The runtime also records session states beneath the managed deployment:
+`pending`, `running`, `completed`, `failed`, `stopped`, and `stale`.
+A revision is separately `pending`, `accepted`, or `failed`. Acceptance of
+the current package digest is what produces the managed `ready` state.
 
-Deletion is consequential and is not a way to retry. Confirm the session and
-what should be preserved first, then:
+## Stop a Goal
 
 ```bash
 telos delete SESSION_ID
 ```
 
-Never leave a Goal in `needs_attention` and create a second deployment beside
-it. Diagnose the first.
+Deletion stops the deployment. A Goal in `needs_attention` still retains its
+identity, history, and failure reason, so a corrected revision can continue on
+the same session.

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -44,7 +44,7 @@ A managed Goal reports:
 | `working` | Cloud is preparing the runtime, implementing the spec, or verifying the revision. |
 | `ready` | The current reconciliation completed and its latest verification passed. |
 | `needs_attention` | Reconciliation stopped after a failed run, rejected verification, or unexpected session stop. The reason identifies the next decision. |
-| `stopped` | The deployment was stopped or deleted. |
+| `stopped` | The deployment is stopped or its deletion has begun. |
 
 ## `ready` belongs to a revision
 
@@ -58,9 +58,11 @@ Public-route publication has its own surface probe and can finish after the
 managed state first becomes `ready`. A public service also needs a non-empty
 `service_url` from `describe --json` before external verification can begin.
 
-Older compatibility deployments can project `ready` from a completed execution
-without digest-bound reconciliation, and the current CLI does not expose that
-status provenance. Live behavior is therefore required evidence even when the
+### Compatibility note
+
+Older deployments can project `ready` from a completed execution without
+digest-bound reconciliation, and the current CLI does not expose that status
+provenance. Live behavior is therefore required evidence even when the
 displayed digest matches the receipt.
 
 ## Observe without waiting forever
@@ -111,12 +113,28 @@ The Goal, session, deployment, and history remain stable. The new immutable
 revision moves through the same lifecycle. [Use Telos](use-telos.md) shows the
 full diff and receipt.
 
-## Stop a Goal
+## Delete a Goal
+
+Resolve the session and context, explain the consequences below, and obtain the
+user's approval before running:
 
 ```bash
 telos delete SESSION_ID --context CONTEXT
 ```
 
-Deletion stops the deployment. A Goal in `needs_attention` retains its session,
-history, and failure reason, so a corrected revision can continue on the same
-identity.
+Cloud deletion is irreversible. It tears down the environment and application,
+including PVC data; removes public routes, the deployment record, integration
+attachments, and Goal history. Teardown is asynchronous, so the receipt may
+report that deletion was requested while cleanup continues. Once cleanup
+finishes, `list` omits the Goal and subsequent `describe` calls return not
+found.
+
+Local deletion has different semantics:
+
+```bash
+telos delete LOCAL_SESSION_ID
+```
+
+It stops the local session and preserves its history. A Goal in
+`needs_attention` also retains its Cloud history until the user either applies
+a corrected revision or explicitly deletes it.

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -1,128 +1,122 @@
 ---
 title: The Goal lifecycle
-description: Follow a Goal through revisions, understand its states, and read the evidence behind Ready.
+description: Understand Goal identity, observe revisions, and read the evidence behind ready.
 group: Concepts
 ---
 
 # The Goal lifecycle
 
-A persistent Goal has one stable session and a sequence of immutable revisions.
-Each revision is another attempt to make the contract in `SPEC.md` true.
+Telos separates the outcome you author from the immutable revisions and
+execution that make it true.
+
+| Term | Public meaning |
+| --- | --- |
+| Goal | The durable outcome and identity that persist across spec revisions. |
+| `SPEC.md` | The editable source contract describing the outcome and its evidence. |
+| Revision | One immutable version of the compiled contract, identified by a digest. |
+| Session | The CLI handle and history. A persistent Goal keeps one session across revisions; each bounded run gets its own session. |
+| Deployment | The managed Cloud object that owns the current revision, runtime allocation, URLs, and status for a persistent Goal. |
+
+The two execution paths are:
 
 ```text
-SPEC.md ── plan ── apply ── working ── ready
-                                  └── needs_attention
+Persistent: SPEC.md → plan → apply → Goal/session/deployment → revision history
+Bounded:    local spec → run with a bound → run session → evidence
 ```
 
-`apply` returns when Cloud accepts the revision for work. Reconciliation then
-continues in the background, and `describe` shows what happened next.
+`apply` returns after Cloud accepts a revision for work. Reconciliation
+continues in the background; `describe` reports the managed Goal state.
 
-## Read the current state
+## Read the state layers
 
-```bash
-telos describe SESSION_ID
-```
+The product exposes three related state layers:
 
-A managed Goal reports one of four states:
+| Layer | States | Where it appears |
+| --- | --- | --- |
+| Managed Goal | `working`, `ready`, `needs_attention`, `stopped` | Cloud `list` and `describe` |
+| Execution session | `pending`, `running`, `completed`, `failed`, `stopped`, `stale` | Local runs and lower-level runtime events |
+| Revision acceptance | `pending`, `accepted`, `failed` | Reconciliation and evidence events |
 
-| State | What it tells you |
+A managed Goal reports:
+
+| State | Meaning |
 | --- | --- |
-| `working` | Cloud is preparing the runtime, implementing the spec, or verifying the result. |
-| `ready` | The displayed revision was reconciled and its latest verification passed. |
-| `needs_attention` | Reconciliation stopped after a failed run, rejected verification, or unexpected session stop. The reason describes the next decision. |
+| `working` | Cloud is preparing the runtime, implementing the spec, or verifying the revision. |
+| `ready` | The current reconciliation completed and its latest verification passed. |
+| `needs_attention` | Reconciliation stopped after a failed run, rejected verification, or unexpected session stop. The reason identifies the next decision. |
 | `stopped` | The deployment was stopped or deleted. |
 
-The accompanying reason makes `working` and `needs_attention` more specific.
-It distinguishes runtime preparation from implementation and verification, and
-it preserves the failure that ended an unsuccessful attempt.
+## `ready` belongs to a revision
 
-## Ready belongs to a revision
+Capture the revision digest returned by `apply`, then compare it with
+`package_digest` from `describe --json`. On current reconciliation-aware
+runtimes, `ready` means reconciliation completed and the latest verification
+passed for that displayed digest. The service itself completes the evidence:
+exercise the behavior named by the spec after the matching revision is `ready`.
 
-The revision digest in `describe` is part of the result:
+Public-route publication has its own surface probe and can finish after the
+managed state first becomes `ready`. A public service also needs a non-empty
+`service_url` from `describe --json` before external verification can begin.
 
-```console
-$ telos describe sess_c7d2f0a4e8
-Name      reading-list
-Status    ready
-Session   sess_c7d2f0a4e8
-Revision  sha256:8f21c47a91ee1438e724bdb55edc81af864db782c29dfb10870e8cdb304f6e1a
-Context   personal
-Service   https://reading-list-c7d2f0a4e8.usetelos.ai
-```
+Older compatibility deployments can project `ready` from a completed execution
+without digest-bound reconciliation, and the current CLI does not expose that
+status provenance. Live behavior is therefore required evidence even when the
+displayed digest matches the receipt.
 
-This says that the displayed package was accepted. A later edit, a previous
-green event, or a running process is a different fact. For automation,
-`telos describe SESSION_ID --json` exposes both `status` and
-`package_digest` without parsing the table.
+## Observe without waiting forever
 
-When a Goal publishes a service, the service itself completes the evidence:
-exercise the behavior named in the spec after the matching revision is
-`ready`.
-
-## Move the Goal forward
-
-Edit `SPEC.md`, bump its version, and compare it with the deployed revision:
-
-```console
-$ telos plan SPEC.md --session sess_c7d2f0a4e8
-Spec      reading-list
-Target    cloud
-Context   personal
-Session   sess_c7d2f0a4e8
-Current   @alice/reading-list:0.1.0
-Path      /Users/alice/reading-list/SPEC.md
-Namespace ns-reading-list
-Hash      9e8d86776e85ffbc
-Version   0.1.0 -> 0.2.0
-
---- deployed/SPEC.md
-+++ proposed/SPEC.md
-@@ -1,6 +1,6 @@
- ---
- name: reading-list
--version: 0.1.0
-+version: 0.2.0
- platform: cloud
- ---
-```
-
-`Current` is the immutable package reference deployed in the session. The
-unified diff that follows is the contract change Cloud will reconcile.
+Use the context, session, and digest from the `apply` receipt. Unless the Goal
+suggests a different runtime, use a 30-minute observation deadline:
 
 ```bash
-telos apply SPEC.md --session sess_c7d2f0a4e8
+telos describe SESSION_ID --context CONTEXT --json
 ```
 
-The session ID and its history remain stable while the new revision moves
-through the lifecycle.
+An agent observation loop has four operations:
 
-## Read the work behind the state
+1. Run `describe --json` every 15 seconds.
+2. Read `status` and `package_digest` from each response.
+3. Continue at `working`. Finish at `ready` when no public route is required;
+   for a public service, finish when `ready` also includes `service_url`.
+   Return the reason at `needs_attention` or `stopped`.
+4. Stop if the digest changes or the 30-minute deadline expires, then return the
+   last state instead of waiting indefinitely.
+
+`logs` supplies the work and verification evidence behind the state:
 
 ```bash
-telos logs SESSION_ID
+telos logs SESSION_ID --context CONTEXT
 ```
 
-The default view contains the 50 most recent activity rows. Choose a larger or
-more structured view when the question requires it:
+The default view contains the 50 most recent activity rows:
 
 | View | Command |
 | --- | --- |
-| Last N activity rows | `telos logs SESSION_ID --tail N` |
-| Complete activity history | `telos logs SESSION_ID --all` |
-| Underlying transcript and evidence events | `telos logs SESSION_ID --raw` |
-| Newline-delimited event records | `telos logs SESSION_ID --json` |
+| Last N activity rows | `telos logs SESSION_ID --context CONTEXT --tail N` |
+| Complete activity history | `telos logs SESSION_ID --context CONTEXT --all` |
+| Underlying transcript and evidence events | `telos logs SESSION_ID --context CONTEXT --raw` |
+| Newline-delimited event records | `telos logs SESSION_ID --context CONTEXT --json` |
 
-The runtime also records session states beneath the managed deployment:
-`pending`, `running`, `completed`, `failed`, `stopped`, and `stale`.
-A revision is separately `pending`, `accepted`, or `failed`. Acceptance of
-the current package digest is what produces the managed `ready` state.
+## Move a persistent Goal forward
+
+Edit `SPEC.md`, bump its version, and compare the proposed contract with the
+deployed revision:
+
+```bash
+telos plan SPEC.md --session SESSION_ID --context CONTEXT
+telos apply SPEC.md --session SESSION_ID --context CONTEXT
+```
+
+The Goal, session, deployment, and history remain stable. The new immutable
+revision moves through the same lifecycle. [Use Telos](use-telos.md) shows the
+full diff and receipt.
 
 ## Stop a Goal
 
 ```bash
-telos delete SESSION_ID
+telos delete SESSION_ID --context CONTEXT
 ```
 
-Deletion stops the deployment. A Goal in `needs_attention` still retains its
-identity, history, and failure reason, so a corrected revision can continue on
-the same session.
+Deletion stops the deployment. A Goal in `needs_attention` retains its session,
+history, and failure reason, so a corrected revision can continue on the same
+identity.

--- a/skills/telos-cli/references/nested-goals.md
+++ b/skills/telos-cli/references/nested-goals.md
@@ -1,27 +1,46 @@
 # Nested child goals
 
-A running Telos agent may use `telos run` to launch bounded child work. Telos
-automatically scopes it to the current parent session.
+A running Telos agent can delegate an independent, bounded result to another
+Telos run. The child becomes its own session while remaining linked to the
+parent.
 
-Use a child only when decomposition creates a genuinely independent result or
-reduces the parent agent's context burden. Prefer direct work for small tasks.
+For example, a parent implementing a service might delegate a compatibility
+report:
 
-Inside a Telos session:
+```markdown
+---
+name: compatibility-report
+version: 0.1.0
+platform: local
+---
+
+# Goal
+
+Compare the current API responses with the v1 fixtures and return a report of
+every incompatible change, with the fixture and response that prove it.
+```
+
+Inside the parent session:
 
 ```bash
 telos run path/to/CHILD_SPEC.md --until 2 --max-cost-usd 5
 ```
 
-What a child can and cannot do:
+`--until` accepts a review-cycle count or a duration such as `30m`.
+`--max-cost-usd` adds a spend bound. Telos supplies the environment-local
+capability needed to create and inspect the child, so the spec contains no user
+or Cloud credentials.
 
-- A child may not create or update a durable Goal with `telos apply`. That
-  mutation stays a top-level operator action.
-- A child needs no credentials of its own. Telos supplies the scoped,
-  environment-local capability for creating and inspecting children, so user
-  and Cloud credentials never belong in a child spec.
-- A child accepts the same bounds as any `run`: `--until` for cycles or
-  duration, `--max-cost-usd` for spend.
+A child can produce files, tests, analysis, or another observable deliverable.
+Persistent `telos apply` is a top-level lifecycle and is unavailable inside a
+session; nested work uses `run`.
 
-Inspect child work with `telos list --wide`, `telos describe CHILD_SESSION_ID`,
-and `telos logs CHILD_SESSION_ID`. Submission is not completion — see
-[The Goal lifecycle](lifecycle.md).
+The submission receipt contains the child session ID. Follow it like any other
+run:
+
+```bash
+telos describe CHILD_SESSION_ID
+telos logs CHILD_SESSION_ID
+```
+
+The parent can then inspect, integrate, and verify the child's result.

--- a/skills/telos-cli/references/nested-goals.md
+++ b/skills/telos-cli/references/nested-goals.md
@@ -1,46 +1,33 @@
-# Nested child goals
-
-A running Telos agent can delegate an independent, bounded result to another
-Telos run. The child becomes its own session while remaining linked to the
-parent.
-
-For example, a parent implementing a service might delegate a compatibility
-report:
-
-```markdown
 ---
-name: compatibility-report
-version: 0.1.0
-platform: local
+title: Nested Goals
+description: Delegate bounded child work from a running Telos session and integrate its evidence.
+group: Concepts
 ---
 
-# Goal
+# Nested Goals
 
-Compare the current API responses with the v1 fixtures and return a report of
-every incompatible change, with the fixture and response that prove it.
-```
-
-Inside the parent session:
+A nested Goal is the [bounded-run](bounded-runs.md) workflow launched from
+inside another Telos session. The child receives its own session and remains
+linked to its parent.
 
 ```bash
 telos run path/to/CHILD_SPEC.md --until 2 --max-cost-usd 5
 ```
 
-`--until` accepts a review-cycle count or a duration such as `30m`.
-`--max-cost-usd` adds a spend bound. Telos supplies the environment-local
-capability needed to create and inspect the child, so the spec contains no user
-or Cloud credentials.
+The child spec uses `platform: local`. `--until` accepts a review-cycle count or
+a duration such as `30m`; `--max-cost-usd` adds a spend bound. Telos supplies
+the environment-local capability to create and inspect the child, so the spec
+contains no user or Cloud credentials.
 
 A child can produce files, tests, analysis, or another observable deliverable.
-Persistent `telos apply` is a top-level lifecycle and is unavailable inside a
-session; nested work uses `run`.
+Persistent `telos apply` is a top-level lifecycle; nested work uses `run`.
 
-The submission receipt contains the child session ID. Follow it like any other
-run:
+The submission receipt contains the child session ID:
 
 ```bash
 telos describe CHILD_SESSION_ID
 telos logs CHILD_SESSION_ID
 ```
 
-The parent can then inspect, integrate, and verify the child's result.
+The parent inspects the result, integrates anything it needs, and verifies the
+child evidence against the parent Goal.

--- a/skills/telos-cli/references/nested-goals.md
+++ b/skills/telos-cli/references/nested-goals.md
@@ -12,18 +12,16 @@ Inside a Telos session:
 telos run path/to/CHILD_SPEC.md --until 2 --max-cost-usd 5
 ```
 
-Rules:
+What a child can and cannot do:
 
-- Always give child work an observable deliverable and a finite cycle, time, or
-  cost bound.
-- Avoid recursive fan-out. Launch the fewest children needed and inspect their
-  results before creating more.
-- A child may not create or update a durable controller with `telos apply`.
-  That mutation remains a top-level operator action.
-- Do not pass user or Cloud credentials into the child spec. Telos supplies the
-  scoped environment-local capability needed to create and inspect children.
-- The parent remains responsible for integrating and verifying child output.
+- A child may not create or update a durable Goal with `telos apply`. That
+  mutation stays a top-level operator action.
+- A child needs no credentials of its own. Telos supplies the scoped,
+  environment-local capability for creating and inspecting children, so user
+  and Cloud credentials never belong in a child spec.
+- A child accepts the same bounds as any `run`: `--until` for cycles or
+  duration, `--max-cost-usd` for spend.
 
-Use `telos list --wide`, `telos describe CHILD_SESSION_ID`, and
-`telos logs CHILD_SESSION_ID` to inspect child work. Never treat successful
-submission as successful completion.
+Inspect child work with `telos list --wide`, `telos describe CHILD_SESSION_ID`,
+and `telos logs CHILD_SESSION_ID`. Submission is not completion — see
+[The Goal lifecycle](lifecycle.md).

--- a/skills/telos-cli/references/packages-and-skills.md
+++ b/skills/telos-cli/references/packages-and-skills.md
@@ -1,8 +1,22 @@
+---
+title: Packages and skills
+description: Publish immutable Telos artifacts, consume exact refs, and use skills as capabilities or rubrics.
+group: Platform
+---
+
 # Packages and skills
 
-Telos publishes immutable, versioned artifacts. The source file or skill
-directory remains the authoring source; the registry stores the exact bundle
-and content digest used by managed runtimes.
+Telos stores exact, versioned inputs so a revision can be reconstructed and
+verified later.
+
+| Term | Meaning |
+| --- | --- |
+| Package | An immutable compiled spec and its locked skill dependencies. |
+| Ref | A human-readable registry identity and version, such as `@scope/name:1.0.0`. |
+| Digest | The content identity of the exact bytes used by a revision. |
+| Rubric | A skill that an independent verifier must use when deciding whether the revision passes. |
+
+## Publish
 
 Publish a spec package:
 
@@ -16,27 +30,39 @@ Publish a skill directory containing `SKILL.md`:
 telos push path/to/skill --scope your-scope
 ```
 
-The skill version may come from its frontmatter or an explicit `--version`.
-Never reuse a version for different bytes. Capture the returned ref and digest.
+The version can come from frontmatter or an explicit `--version`. Registry
+versions are immutable; changed bytes receive a new version. Capture the
+returned ref and digest.
 
-Consume an exact registry skill from `SPEC.md`:
+## Consume
+
+Import an exact registry skill from `SPEC.md`:
 
 ```yaml
 skills:
   - "@scope/skill-name:0.1.0"
 ```
 
-A trailing `*` makes passing the skill's rubric required. Use it only when that
-rubric is part of the contract.
+The skill guides implementation. Add a trailing `*` when the same skill is
+also part of acceptance:
+
+```yaml
+skills:
+  - "@scope/service-readiness:1.0.0*"
+```
+
+Here, an independent verifier evaluates the result using
+`service-readiness`; the revision becomes accepted only if that rubric passes.
 
 Pull an immutable package for inspection or reuse:
 
 ```bash
 telos pull @scope/package-name:0.1.0
-telos apply @scope/package-name:0.1.0
+telos apply @scope/package-name:0.1.0 --context CONTEXT
 ```
 
-Use `telos get SESSION_ID` when the starting point is a session rather than a
-known registry ref. Telos verifies registry digests before materializing
-packages and skills. `apply` verifies and deploys an exact registry package
-without materializing or republishing it.
+Use `telos get SESSION_ID --context CONTEXT` when the starting point is a
+session rather than a known registry ref. Telos verifies registry digests
+before materializing packages and skills. `apply` deploys an exact registry
+package without materializing or republishing it. [The Goal lifecycle](lifecycle.md)
+explains how that package digest identifies a revision.

--- a/skills/telos-cli/references/packages-and-skills.md
+++ b/skills/telos-cli/references/packages-and-skills.md
@@ -18,6 +18,9 @@ verified later.
 
 ## Publish
 
+Resolve the intended scope, name, and immutable version, present them to the
+user, and obtain approval before publishing.
+
 Publish a spec package:
 
 ```bash

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -1,53 +1,74 @@
+---
+title: Troubleshooting
+description: Start from the observed symptom, inspect the decisive state, and return useful evidence.
+group: Reference
+---
+
 # Troubleshooting
 
-Start with facts:
+Start with the command that can distinguish the observed symptom:
 
-```bash
-telos --version
-telos config
-telos plan SPEC.md
-telos describe SESSION_ID
-telos logs SESSION_ID
-```
-
-Use `--json` when exact fields or automated diagnosis matter. Do not paste
-credential files, bearer tokens, or unrestricted environment dumps into logs
-or support messages.
+| Symptom | First check | Decisive evidence |
+| --- | --- | --- |
+| `telos` is unavailable | `command -v telos` | Binary path or missing installation |
+| A local run will not start | `telos plan SPEC.md` | Platform or spec validation error |
+| Cloud authentication or target is wrong | `telos config` | Authentication and active context |
+| A spec is rejected | `telos plan SPEC.md` | First validation error |
+| A skill publish is rejected | Read the original `push` error and inspect the local frontmatter | Invalid bundle input or immutable-version conflict |
+| A deployment is not `ready` | `telos describe SESSION_ID --context CONTEXT --json` | Status, digest, and reason |
+| A nested run is rejected | `telos plan CHILD_SPEC.md` plus the original run error | Child platform/spec error or unavailable parent capability |
 
 ## Command not found
 
-Verify the installer completed and `${TELOS_INSTALL_DIR:-$HOME/.local/bin}` is
-on `PATH`. Re-run the checksummed installer when the binary is absent or the
-installed release is not the intended version.
+If `command -v telos` returns nothing, verify that
+`${TELOS_INSTALL_DIR:-$HOME/.local/bin}` is on `PATH`. Re-run the checksummed
+installer when the binary is absent or not the intended release.
 
 ## Local run cannot start
 
-Confirm the spec says `platform: local`, `pi` is on `PATH`, and the selected pi
-provider is authenticated. Use `telos run --help` to confirm model, thinking,
-cycle, time, and cost flags supported by the installed release.
+`telos plan` identifies malformed frontmatter or a platform mismatch. A local
+run requires `platform: local`, `pi` on `PATH`, and an authenticated provider.
+`telos run --help` shows the model, thinking, cycle, time, and cost flags
+supported by the installed release.
 
-## Cloud command is unauthenticated or targets the wrong team
+## Cloud authentication or context is wrong
 
-Run `telos config`. Log in again if authentication is invalid. Set the intended
-context explicitly; do not mutate a team deployment while the target is
-ambiguous.
+`telos config` shows whether authentication is valid and which context the CLI
+will use. Log in again if needed, then pass the intended `--context` explicitly
+through the Cloud workflow.
 
 ## Plan or publish rejects a spec or skill
 
-Read the first validation error. Check YAML frontmatter, semantic version,
-non-empty instructions, safe file paths, and exact registry refs. If a version
-already exists with different content, bump the version rather than attempting
-to overwrite it.
+The first validation error usually identifies the contract boundary: YAML
+frontmatter, semantic version, non-empty instructions, safe file paths, or an
+exact registry ref. A rejected `push` is already the evidence; retry after
+correcting its cited input. If a registry version exists with different
+content, publish the changed bytes under a new version.
 
-## Deployment is not ready
+## Deployment is not `ready`
 
-Inspect `describe` and `logs` before retrying. Distinguish active work, revision
-rejection, package-digest mismatch, runtime failure, and public-service failure.
-Do not create a second deployment merely to hide an actionable state in the
-first one.
+Compare `package_digest` with the revision from the `apply` receipt, then read
+the status reason and logs. This separates active work, revision rejection,
+runtime failure, and public-service failure. Continue the same session when it
+contains an actionable failure; create another deployment only for a distinct
+Goal.
+
+Legacy compatibility deployments can report `ready` from a completed execution
+without exposing whether reconciliation was digest-bound. The CLI cannot
+distinguish that provenance, so verify live behavior for every service even
+when the displayed digest matches.
 
 ## Nested run is rejected
 
-Nested execution supports `telos run`, not `telos apply`. Confirm the parent is
-running under Telos, the child spec is reachable inside its workspace, and the
-requested bounds are valid.
+Nested execution supports `telos run`, not `telos apply`. The original run
+error identifies whether the parent capability or a bound was rejected;
+`telos plan CHILD_SPEC.md` checks the child's frontmatter and platform without
+launching it. The child file must be reachable in the parent's workspace and
+declare `platform: local`.
+
+## Return diagnostic evidence
+
+Use `--json` when exact fields matter. Return the installed version, context,
+session ID, revision digest, status, reason, and the smallest relevant log
+slice. Credential files, bearer tokens, and unrestricted environment dumps are
+not diagnostic evidence.

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -53,10 +53,10 @@ runtime failure, and public-service failure. Continue the same session when it
 contains an actionable failure; create another deployment only for a distinct
 Goal.
 
-Legacy compatibility deployments can report `ready` from a completed execution
-without exposing whether reconciliation was digest-bound. The CLI cannot
-distinguish that provenance, so verify live behavior for every service even
-when the displayed digest matches.
+The lifecycle's [compatibility note](lifecycle.md#compatibility-note)
+explains why some older deployments lack digest-bound status provenance.
+Regardless of provenance, verify the live behavior promised by every service
+spec.
 
 ## Nested run is rejected
 

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -1,6 +1,7 @@
 ---
 title: Use Telos
 description: Give Telos a Goal, then follow it from a proposed contract to verified software.
+group: Getting started
 ---
 
 # Use Telos
@@ -9,34 +10,25 @@ Telos is a goal-oriented programming system. You describe what the software
 should do in `SPEC.md`; Telos assigns agents to implement, run, and verify the
 current revision.
 
-The spec is the durable artifact. Implementations can change as the Goal
-evolves, while the Goal keeps its identity, history, and evidence.
+The spec is the durable source. Implementations can change as the Goal evolves,
+while its session, deployment, history, and evidence remain connected.
 
 This guide follows one small service from its first spec through a live update.
+Generated IDs, digests, paths, and URLs in the transcripts are illustrative;
+the command and field shapes match the current CLI.
 
-## Install
+## Sign in and choose a context
 
-The CLI is designed to be driven by your coding agent. You can ask it:
-
-```text
-Set up Telos.
-
-- Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
-- Run `telos login` so I can approve access in the browser.
-- Read the installed `telos-cli` skill before continuing.
-```
-
-Or install and sign in directly:
-
-```bash
-curl -fsSL https://usetelos.ai/install.sh | sh
-telos login
-```
-
-`telos login` opens a browser approval flow. Once it completes, `telos config`
-shows the account and Cloud context the CLI will use:
+Install Telos first if needed, then authenticate and inspect the available
+Cloud contexts:
 
 ```console
+$ telos login
+Opening your browser to approve this login...
+If it doesn't open, visit this link on any device: https://usetelos.ai/cli-auth?code=...
+Waiting for approval...
+logged in to https://api.usetelos.ai as alice@example.com
+
 $ telos config
 Config file     ~/.telos/config.yaml
 Endpoint        https://api.usetelos.ai
@@ -45,6 +37,9 @@ Context         personal
 Default model   workspace default
 Subscriptions
 ```
+
+[Install Telos](install.md) covers first-time setup and PATH repair. This
+walkthrough uses the personal context explicitly on every Cloud command.
 
 ## Describe the Goal
 
@@ -71,21 +66,22 @@ Run a public service for a shared reading list.
   returns it.
 ```
 
-This contract names the behavior that matters without choosing a framework,
-database, or deployment layout. `platform: cloud` gives the Goal a managed,
-persistent lifecycle. A local spec uses `platform: local` instead.
+The contract names the behavior that matters without choosing a framework,
+database, or deployment layout. Before applying, confirm that the service fits
+the [managed Cloud runtime](cloud.md). This one does: a small interpreted
+service can be delivered from source, and environment-local persistent storage
+can satisfy its restart requirement.
 
-[Goals and specifications](goals.md) covers the complete spec shape.
-[Packages and skills](packages-and-skills.md) shows how to import reusable
-capabilities and evaluation rubrics.
+[Write a SPEC.md](goals.md) covers every supported frontmatter field and the
+boundary between a desired outcome and an available platform capability.
 
 ## Preview the first revision
 
-`plan` validates the spec and shows where it will run without changing any
-remote state:
+`plan` validates the spec and shows where it will run without changing remote
+state:
 
 ```console
-$ telos plan SPEC.md
+$ telos plan SPEC.md --context personal
 Spec      reading-list
 Target    cloud
 Context   personal
@@ -94,13 +90,14 @@ Namespace ns-reading-list
 Hash      799e5c31172afb26
 ```
 
-The first plan has no deployed revision to compare with, so it shows the
-Goal's identity, target, namespace, and content hash.
+Confirm the target and context before continuing. The first plan has no
+deployed revision to compare, so it shows the Goal identity, namespace, and
+content hash.
 
 ## Apply it
 
 ```console
-$ telos apply SPEC.md
+$ telos apply SPEC.md --context personal
 created reading-list
 
 Status    working
@@ -110,27 +107,28 @@ Context   personal
 Logs      telos logs --context personal sess_c7d2f0a4e8
 ```
 
-`working` means Cloud accepted this revision and is reconciling it. The
-session ID remains the identity of the Goal across later revisions.
+`working` means Cloud accepted this revision and is reconciling it. Keep both
+the session ID and revision digest: the session identifies the Goal, while the
+digest identifies the exact contract now being implemented.
 
-Follow progress with the commands printed in the receipt:
+Follow progress with the context printed in the receipt:
 
 ```bash
-telos describe sess_c7d2f0a4e8
-telos logs sess_c7d2f0a4e8
+telos describe sess_c7d2f0a4e8 --context personal --json
+telos logs sess_c7d2f0a4e8 --context personal
 ```
 
-Log messages reflect the actual implementation and verification work, so they
-vary from Goal to Goal. By default, `logs` shows the 50 most recent activity
-rows.
+[The Goal lifecycle](lifecycle.md) gives the polling interval, stopping
+conditions, and evidence rules for this observation step.
 
-## Observe Ready
+## Observe `ready`
 
-When reconciliation succeeds, `describe` reports the exact accepted revision
-and any public service URL:
+When reconciliation succeeds, `describe` reports the accepted revision. The
+public route is published after its own surface probe; once that succeeds,
+`describe` also includes `Service`:
 
 ```console
-$ telos describe sess_c7d2f0a4e8
+$ telos describe sess_c7d2f0a4e8 --context personal
 Name      reading-list
 Status    ready
 Session   sess_c7d2f0a4e8
@@ -139,28 +137,24 @@ Context   personal
 Service   https://reading-list-c7d2f0a4e8.usetelos.ai
 ```
 
-`ready` belongs to that revision digest: Cloud reconciled it and its latest
-verification passed. The service URL is the next piece of evidence. Exercise
-the routes named by the spec and confirm that their behavior matches the
-contract.
+On current managed runtimes, this `ready` result belongs to the displayed
+revision digest. The Cloud agent's evidence should include the promised
+write–restart–read sequence. From outside the environment, exercise
+`POST /books` and `GET /books` through the public URL and confirm the live
+behavior independently.
+
+If `ready` appears before `Service`, keep observing `describe` for route
+publication within the same deadline. A public service is not externally
+verifiable until that URL exists.
 
 ## Revise the same Goal
 
-Suppose the reading list now needs attribution. Bump the version and add the
-new behavior to the same spec:
-
-```markdown
-version: 0.2.0
-
-# Goal
-
-- Every book records who added it.
-```
-
+Suppose the reading list now needs attribution. Edit the same `SPEC.md`, bump
+its version to `0.2.0`, and add “Every book records who added it” to the Goal.
 Plan against the existing session:
 
 ```console
-$ telos plan SPEC.md --session sess_c7d2f0a4e8
+$ telos plan SPEC.md --session sess_c7d2f0a4e8 --context personal
 Spec      reading-list
 Target    cloud
 Context   personal
@@ -188,33 +182,29 @@ Version   0.1.0 -> 0.2.0
 +- Every book records who added it.
 ```
 
-Unlike the first preview, a session-aware plan includes the package currently
-deployed and a unified diff of the proposed contract. Apply the revision to
-that same session:
+The session-aware plan identifies the deployed package and displays the
+contract change. Apply that new revision to the same session:
 
-```bash
-telos apply SPEC.md --session sess_c7d2f0a4e8
+```console
+$ telos apply SPEC.md --session sess_c7d2f0a4e8 --context personal
+updated reading-list
+
+Status    working
+Session   sess_c7d2f0a4e8
+Revision  sha256:3211e85fe81bd70aa74726d4ce0dc68d729d816826a21b62b18eb86074ff3317
+Context   personal
+Service   https://reading-list-c7d2f0a4e8.usetelos.ai
+Logs      telos logs --context personal sess_c7d2f0a4e8
 ```
 
-Cloud reconciles the change while preserving the Goal's session and history.
-The new revision moves through `working` and `ready` like the first.
+The Goal, session, deployment, and history stay the same; only the immutable
+revision changes. Observe the new digest through `working` to `ready`, then
+exercise the updated API behavior.
 
-## Run bounded work
+## Continue from here
 
-Some work has a natural stopping point rather than a persistent service
-lifecycle. A local spec can run for at most three review cycles:
-
-```bash
-telos run SPEC.md --workspace . --until 3
-```
-
-`run` returns a session with logs and evidence, then stops at the bound.
-`apply` is the persistent lifecycle used by the reading-list example.
-
-## Go deeper
-
-- [The Goal lifecycle](lifecycle.md) explains states, revisions, and evidence.
-- [Goals and specifications](goals.md) explains what the contract can express.
-- [Telos Cloud](cloud.md) covers contexts, teams, and managed deployments.
-- [Models and inference](inference.md) covers managed models and connected subscriptions.
-- [Troubleshooting](troubleshooting.md) starts from the state Telos actually reports.
+- [Write a SPEC.md](goals.md) to express another contract.
+- [The Goal lifecycle](lifecycle.md) to understand identity and state.
+- [Bounded runs](bounded-runs.md) for local work with a stopping point.
+- [Models and inference](inference.md) to choose Cloud or local inference.
+- [Troubleshooting](troubleshooting.md) when observed state diverges from the contract.

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -1,60 +1,167 @@
 ---
 title: Use Telos
-description: You work with a coding agent. It uses Telos to run and verify background agents.
+description: Give Telos a goal, and it builds, runs, and verifies the software behind it.
 ---
 
-## Install
+## What Telos does
 
-Your coding agent can install the CLI. `telos login` pauses for your browser
-approval.
+You state what should remain true. Telos writes the implementation, deploys
+it, verifies it against your contract, and keeps it aligned as the contract
+changes. **You do not write or review the implementation** — the Goal is the
+artifact you keep.
+
+That contract is a `SPEC.md`. It outlives every agent and revision that tries
+to satisfy it.
+
+This page walks one Goal from nothing to a running, verified service.
+
+## 1. Install
 
 ```bash
 curl -fsSL https://usetelos.ai/install.sh | sh
 telos login
 ```
 
-## Specify
+`telos login` pauses for browser approval. Confirm where commands will land
+before running anything that spends:
 
-You and your coding agent agree on what should remain true. The agent writes it
-as a verifiable `SPEC.md`.
+```console
+$ telos config
+Config file     ~/.telos/config.yaml
+Endpoint        https://api.usetelos.ai
+Authentication  valid
+Context         @telos
+Default model   workspace default
+```
+
+## 2. Write the contract
+
+Smallest useful spec: an observable outcome, what must survive, and how
+success is proven.
 
 ```markdown
 ---
-name: hello-service
+name: status-page
 version: 0.1.0
 platform: cloud
 ---
 
 # Goal
 
-Keep `/healthz` available with persistent Postgres storage.
+Run a public status page for our services.
+
+- `GET /api/status` returns every service with its current state.
+- Incident history survives restarts and redeploys.
+
+# Acceptance
+
+- A newly reported incident appears on the public page within 60 seconds.
 ```
 
-## Apply
+`platform: cloud` runs it as a managed deployment. `platform: local` runs it
+on this machine. See [Goals and specifications](goals.md) for the full shape,
+and [Packages and skills](packages-and-skills.md) to attach skills or a
+required rubric.
+
+## 3. Preview
+
+```console
+$ telos plan SPEC.md
+Spec      status-page
+Target    cloud
+Context   @telos
+Path      SPEC.md
+Namespace ns-status-page
+Hash      e29c25796f22f453
+```
+
+A first `plan` confirms identity and target — which spec, which context, what
+it hashes to. It does not describe the work. The reviewable diff comes later,
+once there is a deployed revision to compare against.
+
+## 4. Apply
+
+```console
+$ telos apply SPEC.md
+created status-page
+
+Status    working
+Session   sess_c7d2f0a4e8
+Revision  sha256:8f21c47a...
+Logs      telos logs sess_c7d2f0a4e8
+```
+
+`apply` returns as soon as the work is accepted, not when it is finished.
+Agents build, test, and deploy in the background. **The session ID is stable
+for the life of the Goal** — every later revision reuses it.
+
+## 5. Wait for Ready
+
+```console
+$ telos describe sess_c7d2f0a4e8
+Name      status-page
+Status    ready
+Session   sess_c7d2f0a4e8
+Revision  sha256:8f21c47a...
+Service   https://status-page-c7d2f0a4e8.usetelos.ai
+```
+
+`ready` means that exact revision passed verification and is running. Poll
+`describe` with a bounded timeout; stop on a terminal failure. The four states
+and what each proves are in [The Goal lifecycle](lifecycle.md).
+
+Trace the work with:
+
+```console
+$ telos logs sess_c7d2f0a4e8
+[12:00:00Z] [INFO] Accepted managed session
+[12:04:22Z] [INFO] Implemented persistent incident history
+[12:08:47Z] [INFO] Service URL verified
+[12:11:06Z] [INFO] Running the required service checks
+[12:15:31Z] [INFO] Current revision accepted
+```
+
+`logs` shows the 50 most recent rows; pass `--all` or `--tail N` for more.
+
+Then use the live service. It is the claim; the logs are not.
+
+## 6. Change the contract
+
+Edit the spec, bump its version, and plan against the durable session. This
+form produces a real diff:
+
+```console
+$ telos plan SPEC.md --session sess_c7d2f0a4e8
+Session   sess_c7d2f0a4e8
+Current   sha256:8f21c47a...
+Version   0.1.0 -> 0.2.0
+
++ 30 days of uptime history render for each service.
+```
 
 ```bash
-telos plan SPEC.md
-telos apply SPEC.md
+telos apply SPEC.md --session sess_c7d2f0a4e8
 ```
 
-The agent runs `plan`; you approve the contract; the agent runs `apply`. Telos
-then delegates the background work.
+Agents reconcile the change incrementally. The session, its history, and the
+service URL stay stable.
 
-## Ready
+## Bounded work
 
-```bash
-telos describe SESSION_ID
-telos logs SESSION_ID
-```
-
-Ready means the exact revision passed verification and is running. Your coding
-agent follows the session and returns the evidence.
-
-## Local runs
+`apply` is for a Goal that should persist. For one bounded piece of work that
+should stop at a limit, use `run`:
 
 ```bash
 telos run SPEC.md --workspace . --until 3
 ```
 
-Your coding agent can use `run` for a bounded subgoal. It stops; `apply`
-persists.
+It stops at the bound and returns evidence. It does not create a durable
+Goal — only `apply` does.
+
+## Next
+
+- [The Goal lifecycle](lifecycle.md) — states, revisions, and what Ready proves
+- [Goals and specifications](goals.md) — writing the contract
+- [Telos Cloud](cloud.md) — contexts, teams, and managed deployments
+- [Models and inference](inference.md) — managed tiers or your own subscription
+- [Troubleshooting](troubleshooting.md) — when something does not reach Ready

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -92,7 +92,8 @@ Hash      799e5c31172afb26
 
 Confirm the target and context before continuing. The first plan has no
 deployed revision to compare, so it shows the Goal identity, namespace, and
-content hash.
+content hash. Present the resolved Cloud mutation to the user and obtain
+approval before applying it.
 
 ## Apply it
 
@@ -201,10 +202,32 @@ The Goal, session, deployment, and history stay the same; only the immutable
 revision changes. Observe the new digest through `working` to `ready`, then
 exercise the updated API behavior.
 
-## Continue from here
+For another contract, continue with [Write a SPEC.md](goals.md). Use
+[Bounded runs](bounded-runs.md) for local work and
+[Troubleshooting](troubleshooting.md) when observed state diverges from the
+contract.
 
-- [Write a SPEC.md](goals.md) to express another contract.
-- [The Goal lifecycle](lifecycle.md) to understand identity and state.
-- [Bounded runs](bounded-runs.md) for local work with a stopping point.
-- [Models and inference](inference.md) to choose Cloud or local inference.
-- [Troubleshooting](troubleshooting.md) when observed state diverges from the contract.
+## Resume later
+
+Return through the same context and recover the session ID from `list`:
+
+```bash
+telos list --context personal
+telos describe SESSION_ID --context personal
+```
+
+Continue revisions on that session so its identity and history remain joined.
+
+## Delete the Goal
+
+Cloud deletion is irreversible. After the user approves the exact session,
+context, and loss of the environment, application and PVC data, routes,
+attachments, deployment record, and history, run:
+
+```bash
+telos delete SESSION_ID --context personal
+```
+
+Teardown continues asynchronously; subsequent inspection eventually returns
+not found. [The Goal lifecycle](lifecycle.md#delete-a-goal) distinguishes this
+from local deletion, which preserves session history.

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -1,167 +1,220 @@
 ---
 title: Use Telos
-description: Give Telos a goal, and it builds, runs, and verifies the software behind it.
+description: Give Telos a Goal, then follow it from a proposed contract to verified software.
 ---
 
-## What Telos does
+# Use Telos
 
-You state what should remain true. Telos writes the implementation, deploys
-it, verifies it against your contract, and keeps it aligned as the contract
-changes. **You do not write or review the implementation** — the Goal is the
-artifact you keep.
+Telos is a goal-oriented programming system. You describe what the software
+should do in `SPEC.md`; Telos assigns agents to implement, run, and verify the
+current revision.
 
-That contract is a `SPEC.md`. It outlives every agent and revision that tries
-to satisfy it.
+The spec is the durable artifact. Implementations can change as the Goal
+evolves, while the Goal keeps its identity, history, and evidence.
 
-This page walks one Goal from nothing to a running, verified service.
+This guide follows one small service from its first spec through a live update.
 
-## 1. Install
+## Install
+
+The CLI is designed to be driven by your coding agent. You can ask it:
+
+```text
+Set up Telos.
+
+- Install it with `curl -fsSL https://usetelos.ai/install.sh | sh`.
+- Run `telos login` so I can approve access in the browser.
+- Read the installed `telos-cli` skill before continuing.
+```
+
+Or install and sign in directly:
 
 ```bash
 curl -fsSL https://usetelos.ai/install.sh | sh
 telos login
 ```
 
-`telos login` pauses for browser approval. Confirm where commands will land
-before running anything that spends:
+`telos login` opens a browser approval flow. Once it completes, `telos config`
+shows the account and Cloud context the CLI will use:
 
 ```console
 $ telos config
 Config file     ~/.telos/config.yaml
 Endpoint        https://api.usetelos.ai
 Authentication  valid
-Context         @telos
+Context         personal
 Default model   workspace default
+Subscriptions
 ```
 
-## 2. Write the contract
+## Describe the Goal
 
-Smallest useful spec: an observable outcome, what must survive, and how
-success is proven.
+Create `SPEC.md`:
 
 ```markdown
 ---
-name: status-page
+name: reading-list
 version: 0.1.0
 platform: cloud
 ---
 
 # Goal
 
-Run a public status page for our services.
+Run a public service for a shared reading list.
 
-- `GET /api/status` returns every service with its current state.
-- Incident history survives restarts and redeploys.
+- `POST /books` adds a title.
+- `GET /books` returns the current list.
+- Books remain available when the application restarts.
 
 # Acceptance
 
-- A newly reported incident appears on the public page within 60 seconds.
+- Add a title, restart the application, and confirm that `GET /books` still
+  returns it.
 ```
 
-`platform: cloud` runs it as a managed deployment. `platform: local` runs it
-on this machine. See [Goals and specifications](goals.md) for the full shape,
-and [Packages and skills](packages-and-skills.md) to attach skills or a
-required rubric.
+This contract names the behavior that matters without choosing a framework,
+database, or deployment layout. `platform: cloud` gives the Goal a managed,
+persistent lifecycle. A local spec uses `platform: local` instead.
 
-## 3. Preview
+[Goals and specifications](goals.md) covers the complete spec shape.
+[Packages and skills](packages-and-skills.md) shows how to import reusable
+capabilities and evaluation rubrics.
+
+## Preview the first revision
+
+`plan` validates the spec and shows where it will run without changing any
+remote state:
 
 ```console
 $ telos plan SPEC.md
-Spec      status-page
+Spec      reading-list
 Target    cloud
-Context   @telos
-Path      SPEC.md
-Namespace ns-status-page
-Hash      e29c25796f22f453
+Context   personal
+Path      /Users/alice/reading-list/SPEC.md
+Namespace ns-reading-list
+Hash      799e5c31172afb26
 ```
 
-A first `plan` confirms identity and target — which spec, which context, what
-it hashes to. It does not describe the work. The reviewable diff comes later,
-once there is a deployed revision to compare against.
+The first plan has no deployed revision to compare with, so it shows the
+Goal's identity, target, namespace, and content hash.
 
-## 4. Apply
+## Apply it
 
 ```console
 $ telos apply SPEC.md
-created status-page
+created reading-list
 
 Status    working
 Session   sess_c7d2f0a4e8
-Revision  sha256:8f21c47a...
-Logs      telos logs sess_c7d2f0a4e8
+Revision  sha256:8f21c47a91ee1438e724bdb55edc81af864db782c29dfb10870e8cdb304f6e1a
+Context   personal
+Logs      telos logs --context personal sess_c7d2f0a4e8
 ```
 
-`apply` returns as soon as the work is accepted, not when it is finished.
-Agents build, test, and deploy in the background. **The session ID is stable
-for the life of the Goal** — every later revision reuses it.
+`working` means Cloud accepted this revision and is reconciling it. The
+session ID remains the identity of the Goal across later revisions.
 
-## 5. Wait for Ready
+Follow progress with the commands printed in the receipt:
+
+```bash
+telos describe sess_c7d2f0a4e8
+telos logs sess_c7d2f0a4e8
+```
+
+Log messages reflect the actual implementation and verification work, so they
+vary from Goal to Goal. By default, `logs` shows the 50 most recent activity
+rows.
+
+## Observe Ready
+
+When reconciliation succeeds, `describe` reports the exact accepted revision
+and any public service URL:
 
 ```console
 $ telos describe sess_c7d2f0a4e8
-Name      status-page
+Name      reading-list
 Status    ready
 Session   sess_c7d2f0a4e8
-Revision  sha256:8f21c47a...
-Service   https://status-page-c7d2f0a4e8.usetelos.ai
+Revision  sha256:8f21c47a91ee1438e724bdb55edc81af864db782c29dfb10870e8cdb304f6e1a
+Context   personal
+Service   https://reading-list-c7d2f0a4e8.usetelos.ai
 ```
 
-`ready` means that exact revision passed verification and is running. Poll
-`describe` with a bounded timeout; stop on a terminal failure. The four states
-and what each proves are in [The Goal lifecycle](lifecycle.md).
+`ready` belongs to that revision digest: Cloud reconciled it and its latest
+verification passed. The service URL is the next piece of evidence. Exercise
+the routes named by the spec and confirm that their behavior matches the
+contract.
 
-Trace the work with:
+## Revise the same Goal
 
-```console
-$ telos logs sess_c7d2f0a4e8
-[12:00:00Z] [INFO] Accepted managed session
-[12:04:22Z] [INFO] Implemented persistent incident history
-[12:08:47Z] [INFO] Service URL verified
-[12:11:06Z] [INFO] Running the required service checks
-[12:15:31Z] [INFO] Current revision accepted
+Suppose the reading list now needs attribution. Bump the version and add the
+new behavior to the same spec:
+
+```markdown
+version: 0.2.0
+
+# Goal
+
+- Every book records who added it.
 ```
 
-`logs` shows the 50 most recent rows; pass `--all` or `--tail N` for more.
-
-Then use the live service. It is the claim; the logs are not.
-
-## 6. Change the contract
-
-Edit the spec, bump its version, and plan against the durable session. This
-form produces a real diff:
+Plan against the existing session:
 
 ```console
 $ telos plan SPEC.md --session sess_c7d2f0a4e8
+Spec      reading-list
+Target    cloud
+Context   personal
 Session   sess_c7d2f0a4e8
-Current   sha256:8f21c47a...
+Current   @alice/reading-list:0.1.0
+Path      /Users/alice/reading-list/SPEC.md
+Namespace ns-reading-list
+Hash      9e8d86776e85ffbc
 Version   0.1.0 -> 0.2.0
 
-+ 30 days of uptime history render for each service.
+--- deployed/SPEC.md
++++ proposed/SPEC.md
+@@ -1,6 +1,6 @@
+ ---
+ name: reading-list
+-version: 0.1.0
++version: 0.2.0
+ platform: cloud
+ ---
+
+@@ -11,6 +11,7 @@
+ - `POST /books` adds a title.
+ - `GET /books` returns the current list.
+ - Books remain available when the application restarts.
++- Every book records who added it.
 ```
+
+Unlike the first preview, a session-aware plan includes the package currently
+deployed and a unified diff of the proposed contract. Apply the revision to
+that same session:
 
 ```bash
 telos apply SPEC.md --session sess_c7d2f0a4e8
 ```
 
-Agents reconcile the change incrementally. The session, its history, and the
-service URL stay stable.
+Cloud reconciles the change while preserving the Goal's session and history.
+The new revision moves through `working` and `ready` like the first.
 
-## Bounded work
+## Run bounded work
 
-`apply` is for a Goal that should persist. For one bounded piece of work that
-should stop at a limit, use `run`:
+Some work has a natural stopping point rather than a persistent service
+lifecycle. A local spec can run for at most three review cycles:
 
 ```bash
 telos run SPEC.md --workspace . --until 3
 ```
 
-It stops at the bound and returns evidence. It does not create a durable
-Goal — only `apply` does.
+`run` returns a session with logs and evidence, then stops at the bound.
+`apply` is the persistent lifecycle used by the reading-list example.
 
-## Next
+## Go deeper
 
-- [The Goal lifecycle](lifecycle.md) — states, revisions, and what Ready proves
-- [Goals and specifications](goals.md) — writing the contract
-- [Telos Cloud](cloud.md) — contexts, teams, and managed deployments
-- [Models and inference](inference.md) — managed tiers or your own subscription
-- [Troubleshooting](troubleshooting.md) — when something does not reach Ready
+- [The Goal lifecycle](lifecycle.md) explains states, revisions, and evidence.
+- [Goals and specifications](goals.md) explains what the contract can express.
+- [Telos Cloud](cloud.md) covers contexts, teams, and managed deployments.
+- [Models and inference](inference.md) covers managed models and connected subscriptions.
+- [Troubleshooting](troubleshooting.md) starts from the state Telos actually reports.


### PR DESCRIPTION
## Summary

Reworks the Telos CLI documentation around one progressive model: author an observable contract, preview it, approve the resolved action, apply or run it, observe the exact revision, and retrieve the evidence or deliverable.

- **One persistent worked example.** `references/use-telos.md` follows a reading-list service from `SPEC.md` through `plan`, approval, `apply`, route publication, live verification, revision, resumption, and deletion. Prose, commands, representative output, and interpretation stay adjacent.
- **A distinct bounded path.** `references/bounded-runs.md` gives local work its own spec, stopping bound, $20 default cost ceiling and override precedence, clean-checkout contract, isolated workspace semantics, and checkpoint-extraction flow.
- **A stable lifecycle vocabulary.** `references/lifecycle.md` separates Goal, spec, revision, session, deployment, and their state layers. It is authoritative for detailed status semantics, including public-route publication lag and compatibility-runtime provenance.
- **A canonical glossary.** `references/glossary.md` defines Telos vocabulary in conceptual order, from Goal and spec through execution, evidence, and registry artifacts.
- **Explicit authorization and deletion semantics.** `run`, `apply`, `push`, and `delete` require approval of the resolved target and action. Cloud deletion is asynchronous and irreversible; local deletion preserves session history.
- **An expressive boundary.** `references/goals.md` starts with the smallest valid spec, then introduces the supported public fields and explains what a spec can express versus what the platform must already provide. Legacy `extends` machinery is not presented as a product surface.
- **Correct Cloud and inference contracts.** The public CLI contract covers explicit personal/team contexts, default-deny egress, current integration timing limits, workload delivery and storage preflight, Cloud model precedence, local pi selection, and explicit-empty model updates.
- **Progressive disclosure for agents.** `SKILL.md` owns the executable lifecycle and routes conditional detail into focused references instead of a wall of prohibitions.
- **A cleaner README.** The README keeps the smallest persistent path and defers detailed status semantics to the lifecycle reference.

## Documentation approach

The README is the style fixture for this work: one idea at a time, one evolving example, and reference material after the happy path. Agent-first means exact commands, stable vocabulary, observable outcomes, and explicit mutation boundaries. Human readers get the system model and capability boundary without having to reconstruct it from guardrails.

Generated IDs, digests, paths, and URLs in the worked transcript are labeled illustrative. Command and field shapes were checked against the current CLI and source; producing a real session-aware Cloud transcript still requires a live deployment.

## Validation

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/telos-cli`
- `go test ./cmd/telos ./internal/cli ./internal/spec`
- internal Markdown link check
- `git diff --check`
- adversarial review: editorial 9.1/10, cold-agent operability 9.4/10, factual contract 9.3/10 across both documentation PRs

## Follow-ups outside this PR

- Fix the launch post's invalid bare skill references.
- Add the CLI reference page and reclaim `/docs/cli`.
- Normalize context rendering between `telos config` and command receipts.

A Telos release publish and promotion is still required before these docs reach usetelos.ai/docs.
