### PR TITLE
feat(cli): add force flag for deployment updates

### DIFF
--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -531,13 +531,21 @@ func actionableDeploymentUpdateError(err error, force bool) error {
 	if !errors.As(err, &apiErr) || apiErr.StatusCode != 409 || apiErr.Code != "snapshot_pending" {
 		return err
 	}
-	return &cloud.APIError{
-		StatusCode: apiErr.StatusCode,
-		Code:       apiErr.Code,
-		Detail: "The current revision has not been snapshotted.\n" +
-			"Deploying now means you won’t be able to restore its exact workspace and runtime state.\n\n" +
-			"To deploy anyway, retry the same command with --force.",
-	}
+	return &snapshotPendingUpdateError{cause: err}
+}
+
+type snapshotPendingUpdateError struct {
+	cause error
+}
+
+func (e *snapshotPendingUpdateError) Error() string {
+	return "The current revision has not been snapshotted.\n" +
+		"Deploying now means you won’t be able to restore its exact workspace and runtime state.\n\n" +
+		"To deploy anyway, retry the same command with --force."
+}
+
+func (e *snapshotPendingUpdateError) Unwrap() error {
+	return e.cause
 }
 
 func cloudRuntimeConfigSet(cfg sessionRuntimeConfig) bool {

--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -507,7 +507,7 @@ func applyCloudSessionPackage(
 				return "unchanged", current, nil
 			}
 		}
-		return "updated", session, err
+		return "updated", session, actionableDeploymentUpdateError(err, force)
 	}
 
 	inference, err := resolveCloudInference(control, runtimeConfig.Model)
@@ -521,6 +521,23 @@ func applyCloudSessionPackage(
 		Inference:     inference,
 	})
 	return "created", session, err
