### PR TITLE
docs(skill): remove canned quickstart prompt

### DIFF
--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -3,7 +3,6 @@ name: telos-cli
 description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud login and context, session inspection, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
 metadata:
   registry: "@telos/telos-cli"
-  quickstart_prompt: "assets/quickstart-prompt.txt"
   public_guide: "references/use-telos.md"
   source_repository: "https://github.com/telos-org/telos"
 ---

--- a/skills/telos-cli/agents/openai.yaml
+++ b/skills/telos-cli/agents/openai.yaml
@@ -1,4 +1,3 @@
 interface:
   display_name: "Telos CLI"
   short_description: "Apply persistent Goals with Telos"
-  default_prompt: "Use $telos-cli to turn this outcome into the smallest verifiable persistent Goal, review its SPEC.md with me, plan it, apply it after I approve, and show me the evidence when it reaches Ready."

--- a/skills/telos-cli/assets/quickstart-prompt.txt
+++ b/skills/telos-cli/assets/quickstart-prompt.txt
@@ -1,1 +1,0 @@
-Use Telos for this Goal: <what should remain true>. Install and sign in if needed. Draft the smallest verifiable `SPEC.md`, then show me `telos plan`. After I approve, run `telos apply` and return the evidence when it reaches Ready.

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -1,6 +1,6 @@
 ---
 title: Use Telos
-description: Give Telos a Goal, then follow it from a proposed contract to verified software.
+description: Each Goal keeps its spec, revisions, deployment, and verification evidence together.
 group: Getting started
 ---
 


### PR DESCRIPTION
## Summary

- remove `quickstart_prompt` from the public skill metadata
- delete the canned prompt asset and invocation default
- replace the abstract guide description with a literal statement of Goal identity

The skill owns Telos operating knowledge. It no longer manufactures a user request that narrates install, plan, apply, and Ready.

## Validation

- skill quick validation
- `go test ./...`
- `git diff --check`