### PR TITLE
fix(cli): render canonical context handles

### DIFF
--- a/cmd/telos/cloud_context.go
+++ b/cmd/telos/cloud_context.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"strings"
-
-	"github.com/telos-org/telos/internal/cloud"
 )
 
 func cloudContextFlag(fs *flag.FlagSet) *string {
@@ -14,13 +12,6 @@ func cloudContextFlag(fs *flag.FlagSet) *string {
 		"",
 		"Cloud context for this command as @handle, organization ID, or personal",
 	)
-}
-
-func resolvedCloudContext(client *cloud.Client) string {
-	if context := strings.TrimSpace(client.OrgID); context != "" {
-		return context
-	}
-	return "personal"
 }
 
 func cloudContextOverride(fs *flag.FlagSet, value string) (string, error) {

--- a/cmd/telos/config.go
+++ b/cmd/telos/config.go
@@ -98,10 +98,9 @@ func setContext(stored *config.Config, value string) {
 		os.Exit(1)
 	}
 
-	contextName := organization.ContextName()
+	contextName := account.CanonicalContextName(organization)
 	if organization.ID == account.PersonalOrgID {
 		stored.Context = ""
-		contextName = "personal"
 	} else {
 		stored.Context = contextName
 	}
@@ -149,10 +148,8 @@ func printConfig(cfg *config.Config, path string) {
 				organization, err := account.ResolveContext(cfg.Context)
 				if err != nil {
 					statusError = err
-				} else if organization.ID == account.PersonalOrgID {
-					contextName = "personal"
 				} else {
-					contextName = organization.ContextName()
+					contextName = account.CanonicalContextName(organization)
 				}
 				if statusError == nil {
 					client.OrgID = organization.ID

--- a/cmd/telos/delete.go
+++ b/cmd/telos/delete.go
@@ -93,7 +93,7 @@ func deleteCloudSessionForContext(
 	if err != nil {
 		return nil, "", err
 	}
-	return session, resolvedCloudContext(control), nil
+	return session, control.ContextName(), nil
 }
 
 func deleteCloudSessionIfConfigured(

--- a/cmd/telos/describe.go
+++ b/cmd/telos/describe.go
@@ -102,7 +102,7 @@ func getCloudSessionForContext(
 	if err != nil {
 		return nil, "", err
 	}
-	return session, resolvedCloudContext(control), nil
+	return session, control.ContextName(), nil
 }
 
 func printCloudSessionDescription(out io.Writer, session cloud.SessionRecord) {

--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -470,7 +470,7 @@ func applyCloudControl(
 	}
 	if jsonOut {
 		printJSON(map[string]any{
-			"context":   resolvedCloudContext(control),
+			"context":   control.ContextName(),
 			"operation": operation,
 			"package":   packageRecord,
 			"session":   session,
@@ -481,7 +481,7 @@ func applyCloudControl(
 		os.Stdout,
 		operation,
 		session,
-		resolvedCloudContext(control),
+		control.ContextName(),
 	)
 }
 

--- a/cmd/telos/list.go
+++ b/cmd/telos/list.go
@@ -213,7 +213,7 @@ func listCloudSessions(contextOverride string, jsonOut bool, limit int, wide boo
 	cloudSessions = limitCloudSessions(cloudSessions, limit)
 	if jsonOut {
 		printJSON(map[string]any{
-			"context":  resolvedCloudContext(control),
+			"context":  control.ContextName(),
 			"sessions": cloudSessions,
 		})
 		return
@@ -223,7 +223,7 @@ func listCloudSessions(contextOverride string, jsonOut bool, limit int, wide boo
 		return
 	}
 	if wide {
-		printSummaryField(os.Stdout, "Context", resolvedCloudContext(control))
+		printSummaryField(os.Stdout, "Context", control.ContextName())
 		fmt.Println()
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)

--- a/cmd/telos/list_test.go
+++ b/cmd/telos/list_test.go
@@ -220,8 +220,8 @@ func TestCmdListContextFlagOverridesEnvironment(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &body); err != nil {
 		t.Fatal(err)
 	}
-	if body["context"] != "org_flag" {
-		t.Fatalf("context = %#v, want org_flag", body["context"])
+	if body["context"] != "@flag" {
+		t.Fatalf("context = %#v, want @flag", body["context"])
 	}
 }
 

--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -142,7 +142,7 @@ func printCloudSessionLogs(
 		if err := printJSONLogEventsForContext(
 			os.Stdout,
 			selectLogEvents(page.Events, options),
-			resolvedCloudContext(control),
+			control.ContextName(),
 		); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)

--- a/cmd/telos/plan.go
+++ b/cmd/telos/plan.go
@@ -105,7 +105,7 @@ func cmdPlan(args []string) {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				os.Exit(1)
 			}
-			targetContext = resolvedCloudContext(control)
+			targetContext = control.ContextName()
 		}
 	}
 	targetOperation := "create"

--- a/cmd/telos/plan_test.go
+++ b/cmd/telos/plan_test.go
@@ -122,7 +122,7 @@ func TestPrintPlanPreviewShowsNoSpecChanges(t *testing.T) {
 	}
 }
 
-func TestPlanShowsHandleContext(t *testing.T) {
+func TestPlanShowsCanonicalContext(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/account/bootstrap" {
 			http.NotFound(w, r)
@@ -131,6 +131,13 @@ func TestPlanShowsHandleContext(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"personal_org_id": "org_personal",
 			"organizations": []map[string]any{
+				{
+					"id":           "org_personal",
+					"handle":       "grohan",
+					"display_name": "Rohan",
+					"kind":         "personal",
+					"role":         "owner",
+				},
 				{
 					"id":           "org_telos",
 					"handle":       "telos",
@@ -145,9 +152,6 @@ func TestPlanShowsHandleContext(t *testing.T) {
 
 	configureCloudTest(t, srv.URL)
 	t.Setenv(config.ContextEnv, "")
-	if err := config.SaveConfig(&config.Config{Context: "org_telos"}); err != nil {
-		t.Fatal(err)
-	}
 	specPath := filepath.Join(t.TempDir(), "SPEC.md")
 	if err := os.WriteFile(specPath, []byte(`---
 name: demo
@@ -162,14 +166,29 @@ Serve a demo.
 		t.Fatal(err)
 	}
 
-	out := captureStdout(t, func() {
-		cmdPlan([]string{specPath})
-	})
-	if got := configOutputValue(t, out, "Context"); got != "@telos" {
-		t.Fatalf("Context = %q, want @telos\n%s", got, out)
-	}
-	if strings.Contains(out, "org_telos") {
-		t.Fatalf("plan exposed internal organization ID:\n%s", out)
+	for _, tt := range []struct {
+		name   string
+		stored string
+		want   string
+		hidden string
+	}{
+		{name: "team", stored: "org_telos", want: "@telos", hidden: "org_telos"},
+		{name: "personal", stored: "org_personal", want: "personal", hidden: "org_personal"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := config.SaveConfig(&config.Config{Context: tt.stored}); err != nil {
+				t.Fatal(err)
+			}
+			out := captureStdout(t, func() {
+				cmdPlan([]string{specPath})
+			})
+			if got := configOutputValue(t, out, "Context"); got != tt.want {
+				t.Fatalf("Context = %q, want %q\n%s", got, tt.want, out)
+			}
+			if strings.Contains(out, tt.hidden) {
+				t.Fatalf("plan exposed internal organization ID:\n%s", out)
+			}
+		})
 	}
 }
 

--- a/cmd/telos/plan_test.go
+++ b/cmd/telos/plan_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/telos-org/telos/internal/cloud"
+	"github.com/telos-org/telos/internal/config"
 	"github.com/telos-org/telos/internal/sessionapi"
 	"github.com/telos-org/telos/internal/spec"
 )
@@ -118,6 +119,57 @@ func TestPrintPlanPreviewShowsNoSpecChanges(t *testing.T) {
 	printPlanPreview(&out, compiled, "./SPEC.md", "cloud", "personal", comparison)
 	if !strings.Contains(out.String(), "No spec changes.") {
 		t.Fatalf("plan output:\n%s", out.String())
+	}
+}
+
+func TestPlanShowsHandleContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/account/bootstrap" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"personal_org_id": "org_personal",
+			"organizations": []map[string]any{
+				{
+					"id":           "org_telos",
+					"handle":       "telos",
+					"display_name": "Telos",
+					"kind":         "platform",
+					"role":         "owner",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	configureCloudTest(t, srv.URL)
+	t.Setenv(config.ContextEnv, "")
+	if err := config.SaveConfig(&config.Config{Context: "org_telos"}); err != nil {
+		t.Fatal(err)
+	}
+	specPath := filepath.Join(t.TempDir(), "SPEC.md")
+	if err := os.WriteFile(specPath, []byte(`---
+name: demo
+version: 1.0.0
+platform: cloud
+---
+
+# Goal
+
+Serve a demo.
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdPlan([]string{specPath})
+	})
+	if got := configOutputValue(t, out, "Context"); got != "@telos" {
+		t.Fatalf("Context = %q, want @telos\n%s", got, out)
+	}
+	if strings.Contains(out, "org_telos") {
+		t.Fatalf("plan exposed internal organization ID:\n%s", out)
 	}
 }
 

--- a/cmd/telos/push.go
+++ b/cmd/telos/push.go
@@ -79,7 +79,7 @@ func cmdPush(args []string) {
 		}
 		if *jsonOut {
 			printJSON(map[string]any{
-				"context": resolvedCloudContext(client),
+				"context": client.ContextName(),
 				"name":    skill.name,
 				"skill":   record,
 			})
@@ -124,7 +124,7 @@ func cmdPush(args []string) {
 	}
 	if *jsonOut {
 		printJSON(map[string]any{
-			"context": resolvedCloudContext(client),
+			"context": client.ContextName(),
 			"name":    pkg.name,
 			"version": pkg.version,
 			"package": record,

--- a/internal/cloud/account.go
+++ b/internal/cloud/account.go
@@ -63,6 +63,15 @@ func (account *AccountBootstrapRecord) ResolveContext(value string) (*Organizati
 	return nil, fmt.Errorf("context %q is unavailable to this account", value)
 }
 
+func (account *AccountBootstrapRecord) CanonicalContextName(
+	organization *OrganizationRecord,
+) string {
+	if organization.ID == account.PersonalOrgID {
+		return "personal"
+	}
+	return organization.ContextName()
+}
+
 func (organization *OrganizationRecord) ContextName() string {
 	if organization.Handle != nil && *organization.Handle != "" {
 		return "@" + *organization.Handle

--- a/internal/cloud/account_test.go
+++ b/internal/cloud/account_test.go
@@ -76,3 +76,38 @@ func TestResolveContext(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalContextName(t *testing.T) {
+	personalHandle := "grohan"
+	teamHandle := "telos"
+	account := AccountBootstrapRecord{PersonalOrgID: "org_personal"}
+
+	tests := []struct {
+		name         string
+		organization OrganizationRecord
+		want         string
+	}{
+		{
+			name:         "personal",
+			organization: OrganizationRecord{ID: "org_personal", Handle: &personalHandle},
+			want:         "personal",
+		},
+		{
+			name:         "team handle",
+			organization: OrganizationRecord{ID: "org_telos", Handle: &teamHandle},
+			want:         "@telos",
+		},
+		{
+			name:         "team id",
+			organization: OrganizationRecord{ID: "org_legacy"},
+			want:         "org_legacy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := account.CanonicalContextName(&tt.organization); got != tt.want {
+				t.Fatalf("CanonicalContextName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -274,11 +274,15 @@ func ControlClientForContext(contextOverride string) (*Client, error) {
 		client.contextName = resolved.name
 		return client, nil
 	}
-	organization, err := client.ResolveContext(context)
+	account, err := client.AccountBootstrap()
 	if err != nil {
 		return nil, err
 	}
-	contextName := organization.ContextName()
+	organization, err := account.ResolveContext(context)
+	if err != nil {
+		return nil, err
+	}
+	contextName := account.CanonicalContextName(organization)
 	resolvedContexts.Store(key, resolvedContext{orgID: organization.ID, name: contextName})
 	client.OrgID = organization.ID
 	client.contextName = contextName

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -185,6 +185,8 @@ type Client struct {
 	Token    string
 	OrgID    string
 	HTTP     *http.Client
+
+	contextName string
 }
 
 type APIError struct {
@@ -214,11 +216,28 @@ func NewClient(endpoint, token string) *Client {
 	}
 }
 
-// resolvedContexts memoizes successful handle resolutions for the life of
+type resolvedContext struct {
+	orgID string
+	name  string
+}
+
+// resolvedContexts memoizes successful context resolutions for the life of
 // the process, keyed by endpoint, token, and context so distinct identities
 // never share an entry. Failures are not cached so transient errors stay
 // retryable.
 var resolvedContexts sync.Map
+
+// ContextName returns the canonical name of the selected context while OrgID
+// remains the stable identifier used for API routing.
+func (c *Client) ContextName() string {
+	if name := strings.TrimSpace(c.contextName); name != "" {
+		return name
+	}
+	if orgID := strings.TrimSpace(c.OrgID); orgID != "" {
+		return orgID
+	}
+	return "personal"
+}
 
 // ControlClient returns a client for the configured Telos control plane.
 func ControlClient() (*Client, error) {
@@ -248,21 +267,21 @@ func ControlClientForContext(contextOverride string) (*Client, error) {
 	if context == "" || context == "personal" {
 		return client, nil
 	}
-	if strings.HasPrefix(context, "org_") {
-		client.OrgID = context
-		return client, nil
-	}
 	key := client.Endpoint + "\x00" + token + "\x00" + context
-	if orgID, ok := resolvedContexts.Load(key); ok {
-		client.OrgID = orgID.(string)
+	if cached, ok := resolvedContexts.Load(key); ok {
+		resolved := cached.(resolvedContext)
+		client.OrgID = resolved.orgID
+		client.contextName = resolved.name
 		return client, nil
 	}
 	organization, err := client.ResolveContext(context)
 	if err != nil {
 		return nil, err
 	}
-	resolvedContexts.Store(key, organization.ID)
+	contextName := organization.ContextName()
+	resolvedContexts.Store(key, resolvedContext{orgID: organization.ID, name: contextName})
 	client.OrgID = organization.ID
+	client.contextName = contextName
 	return client, nil
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -127,6 +127,38 @@ func TestControlClientPersonalOverrideWinsOverEnvironment(t *testing.T) {
 	}
 }
 
+func TestControlClientCanonicalizesPersonalOrganizationContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"personal_org_id":"org_personal",
+			"organizations":[
+				{"id":"org_personal","handle":"grohan","display_name":"Rohan","kind":"personal","role":"owner"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv(config.APIEndpointEnv, srv.URL)
+	t.Setenv(config.AuthTokenEnv, "test-token")
+	t.Setenv(config.ContextEnv, "")
+
+	for _, context := range []string{"@grohan", "org_personal"} {
+		t.Run(context, func(t *testing.T) {
+			client, err := ControlClientForContext(context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if client.OrgID != "org_personal" {
+				t.Fatalf("OrgID = %q, want org_personal", client.OrgID)
+			}
+			if client.ContextName() != "personal" {
+				t.Fatalf("ContextName = %q, want personal", client.ContextName())
+			}
+		})
+	}
+}
+
 func TestControlClientCachesHandleResolution(t *testing.T) {
 	bootstraps := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -75,6 +75,9 @@ func TestControlClientResolvesHandleContext(t *testing.T) {
 	if client.OrgID != "org_telos" {
 		t.Fatalf("OrgID = %q", client.OrgID)
 	}
+	if client.ContextName() != "@telos" {
+		t.Fatalf("ContextName = %q, want @telos", client.ContextName())
+	}
 }
 
 func TestControlClientContextOverrideWinsOverEnvironment(t *testing.T) {
@@ -101,6 +104,9 @@ func TestControlClientContextOverrideWinsOverEnvironment(t *testing.T) {
 	if client.OrgID != "org_flag" {
 		t.Fatalf("OrgID = %q, want org_flag", client.OrgID)
 	}
+	if client.ContextName() != "@flag" {
+		t.Fatalf("ContextName = %q, want @flag", client.ContextName())
+	}
 }
 
 func TestControlClientPersonalOverrideWinsOverEnvironment(t *testing.T) {
@@ -115,6 +121,9 @@ func TestControlClientPersonalOverrideWinsOverEnvironment(t *testing.T) {
 	}
 	if client.OrgID != "" {
 		t.Fatalf("OrgID = %q, want personal scope", client.OrgID)
+	}
+	if client.ContextName() != "personal" {
+		t.Fatalf("ContextName = %q, want personal", client.ContextName())
 	}
 }
 
@@ -144,15 +153,31 @@ func TestControlClientCachesHandleResolution(t *testing.T) {
 		if client.OrgID != "org_telos" {
 			t.Fatalf("OrgID = %q", client.OrgID)
 		}
+		if client.ContextName() != "@telos" {
+			t.Fatalf("ContextName = %q, want @telos", client.ContextName())
+		}
 	}
 	if bootstraps != 1 {
 		t.Fatalf("bootstrap requests = %d, want 1", bootstraps)
 	}
 }
 
-func TestControlClientUsesStableContextWithoutLookup(t *testing.T) {
+func TestControlClientResolvesStableContextName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/account/bootstrap" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"personal_org_id":"org_personal",
+			"organizations":[
+				{"id":"org_telos","handle":"telos","display_name":"Telos","kind":"platform","role":"owner"}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
 	t.Setenv(config.ConfigPathEnv, filepath.Join(t.TempDir(), "missing.yaml"))
-	t.Setenv(config.APIEndpointEnv, "https://api.example.com")
+	t.Setenv(config.APIEndpointEnv, srv.URL)
 	t.Setenv(config.AuthTokenEnv, "test-token")
 	t.Setenv(config.ContextEnv, "org_telos")
 
@@ -162,6 +187,9 @@ func TestControlClientUsesStableContextWithoutLookup(t *testing.T) {
 	}
 	if client.OrgID != "org_telos" {
 		t.Fatalf("OrgID = %q", client.OrgID)
+	}
+	if client.ContextName() != "@telos" {
+		t.Fatalf("ContextName = %q, want @telos", client.ContextName())
 	}
 }
 

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -31,6 +31,10 @@ telos config --context @team-handle
 telos list --context @team-handle
 ```
 
+Commands also accept a stable organization ID when you have one. Receipts and
+JSON output still show `personal` or the team's `@handle`, keeping the visible
+context consistent across commands.
+
 `telos config --context personal` returns to the personal context. A
 command-level `--context` overrides `TELOS_CONTEXT` and stored configuration
 for that invocation without changing either. Carry the chosen context through


### PR DESCRIPTION
## Summary

- keep stable organization IDs for Cloud API routing
- render canonical `@handle` context names in CLI receipts and JSON output
- normalize legacy stored `org_*` contexts through the same resolution path
- preserve `personal` as the canonical name for the personal organization
- document canonical context output in the CLI guide

This makes `telos plan` and `telos config` describe the same context the same way.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `bazel build //skills:telos_cli_bundle`
- `git diff --check`

## Release

A Telos release must be published and promoted after merge before the updated CLI and guide are available to users.