+}
+
+func actionableDeploymentUpdateError(err error, force bool) error {
+	if force {
+		return err
+	}
+	var apiErr *cloud.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 409 || apiErr.Code != "snapshot_pending" {
+		return err
+	}
+	return &cloud.APIError{
+		StatusCode: apiErr.StatusCode,
+		Code:       apiErr.Code,
+		Detail: "The current revision has not been snapshotted.\n" +
+			"Deploying now means you won’t be able to restore its exact workspace and runtime state.\n\n" +
+			"To deploy anyway, retry the same command with --force.",
+	}
 }
 
 func cloudRuntimeConfigSet(cfg sessionRuntimeConfig) bool {

--- a/cmd/telos/launch.go
+++ b/cmd/telos/launch.go
@@ -31,8 +31,11 @@ func cmdLaunch(command, action string, args []string) {
 	workspace := fs.String("workspace", "", "Workspace directory for local specs")
 	sessionIDValue := ""
 	sessionID := &sessionIDValue
+	forceValue := false
+	force := &forceValue
 	if command == "apply" {
 		sessionID = fs.String("session", "", "Managed session ID to update")
+		force = fs.Bool("force", false, "Deploy even if the current revision has not been snapshotted")
 	}
 	model := fs.String("model", "", "pi model as <provider>/<model> (e.g. openai-codex/gpt-5.5); defaults to $TELOS_MODEL")
 	thinking := fs.String("thinking", "", "Thinking effort; defaults to $TELOS_THINKING, then high for local runs")
@@ -105,6 +108,10 @@ func cmdLaunch(command, action string, args []string) {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
+		if err := validateForceApply(*force, *sessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	if command == "apply" && *sessionID != "" && isLocalApplyID(*sessionID) {
 		if !hasLocalSpec {
@@ -158,7 +165,14 @@ func cmdLaunch(command, action string, args []string) {
 			fmt.Fprintln(os.Stderr, "error: cloud runtime config flags can only seed a new session; they cannot update an existing session")
 			os.Exit(1)
 		}
-		applyCloudControl(specArg, *sessionID, runtimeConfig, *jsonOut, contextOverride)
+		applyCloudControl(
+			specArg,
+			*sessionID,
+			runtimeConfig,
+			*force,
+			*jsonOut,
+			contextOverride,
+		)
 		return
 	}
 	if !hasLocalSpec {
@@ -402,6 +416,7 @@ func applyCloudControl(
 	specArg string,
 	sessionID string,
 	runtimeConfig sessionRuntimeConfig,
+	force bool,
 	jsonOut bool,
 	contextOverride string,
 ) {
@@ -447,6 +462,7 @@ func applyCloudControl(
 		packageRecord.Ref,
 		sessionID,
 		runtimeConfig,
+		force,
 	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -475,12 +491,16 @@ func applyCloudSessionPackage(
 	packageRef string,
 	sessionID string,
 	runtimeConfig sessionRuntimeConfig,
+	force bool,
 ) (string, *cloud.SessionRecord, error) {
 	if sessionID != "" {
 		if !isCloudApplyID(sessionID) {
 			return "", nil, fmt.Errorf("invalid cloud session id %q", sessionID)
 		}
-		session, err := control.UpdateSession(sessionID, packageRef)
+		session, err := control.UpdateSession(sessionID, cloud.SessionUpdateOptions{
+			PackageRef: packageRef,
+			Force:      force,
+		})
 		if err != nil && cloud.IsStatus(err, 409) {
 			current, getErr := control.GetSession(sessionID)
 			if getErr == nil && current.PackageRef == packageRef {
@@ -505,6 +525,13 @@ func applyCloudSessionPackage(
 
 func cloudRuntimeConfigSet(cfg sessionRuntimeConfig) bool {
 	return cfg.Model != "" || cfg.Thinking != ""
+}
+
+func validateForceApply(force bool, sessionID string) error {
+	if force && !isCloudApplyID(sessionID) {
+		return errors.New("--force requires --session with a cloud deployment ID")
+	}
+	return nil
 }
 
 func printSessionReceipt(out io.Writer, operation string, session *sessionapi.Session) {

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"net/http"
 	"net/http/httptest"
@@ -1273,6 +1274,69 @@ func TestApplyCloudSessionPackageConflictAlreadyCurrent(t *testing.T) {
 	}
 	if updateCalls != 2 || getCalls != 2 {
 		t.Fatalf("calls: update=%d get=%d", updateCalls, getCalls)
+	}
+}
+
+func TestApplyCloudSessionPackageSnapshotPendingSuggestsForce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/sess_123":
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":{"code":"snapshot_pending","message":"internal snapshot gate detail"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments/sess_123":
+			_, _ = w.Write([]byte(`{"id":"sess_123","name":"auth","state":"healthy","package_ref":"@user-abc/auth:0.1.0","package_digest":"sha256:old","created_at":"then","updated_at":"now"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := applyCloudSessionPackage(
+		cloud.NewClient(srv.URL, "test-token"),
+		"auth",
+		"@user-abc/auth:0.1.1",
+		"sess_123",
+		sessionRuntimeConfig{},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected snapshot pending error")
+	}
+	want := "The current revision has not been snapshotted.\n" +
+		"Deploying now means you won’t be able to restore its exact workspace and runtime state.\n\n" +
+		"To deploy anyway, retry the same command with --force. (HTTP 409)"
+	if err.Error() != want {
+		t.Fatalf("error:\n got: %q\nwant: %q", err, want)
+	}
+	var apiErr *cloud.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "snapshot_pending" {
+		t.Fatalf("structured error not preserved: %#v", err)
+	}
+
+	_, _, err = applyCloudSessionPackage(
+		cloud.NewClient(srv.URL, "test-token"),
+		"auth",
+		"@user-abc/auth:0.1.1",
+		"sess_123",
+		sessionRuntimeConfig{},
+		true,
+	)
+	if err == nil || strings.Contains(err.Error(), "retry the same command with --force") {
+		t.Fatalf("forced retry received an invalid force suggestion: %v", err)
+	}
+	apiErr = nil
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict ||
+		apiErr.Code != "snapshot_pending" || apiErr.Detail != "internal snapshot gate detail" {
+		t.Fatalf("forced retry changed the original error: %#v", err)
+	}
+
+	unrelated := &cloud.APIError{
+		StatusCode: http.StatusConflict,
+		Code:       "operation_in_progress",
+		Detail:     "deployment operation is already in progress",
+	}
+	if got := actionableDeploymentUpdateError(unrelated, false); got != unrelated {
+		t.Fatalf("unrelated conflict changed: got %#v want %#v", got, unrelated)
 	}
 }
 

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -1304,12 +1304,13 @@ func TestApplyCloudSessionPackageSnapshotPendingSuggestsForce(t *testing.T) {
 	}
 	want := "The current revision has not been snapshotted.\n" +
 		"Deploying now means you won’t be able to restore its exact workspace and runtime state.\n\n" +
-		"To deploy anyway, retry the same command with --force. (HTTP 409)"
+		"To deploy anyway, retry the same command with --force."
 	if err.Error() != want {
 		t.Fatalf("error:\n got: %q\nwant: %q", err, want)
 	}
 	var apiErr *cloud.APIError
-	if !errors.As(err, &apiErr) || apiErr.Code != "snapshot_pending" {
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict ||
+		apiErr.Code != "snapshot_pending" || apiErr.Detail != "internal snapshot gate detail" {
 		t.Fatalf("structured error not preserved: %#v", err)
 	}
 

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -526,6 +526,23 @@ func TestValidateApplySessionPlatformAcceptsMatchingTargets(t *testing.T) {
 	}
 }
 
+func TestValidateForceApplyRequiresCloudUpdate(t *testing.T) {
+	for _, sessionID := range []string{"", "local_123"} {
+		err := validateForceApply(true, sessionID)
+		if err == nil || !strings.Contains(err.Error(), "requires --session") {
+			t.Fatalf("forced %q: got %v", sessionID, err)
+		}
+	}
+	for _, sessionID := range []string{"", "local_123", "sess_123"} {
+		if err := validateForceApply(false, sessionID); err != nil {
+			t.Fatalf("normal %q: %v", sessionID, err)
+		}
+	}
+	if err := validateForceApply(true, "sess_123"); err != nil {
+		t.Fatalf("forced cloud update: %v", err)
+	}
+}
+
 func TestSessionCreateRequestForLocalSpec(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "SPEC.md"), []byte("---\nname: demo\n---\n# Demo\n"), 0o644); err != nil {
@@ -1087,6 +1104,7 @@ func TestApplyCloudSessionPackageCreates(t *testing.T) {
 		"@user-abc/auth:0.1.0",
 		"",
 		sessionRuntimeConfig{},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("applyCloudSessionPackage: %v", err)
@@ -1122,6 +1140,7 @@ func TestApplyCloudSessionPackageResolvesNamedSubscription(t *testing.T) {
 		"@user-abc/auth:0.1.0",
 		"",
 		sessionRuntimeConfig{Model: "openai-rohan/gpt-5.6-sol"},
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1146,12 +1165,15 @@ func TestApplyCloudSessionPackageUpdatesExplicitSession(t *testing.T) {
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/sess_123":
 			updated = true
-			var body map[string]string
+			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
 			if body["package_ref"] != "@user-abc/auth:0.1.1" {
 				t.Fatalf("body: got %#v", body)
+			}
+			if body["force"] != true {
+				t.Fatalf("force: got %#v", body["force"])
 			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"id":             "sess_123",
@@ -1174,6 +1196,7 @@ func TestApplyCloudSessionPackageUpdatesExplicitSession(t *testing.T) {
 		"@user-abc/auth:0.1.1",
 		"sess_123",
 		sessionRuntimeConfig{},
+		true,
 	)
 	if err != nil {
 		t.Fatalf("applyCloudSessionPackage: %v", err)
@@ -1189,6 +1212,7 @@ func TestApplyCloudSessionPackageUpdatesExplicitSession(t *testing.T) {
 func TestApplyCloudSessionPackageConflictAlreadyCurrent(t *testing.T) {
 	var updateCalls int
 	var getCalls int
+	currentPackageRef := "@user-abc/auth:0.1.1"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/sess_123":
@@ -1200,7 +1224,7 @@ func TestApplyCloudSessionPackageConflictAlreadyCurrent(t *testing.T) {
 				"id":             "sess_123",
 				"name":           "auth",
 				"state":          "healthy",
-				"package_ref":    "@user-abc/auth:0.1.1",
+				"package_ref":    currentPackageRef,
 				"package_digest": "sha256:new",
 				"created_at":     "then",
 				"updated_at":     "now",
@@ -1217,6 +1241,7 @@ func TestApplyCloudSessionPackageConflictAlreadyCurrent(t *testing.T) {
 		"@user-abc/auth:0.1.1",
 		"sess_123",
 		sessionRuntimeConfig{},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("applyCloudSessionPackage: %v", err)
@@ -1228,6 +1253,25 @@ func TestApplyCloudSessionPackageConflictAlreadyCurrent(t *testing.T) {
 		t.Fatalf("session: got %+v", session)
 	}
 	if updateCalls != 1 || getCalls != 1 {
+		t.Fatalf("calls: update=%d get=%d", updateCalls, getCalls)
+	}
+
+	currentPackageRef = "@user-abc/auth:0.1.0"
+	operation, session, err = applyCloudSessionPackage(
+		cloud.NewClient(srv.URL, "test-token"),
+		"auth",
+		"@user-abc/auth:0.1.1",
+		"sess_123",
+		sessionRuntimeConfig{},
+		true,
+	)
+	if err == nil {
+		t.Fatal("forced update hid an unrelated conflict")
+	}
+	if operation != "updated" || session != nil {
+		t.Fatalf("operation=%q session=%+v", operation, session)
+	}
+	if updateCalls != 2 || getCalls != 2 {
 		t.Fatalf("calls: update=%d get=%d", updateCalls, getCalls)
 	}
 }

--- a/cmd/telos/pull_test.go
+++ b/cmd/telos/pull_test.go
@@ -103,6 +103,7 @@ func TestPackageForReferenceUsesRegistryDigest(t *testing.T) {
 func TestCmdApplyUsesExactRegistryPackageWithoutRepublishing(t *testing.T) {
 	pkg := testApplyPackage(t)
 	var published bool
+	var forcedUpdate bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/packages/telos/demo/versions/1.2.3":
@@ -137,6 +138,24 @@ func TestCmdApplyUsesExactRegistryPackageWithoutRepublishing(t *testing.T) {
 				"created_at":     "then",
 				"updated_at":     "now",
 			})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/sess_registry":
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			if len(request) != 2 || request["package_ref"] != "@telos/demo:1.2.3" || request["force"] != true {
+				t.Fatalf("forced deployment request = %#v", request)
+			}
+			forcedUpdate = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":             "sess_registry",
+				"name":           "demo",
+				"state":          "deploying",
+				"package_ref":    "@telos/demo:1.2.3",
+				"package_digest": pkg.Digest,
+				"created_at":     "then",
+				"updated_at":     "now",
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -157,6 +176,25 @@ func TestCmdApplyUsesExactRegistryPackageWithoutRepublishing(t *testing.T) {
 	}
 	if result["operation"] != "created" || result["context"] != "personal" {
 		t.Fatalf("apply result = %#v", result)
+	}
+
+	out = captureStdout(t, func() {
+		cmdApply([]string{
+			"@telos/demo:1.2.3",
+			"--session", "sess_registry",
+			"--force",
+			"--json",
+		})
+	})
+	if !forcedUpdate {
+		t.Fatal("forced registry apply did not update the deployment")
+	}
+	result = map[string]any{}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("forced apply JSON: %v\n%s", err, out)
+	}
+	if result["operation"] != "updated" || result["context"] != "personal" {
+		t.Fatalf("forced apply result = %#v", result)
 	}
 }
 

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -88,6 +88,11 @@ type SessionCreateOptions struct {
 	Inference       *InferenceSelection
 }
 
+type SessionUpdateOptions struct {
+	PackageRef string `json:"package_ref"`
+	Force      bool   `json:"force,omitempty"`
+}
+
 // The hosted control API still exposes cloud sessions at /api/deployments.
 // Keep that wire contract here and expose session-shaped methods to the CLI.
 type sessionListResponse struct {
@@ -535,8 +540,8 @@ func (c *Client) CreateSession(opts SessionCreateOptions) (*SessionRecord, error
 	return &response, nil
 }
 
-func (c *Client) UpdateSession(sessionID, packageRef string) (*SessionRecord, error) {
-	body, err := json.Marshal(map[string]string{"package_ref": packageRef})
+func (c *Client) UpdateSession(sessionID string, opts SessionUpdateOptions) (*SessionRecord, error) {
+	body, err := json.Marshal(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -461,7 +461,7 @@ func TestClientGetsAndDownloadsPackageVersion(t *testing.T) {
 }
 
 func TestClientUpdateSession(t *testing.T) {
-	var gotBody map[string]string
+	var gotBodies []map[string]any
 	var gotOrgID string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/api/deployments/sess_123" {
@@ -469,9 +469,11 @@ func TestClientUpdateSession(t *testing.T) {
 			return
 		}
 		gotOrgID = r.Header.Get("X-Telos-Org-Id")
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatal(err)
 		}
+		gotBodies = append(gotBodies, body)
 		json.NewEncoder(w).Encode(map[string]any{
 			"id":             "sess_123",
 			"name":           "auth",
@@ -486,15 +488,29 @@ func TestClientUpdateSession(t *testing.T) {
 
 	client := NewClient(srv.URL, "test-token")
 	client.OrgID = " org_telos "
-	session, err := client.UpdateSession("sess_123", "@telos/auth:1.2.4")
+	session, err := client.UpdateSession("sess_123", SessionUpdateOptions{
+		PackageRef: "@telos/auth:1.2.4",
+	})
 	if err != nil {
 		t.Fatalf("UpdateSession: %v", err)
 	}
 	if session.ID != "sess_123" || session.PackageDigest != "sha256:def" || session.State != "deploying" {
 		t.Fatalf("session: got %+v", session)
 	}
-	if gotBody["package_ref"] != "@telos/auth:1.2.4" {
-		t.Fatalf("body: got %#v", gotBody)
+	if len(gotBodies) != 1 || gotBodies[0]["package_ref"] != "@telos/auth:1.2.4" {
+		t.Fatalf("body: got %#v", gotBodies)
+	}
+	if _, exists := gotBodies[0]["force"]; exists {
+		t.Fatalf("normal update sent force: %#v", gotBodies[0])
+	}
+	if _, err := client.UpdateSession("sess_123", SessionUpdateOptions{
+		PackageRef: "@telos/auth:1.2.4",
+		Force:      true,
+	}); err != nil {
+		t.Fatalf("forced UpdateSession: %v", err)
+	}
+	if len(gotBodies) != 2 || gotBodies[1]["force"] != true {
+		t.Fatalf("forced body: got %#v", gotBodies)
 	}
 	if gotOrgID != "org_telos" {
 		t.Fatalf("org header: got %q", gotOrgID)

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -93,6 +93,25 @@ telos plan SPEC.md --session SESSION_ID --context CONTEXT
 telos apply SPEC.md --session SESSION_ID --context CONTEXT
 ```
 
+A healthy revision may still be waiting for its restorable snapshot. If that
+snapshot gate rejects the update, do not bypass it silently. Tell the user:
+
+> The current revision has not been snapshotted.
+>
+> Deploying now means you won’t be able to restore its exact workspace and
+> runtime state.
+
+Obtain explicit approval for that loss, then retry the same Cloud session
+update with `--force`:
+
+```bash
+telos apply SPEC.md --session SESSION_ID --context CONTEXT --force
+```
+
+`--force` is only valid for an existing Cloud session update. It bypasses this
+snapshot gate only; it does not bypass authorization, active operations,
+runtime availability, or stale-revision protection.
+
 [Use Telos](references/use-telos.md) follows this loop with one service.
 [The Goal lifecycle](references/lifecycle.md) gives a bounded observation
 pattern and explains every reported state.

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -204,17 +204,9 @@ exercise the updated API behavior.
 
 ### Deploy without a restorable snapshot
 
-Cloud normally rejects an update until the healthy current revision has a
-restorable snapshot. If that gate rejects the apply, do not retry automatically
-or hide the consequence. Present this warning exactly:
-
-> The current revision has not been snapshotted.
->
-> Deploying now means you won’t be able to restore its exact workspace and
-> runtime state.
-
-After the user explicitly approves that loss, retry the same session and
-context with `--force`:
+If the current revision has not been snapshotted, you will get a warning saying
+that deploying now means you won’t be able to restore its exact workspace and
+runtime state. To continue anyway, retry the update with `--force`:
 
 ```bash
 telos apply SPEC.md --session sess_c7d2f0a4e8 --context personal --force

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -202,6 +202,29 @@ The Goal, session, deployment, and history stay the same; only the immutable
 revision changes. Observe the new digest through `working` to `ready`, then
 exercise the updated API behavior.
 
+### Deploy without a restorable snapshot
+
+Cloud normally rejects an update until the healthy current revision has a
+restorable snapshot. If that gate rejects the apply, do not retry automatically
+or hide the consequence. Present this warning exactly:
+
+> The current revision has not been snapshotted.
+>
+> Deploying now means you won’t be able to restore its exact workspace and
+> runtime state.
+
+After the user explicitly approves that loss, retry the same session and
+context with `--force`:
+
+```bash
+telos apply SPEC.md --session sess_c7d2f0a4e8 --context personal --force
+```
+
+This bypass applies only to the missing-snapshot gate. Active operations,
+authorization, runtime availability, and stale-revision protection still
+apply. Without `--force`, the update remains rejected and the current revision
+continues serving.
+
 For another contract, continue with [Write a SPEC.md](goals.md). Use
 [Bounded runs](bounded-runs.md) for local work and
 [Troubleshooting](troubleshooting.md) when observed state diverges from the


### PR DESCRIPTION
## Summary

- add an apply-only `--force` flag for cloud deployment updates
- require `--session sess_…`, rejecting create and local-update uses
- send `force: true` only when requested so ordinary updates remain wire-compatible
- show the snapshot-loss warning and an actionable `--force` retry hint only for unforced `409 snapshot_pending`
- document forced updates in the canonical CLI skill and customer-facing Web guide
- leave forced failures and unrelated conflicts unchanged

## Dependency

- Requires telos-org/cloud#416 for server-side support.
- The updated guide reaches Web when this CLI release is published and promoted.

## Testing

- `go test ./...`
- `go test -race ./cmd/telos ./internal/cloud -count=1`
- `go vet ./cmd/telos ./internal/cloud`
- `bazel build //skills:telos_cli_bundle`
- focused coverage for normal, forced, snapshot-pending, already-current, and unrelated-conflict updates
- manual apply/run help and invalid-scope checks