### PR TITLE
feat: hot-reload integration placeholders

### DIFF
--- a/internal/platform/BUILD.bazel
+++ b/internal/platform/BUILD.bazel
@@ -5,10 +5,12 @@ go_library(
     srcs = ["platform.go"],
     importpath = "github.com/telos-org/telos/internal/platform",
     visibility = ["//:__subpackages__"],
+    deps = ["//internal/runtimeenv"],
 )
 
 go_test(
     name = "platform_test",
     srcs = ["platform_test.go"],
     embed = [":platform"],
+    deps = ["//internal/runtimeenv"],
 )

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/telos-org/telos/internal/runtimeenv"
 )
 
 const (
@@ -68,6 +70,11 @@ func (p *LocalPlatform) Run(argv []string, task string, env map[string]string, t
 	}
 	if task != "" {
 		mergedEnv = append(mergedEnv, TaskEnvVar+"="+task)
+	}
+	mergedEnv, err := runtimeCredentialProcessEnv(mergedEnv)
+	if err != nil {
+		result.InfraError = "runtime_credential_environment_invalid"
+		return result
 	}
 
 	cmd := exec.Command(argv[0], argv[1:]...)
@@ -305,6 +312,21 @@ func workspaceProcessEnv() []string {
 		env = append(env, e)
 	}
 	return env
+}
+
+func runtimeCredentialProcessEnv(env []string) ([]string, error) {
+	path := strings.TrimSpace(os.Getenv(runtimeenv.PathEnvironmentVariable))
+	if path == "" {
+		return env, nil
+	}
+	state, seeded, err := runtimeenv.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	if !seeded {
+		return nil, fmt.Errorf("runtime credential environment is configured but missing")
+	}
+	return runtimeenv.Apply(env, state), nil
 }
 
 func workspaceFileListing(workspace string) string {

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/telos-org/telos/internal/runtimeenv"
 )
 
 func TestLocalPlatformRun(t *testing.T) {
@@ -83,6 +85,155 @@ func TestLocalPlatformRunWithEnv(t *testing.T) {
 	}
 }
 
+func TestWorkspaceProcessEnvReloadsRuntimeCredentialEnvironment(t *testing.T) {
+	t.Setenv("MODAL_TOKEN_ID", "stale-one")
+	t.Setenv("MODAL_TOKEN_SECRET", "stale-two")
+	path := runtimeenv.Path(t.TempDir())
+	t.Setenv(runtimeenv.PathEnvironmentVariable, path)
+	store := runtimeenv.NewStore(path)
+	if _, err := store.Put(1, map[string]string{
+		"MODAL_TOKEN_ID":     "opaque-one",
+		"MODAL_TOKEN_SECRET": "opaque-two",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := runtimeCredentialProcessEnv(workspaceProcessEnv())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstValues := testEnvironmentMap(first)
+	if firstValues["MODAL_TOKEN_ID"] != "opaque-one" || firstValues["MODAL_TOKEN_SECRET"] != "opaque-two" {
+		t.Fatalf("initial credential environment missing: %v", firstValues)
+	}
+
+	if _, err := store.Put(2, map[string]string{"NEW_TOKEN": "opaque-three"}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := runtimeCredentialProcessEnv(workspaceProcessEnv())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondValues := testEnvironmentMap(second)
+	if _, ok := secondValues["MODAL_TOKEN_ID"]; ok {
+		t.Fatal("detached MODAL_TOKEN_ID remained in the next process environment")
+	}
+	if _, ok := secondValues["MODAL_TOKEN_SECRET"]; ok {
+		t.Fatal("detached MODAL_TOKEN_SECRET remained in the next process environment")
+	}
+	if secondValues["NEW_TOKEN"] != "opaque-three" {
+		t.Fatalf("attached NEW_TOKEN missing: %v", secondValues)
+	}
+
+	if _, err := store.Put(3, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+	third, err := runtimeCredentialProcessEnv(workspaceProcessEnv())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := testEnvironmentMap(third)["NEW_TOKEN"]; ok {
+		t.Fatal("detached NEW_TOKEN remained in the next process environment")
+	}
+}
+
+func TestWorkspaceProcessEnvPreservesLegacyEnvironmentWhenStateIsAbsent(t *testing.T) {
+	t.Setenv("LEGACY_INTEGRATION_TOKEN", "legacy-placeholder")
+	t.Setenv(runtimeenv.PathEnvironmentVariable, "")
+
+	environment, err := runtimeCredentialProcessEnv(workspaceProcessEnv())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := testEnvironmentMap(environment)["LEGACY_INTEGRATION_TOKEN"]; got != "legacy-placeholder" {
+		t.Fatalf("legacy environment: got %q want legacy-placeholder", got)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentIsFinalOverlayAuthority(t *testing.T) {
+	dir := t.TempDir()
+	path := runtimeenv.Path(dir)
+	t.Setenv(runtimeenv.PathEnvironmentVariable, path)
+	t.Setenv("TOKEN", "inherited")
+	store := runtimeenv.NewStore(path)
+	if _, err := store.Put(1, map[string]string{"TOKEN": "credential-placeholder"}); err != nil {
+		t.Fatal(err)
+	}
+	platform := NewLocalPlatform(dir)
+	platform.Env = map[string]string{"TOKEN": "platform-overlay"}
+
+	result := platform.Run(
+		[]string{"sh", "-c", "printf '%s\\n' \"$TOKEN\""},
+		"",
+		map[string]string{"TOKEN": "per-call-overlay"},
+		10,
+		nil,
+		nil,
+	)
+	if result.InfraError != "" || result.ReturnCode != 0 {
+		t.Fatalf("run failed: %#v", result)
+	}
+	if len(result.RawLines) != 1 || result.RawLines[0] != "credential-placeholder" {
+		t.Fatalf("managed credential did not win final overlay: %v", result.RawLines)
+	}
+
+	if _, err := store.Put(2, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+	result = platform.Run(
+		[]string{"sh", "-c", `if [ "${TOKEN+x}" = x ]; then printf '%s\n' "$TOKEN"; else printf 'missing\n'; fi`},
+		"",
+		map[string]string{"TOKEN": "per-call-overlay"},
+		10,
+		nil,
+		nil,
+	)
+	if result.InfraError != "" || result.ReturnCode != 0 {
+		t.Fatalf("run after detach failed: %#v", result)
+	}
+	if len(result.RawLines) != 1 || result.RawLines[0] != "missing" {
+		t.Fatalf("later overlay reintroduced detached credential: %v", result.RawLines)
+	}
+}
+
+func TestLocalPlatformDoesNotSpawnWhenConfiguredRuntimeCredentialEnvironmentIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(runtimeenv.PathEnvironmentVariable, filepath.Join(dir, "missing.json"))
+	marker := filepath.Join(dir, "spawned")
+
+	result := NewLocalPlatform(dir).Run(
+		[]string{"sh", "-c", "touch \"$1\"", "test", marker},
+		"", nil, 10, nil, nil,
+	)
+	if result.InfraError != "runtime_credential_environment_invalid" {
+		t.Fatalf("infra error: got %q", result.InfraError)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("command unexpectedly spawned: %v", err)
+	}
+}
+
+func TestLocalPlatformDoesNotSpawnWithCorruptRuntimeCredentialEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credential-environment.json")
+	if err := os.WriteFile(path, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, path)
+	marker := filepath.Join(dir, "spawned")
+
+	result := NewLocalPlatform(dir).Run(
+		[]string{"sh", "-c", "touch \"$1\"", "test", marker},
+		"", nil, 10, nil, nil,
+	)
+	if result.InfraError != "runtime_credential_environment_invalid" {
+		t.Fatalf("infra error: got %q", result.InfraError)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("command unexpectedly spawned: %v", err)
+	}
+}
+
 func TestLocalPlatformRunFailure(t *testing.T) {
 	dir := t.TempDir()
 	p := NewLocalPlatform(dir)
@@ -95,6 +246,17 @@ func TestLocalPlatformRunFailure(t *testing.T) {
 	if result.ReturnCode != 42 {
 		t.Errorf("expected exit code 42, got %d", result.ReturnCode)
 	}
+}
+
+func testEnvironmentMap(environment []string) map[string]string {
+	values := make(map[string]string, len(environment))
+	for _, entry := range environment {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = value
+		}
+	}
+	return values
 }
 
 func TestLocalPlatformRunCapturesCompleteStderr(t *testing.T) {

--- a/internal/runtimeenv/BUILD.bazel
+++ b/internal/runtimeenv/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "runtimeenv",
+    srcs = ["environment.go"],
+    importpath = "github.com/telos-org/telos/internal/runtimeenv",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "runtimeenv_test",
+    srcs = ["environment_test.go"],
+    embed = [":runtimeenv"],
+)

--- a/internal/runtimeenv/environment.go
+++ b/internal/runtimeenv/environment.go
@@ -1,0 +1,464 @@
+// Package runtimeenv stores the non-secret environment values used by the
+// current runtime credential policy.
+package runtimeenv
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+)
+
+const (
+	Kind                    = "telos.runtime-credential-environment.v1"
+	PathEnvironmentVariable = "TELOS_RUNTIME_CREDENTIAL_ENV_FILE"
+
+	maxEnvironmentEntries = 100
+	maxManagedNames       = 1024
+	maxEnvironmentValue   = 4096
+	maxStateBytes         = 2 << 20
+)
+
+var (
+	ErrInvalidEnvironment = errors.New("invalid runtime credential environment")
+	ErrInvalidState       = errors.New("invalid runtime credential environment state")
+	ErrStaleGeneration    = errors.New("runtime credential environment generation is stale")
+	ErrGenerationConflict = errors.New("runtime credential environment generation conflicts")
+)
+
+var environmentName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,254}$`)
+
+var reservedEnvironmentNames = map[string]struct{}{
+	"ALL_PROXY":           {},
+	"CURL_CA_BUNDLE":      {},
+	"DENO_CERT":           {},
+	"GIT_SSL_CAINFO":      {},
+	"HOME":                {},
+	"HTTPS_PROXY":         {},
+	"HTTP_PROXY":          {},
+	"NODE_EXTRA_CA_CERTS": {},
+	"NODE_USE_ENV_PROXY":  {},
+	"NO_PROXY":            {},
+	"OPENCLAW_PROXY_URL":  {},
+	"PATH":                {},
+	"REQUESTS_CA_BUNDLE":  {},
+	"SSL_CERT_DIR":        {},
+	"SSL_CERT_FILE":       {},
+}
+
+// State is the complete durable credential environment snapshot. Environment
+// contains only opaque workload values, never the backing credential secrets.
+type State struct {
+	Kind              string            `json:"kind"`
+	Generation        uint64            `json:"generation"`
+	ManagedNames      []string          `json:"managed_names"`
+	Environment       map[string]string `json:"environment"`
+	EnvironmentSHA256 string            `json:"environment_sha256"`
+}
+
+// Status is safe for the control plane to inspect. It deliberately excludes
+// both current and historical environment values and names.
+type Status struct {
+	Supported         bool   `json:"supported"`
+	Seeded            bool   `json:"seeded"`
+	Generation        uint64 `json:"generation"`
+	Count             int    `json:"count"`
+	EnvironmentSHA256 string `json:"environment_sha256"`
+}
+
+// Store serializes control-plane updates to one atomic state file. Readers in
+// worker subprocesses do not share this lock and rely on atomic rename.
+type Store struct {
+	path         string
+	requireState bool
+	mu           sync.Mutex
+}
+
+// Path returns the credential environment state path for a telosd state root.
+func Path(root string) string {
+	return filepath.Join(root, "runtime", "credential-environment.json")
+}
+
+// NewStore creates a state store. It does not create or replace state.
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+// Initialize opts this runtime into dynamic credential environments. It
+// creates a seeded generation-zero snapshot before workers start and makes a
+// subsequently missing state file an error for this server process.
+func (s *Store) Initialize() (Status, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, seeded, err := Read(s.path)
+	if err != nil {
+		return Status{}, err
+	}
+	if !seeded {
+		state = State{
+			Kind:              Kind,
+			Generation:        0,
+			ManagedNames:      []string{},
+			Environment:       map[string]string{},
+			EnvironmentSHA256: EnvironmentSHA256(map[string]string{}),
+		}
+		if err := Write(s.path, state); err != nil {
+			return Status{}, err
+		}
+	}
+	s.requireState = true
+	return statusFor(state, true), nil
+}
+
+// Get returns non-secret capability and synchronization status.
+func (s *Store) Get() (Status, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, seeded, err := Read(s.path)
+	if err != nil {
+		return Status{}, err
+	}
+	if !seeded && s.requireState {
+		return Status{}, fmt.Errorf("%w: configured state file is missing", ErrInvalidState)
+	}
+	return statusFor(state, seeded), nil
+}
+
+// Put atomically replaces the current environment with one newer generation.
+// ManagedNames accumulate so a detached key inherited when the pod started is
+// removed from every future agent subprocess.
+func (s *Store) Put(generation uint64, environment map[string]string) (Status, error) {
+	environment, err := validateAndCloneEnvironment(environment)
+	if err != nil {
+		return Status{}, err
+	}
+	if generation == 0 && len(environment) != 0 {
+		return Status{}, fmt.Errorf("%w: generation zero requires an empty environment", ErrInvalidEnvironment)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	current, seeded, err := Read(s.path)
+	if err != nil {
+		return Status{}, err
+	}
+	if !seeded && s.requireState {
+		return Status{}, fmt.Errorf("%w: configured state file is missing", ErrInvalidState)
+	}
+	if seeded {
+		switch {
+		case generation < current.Generation:
+			return Status{}, ErrStaleGeneration
+		case generation == current.Generation:
+			if equalEnvironment(current.Environment, environment) {
+				return statusFor(current, true), nil
+			}
+			return Status{}, ErrGenerationConflict
+		}
+	}
+
+	managed := make(map[string]struct{}, len(current.ManagedNames)+len(environment))
+	for _, name := range current.ManagedNames {
+		managed[name] = struct{}{}
+	}
+	for name := range environment {
+		if _, alreadyManaged := managed[name]; !alreadyManaged {
+			managed[name] = struct{}{}
+		}
+	}
+	if len(managed) > maxManagedNames {
+		return Status{}, fmt.Errorf("%w: too many managed names", ErrInvalidEnvironment)
+	}
+
+	managedNames := make([]string, 0, len(managed))
+	for name := range managed {
+		managedNames = append(managedNames, name)
+	}
+	slices.Sort(managedNames)
+	state := State{
+		Kind:              Kind,
+		Generation:        generation,
+		ManagedNames:      managedNames,
+		Environment:       environment,
+		EnvironmentSHA256: EnvironmentSHA256(environment),
+	}
+	if err := Write(s.path, state); err != nil {
+		return Status{}, err
+	}
+	return statusFor(state, true), nil
+}
+
+// Read loads one complete state snapshot. A missing file means this runtime
+// has not opted into dynamic credential environments and preserves legacy
+// inherited-environment behavior.
+func Read(path string) (State, bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return State{}, false, nil
+	}
+	if err != nil {
+		return State{}, false, fmt.Errorf("read runtime credential environment state: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return State{}, false, fmt.Errorf("%w: unsafe state file", ErrInvalidState)
+	}
+	if info.Size() > maxStateBytes {
+		return State{}, false, fmt.Errorf("%w: state file is too large", ErrInvalidState)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return State{}, false, fmt.Errorf("read runtime credential environment state: %w", err)
+	}
+	var state State
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		return State{}, false, fmt.Errorf("%w: decode state", ErrInvalidState)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return State{}, false, fmt.Errorf("%w: decode state", ErrInvalidState)
+	}
+	if err := validateState(state); err != nil {
+		return State{}, false, err
+	}
+	return state, true, nil
+}
+
+// Write durably replaces one state snapshot without exposing a partially
+// written document to concurrent worker readers.
+func Write(path string, state State) error {
+	if err := validateState(state); err != nil {
+		return err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("encode runtime credential environment state: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxStateBytes {
+		return fmt.Errorf("%w: state file is too large", ErrInvalidState)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create runtime credential environment directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(dir, ".credential-environment-*")
+	if err != nil {
+		return fmt.Errorf("create runtime credential environment state: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("protect runtime credential environment state: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write runtime credential environment state: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync runtime credential environment state: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close runtime credential environment state: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace runtime credential environment state: %w", err)
+	}
+	removeTemporary = false
+	directory, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open runtime credential environment directory for sync: %w", err)
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	if err := errors.Join(syncErr, closeErr); err != nil {
+		return fmt.Errorf("sync runtime credential environment directory: %w", err)
+	}
+	return nil
+}
+
+// Apply removes every historically managed name from base and overlays the
+// current environment snapshot. It returns one entry per environment name.
+func Apply(base []string, state State) []string {
+	managed := make(map[string]struct{}, len(state.ManagedNames))
+	for _, name := range state.ManagedNames {
+		managed[name] = struct{}{}
+	}
+	merged := make(map[string]string, len(base)+len(state.Environment))
+	for _, entry := range base {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if _, remove := managed[name]; remove {
+			continue
+		}
+		merged[name] = value
+	}
+	for name, value := range state.Environment {
+		merged[name] = value
+	}
+	names := make([]string, 0, len(merged))
+	for name := range merged {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	environment := make([]string, 0, len(names))
+	for _, name := range names {
+		environment = append(environment, name+"="+merged[name])
+	}
+	return environment
+}
+
+// EnvironmentSHA256 returns the canonical digest used by Cloud to compare a
+// desired full snapshot without retrieving its values from telosd.
+func EnvironmentSHA256(environment map[string]string) string {
+	names := make([]string, 0, len(environment))
+	for name := range environment {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	hasher := sha256.New()
+	var length [4]byte
+	for _, name := range names {
+		value := environment[name]
+		binary.BigEndian.PutUint32(length[:], uint32(len([]byte(name))))
+		_, _ = hasher.Write(length[:])
+		_, _ = hasher.Write([]byte(name))
+		binary.BigEndian.PutUint32(length[:], uint32(len([]byte(value))))
+		_, _ = hasher.Write(length[:])
+		_, _ = hasher.Write([]byte(value))
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+func validateState(state State) error {
+	if state.Kind != Kind {
+		return fmt.Errorf("%w: unsupported state identity", ErrInvalidState)
+	}
+	environment, err := validateAndCloneEnvironment(state.Environment)
+	if err != nil {
+		return fmt.Errorf("%w: environment", ErrInvalidState)
+	}
+	if state.Generation == 0 && len(environment) != 0 {
+		return fmt.Errorf("%w: generation zero has a non-empty environment", ErrInvalidState)
+	}
+	if len(state.ManagedNames) > maxManagedNames {
+		return fmt.Errorf("%w: too many managed names", ErrInvalidState)
+	}
+	managed := make(map[string]struct{}, len(state.ManagedNames))
+	for index, name := range state.ManagedNames {
+		if err := validateEnvironmentName(name); err != nil {
+			return fmt.Errorf("%w: managed name", ErrInvalidState)
+		}
+		if index > 0 && state.ManagedNames[index-1] >= name {
+			return fmt.Errorf("%w: managed names are not canonical", ErrInvalidState)
+		}
+		managed[name] = struct{}{}
+	}
+	for name := range environment {
+		if _, ok := managed[name]; !ok {
+			return fmt.Errorf("%w: current name is not managed", ErrInvalidState)
+		}
+	}
+	if state.EnvironmentSHA256 != EnvironmentSHA256(environment) {
+		return fmt.Errorf("%w: environment digest mismatch", ErrInvalidState)
+	}
+	return nil
+}
+
+func validateAndCloneEnvironment(environment map[string]string) (map[string]string, error) {
+	if environment == nil {
+		return nil, fmt.Errorf("%w: environment must be an object", ErrInvalidEnvironment)
+	}
+	if len(environment) > maxEnvironmentEntries {
+		return nil, fmt.Errorf("%w: too many entries", ErrInvalidEnvironment)
+	}
+	cloned := make(map[string]string, len(environment))
+	for name, value := range environment {
+		if err := validateEnvironmentName(name); err != nil {
+			return nil, err
+		}
+		if len(value) > maxEnvironmentValue || strings.ContainsRune(value, '\x00') {
+			return nil, fmt.Errorf("%w: value for %s is invalid", ErrInvalidEnvironment, name)
+		}
+		cloned[name] = value
+	}
+	return cloned, nil
+}
+
+func validateEnvironmentName(name string) error {
+	upper := strings.ToUpper(name)
+	if !environmentName.MatchString(name) {
+		return fmt.Errorf("%w: name is invalid", ErrInvalidEnvironment)
+	}
+	if strings.HasPrefix(upper, "TELOS_") {
+		return fmt.Errorf("%w: name %s is reserved", ErrInvalidEnvironment, name)
+	}
+	if _, reserved := reservedEnvironmentNames[upper]; reserved {
+		return fmt.Errorf("%w: name %s is reserved", ErrInvalidEnvironment, name)
+	}
+	return nil
+}
+
+func statusFor(state State, seeded bool) Status {
+	if !seeded {
+		return Status{
+			Supported:         true,
+			EnvironmentSHA256: EnvironmentSHA256(map[string]string{}),
+		}
+	}
+	return Status{
+		Supported:         true,
+		Seeded:            true,
+		Generation:        state.Generation,
+		Count:             len(state.Environment),
+		EnvironmentSHA256: state.EnvironmentSHA256,
+	}
+}
+
+func equalEnvironment(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name, value := range left {
+		rightValue, ok := right[name]
+		if !ok || rightValue != value {
+			return false
+		}
+	}
+	return true
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra json.RawMessage
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values")
+	}
+	return err
+}

--- a/internal/runtimeenv/environment.go
+++ b/internal/runtimeenv/environment.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 const (
@@ -101,6 +102,9 @@ func (s *Store) Initialize() (Status, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := normalizeStatePermissions(s.path); err != nil {
+		return Status{}, err
+	}
 	state, seeded, err := Read(s.path)
 	if err != nil {
 		return Status{}, err
@@ -119,6 +123,42 @@ func (s *Store) Initialize() (Status, error) {
 	}
 	s.requireState = true
 	return statusFor(state, true), nil
+}
+
+// normalizeStatePermissions repairs group-only access introduced by the pod
+// init container while refusing symlinks, nonregular files, and any file that
+// was exposed to other users. Read remains strict for every runtime reload.
+func normalizeStatePermissions(path string) error {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if errors.Is(err, syscall.ELOOP) {
+		return fmt.Errorf("%w: unsafe state file", ErrInvalidState)
+	}
+	if err != nil {
+		return fmt.Errorf("open runtime credential environment state for permission repair: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	info, statErr := file.Stat()
+	if statErr != nil {
+		_ = file.Close()
+		return fmt.Errorf("inspect runtime credential environment state for permission repair: %w", statErr)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o007 != 0 {
+		_ = file.Close()
+		return fmt.Errorf("%w: unsafe state file", ErrInvalidState)
+	}
+	if info.Mode().Perm() != 0o600 {
+		if err := file.Chmod(0o600); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("repair runtime credential environment state permissions: %w", err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close runtime credential environment state after permission repair: %w", err)
+	}
+	return nil
 }
 
 // Get returns non-secret capability and synchronization status.

--- a/internal/runtimeenv/environment_test.go
+++ b/internal/runtimeenv/environment_test.go
@@ -89,6 +89,76 @@ func TestInitializedStoreFailsClosedWhenStateDisappears(t *testing.T) {
 	}
 }
 
+func TestInitializeRepairsPodRecreationPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	if _, err := store.Put(7, map[string]string{"TOKEN": "opaque"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Read(path); !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("strict read of 0660 state: got %v want ErrInvalidState", err)
+	}
+
+	status, err := NewStore(path).Initialize()
+	if err != nil {
+		t.Fatalf("initialize 0660 state: %v", err)
+	}
+	if status.Generation != 7 || status.Count != 1 {
+		t.Fatalf("repaired state changed contents: %#v", status)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("repaired permissions: got %o want 600", got)
+	}
+}
+
+func TestInitializeRejectsUnsafeStateFiles(t *testing.T) {
+	t.Run("other-readable", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		store := NewStore(path)
+		if _, err := store.Put(1, map[string]string{"TOKEN": "opaque"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewStore(path).Initialize(); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("initialize 0644 state: got %v want ErrInvalidState", err)
+		}
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target.json")
+		if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "state.json")
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewStore(path).Initialize(); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("initialize symlink: got %v want ErrInvalidState", err)
+		}
+	})
+
+	t.Run("nonregular", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewStore(path).Initialize(); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("initialize directory: got %v want ErrInvalidState", err)
+		}
+	})
+}
+
 func TestStoreGenerationAndIdempotency(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.json")
 	store := NewStore(path)

--- a/internal/runtimeenv/environment_test.go
+++ b/internal/runtimeenv/environment_test.go
@@ -1,0 +1,306 @@
+package runtimeenv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestStoreUnseededStatusDoesNotExposeEnvironment(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+
+	status, err := store.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Supported || status.Seeded || status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if got, want := status.EnvironmentSHA256, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; got != want {
+		t.Fatalf("empty environment digest: got %q want %q", got, want)
+	}
+}
+
+func TestEnvironmentSHA256UsesLengthPrefixedUTF8Entries(t *testing.T) {
+	environment := map[string]string{
+		"Z": "<&>",
+		"é": "雪",
+	}
+	if got, want := EnvironmentSHA256(environment), "sha256:0ed8d3aae9c9a66ac100bf500eaf4eb80cfc274429b456fe3c1b65613e04b490"; got != want {
+		t.Fatalf("environment digest: got %q want %q", got, want)
+	}
+}
+
+func TestStoreAllowsSeededGenerationZeroForEmptyEnvironment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+
+	status, err := store.Put(0, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Seeded || status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if _, err := store.Put(0, map[string]string{"TOKEN": "opaque"}); !errors.Is(err, ErrInvalidEnvironment) {
+		t.Fatalf("non-empty generation zero: got %v want ErrInvalidEnvironment", err)
+	}
+	if _, err := store.Put(1, map[string]string{"TOKEN": "opaque"}); err != nil {
+		t.Fatalf("attach after generation zero: %v", err)
+	}
+	state, seeded, err := Read(path)
+	if err != nil || !seeded {
+		t.Fatalf("read attached state: seeded=%v err=%v", seeded, err)
+	}
+	if got := testEnvironmentMap(Apply([]string{"TOKEN=stale"}, state))["TOKEN"]; got != "opaque" {
+		t.Fatalf("attached token: got %q want opaque", got)
+	}
+	if _, err := store.Put(2, map[string]string{}); err != nil {
+		t.Fatalf("detach after generation zero: %v", err)
+	}
+	state, _, err = Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := testEnvironmentMap(Apply([]string{"TOKEN=stale"}, state))["TOKEN"]; ok {
+		t.Fatal("detached token remained after generation-zero seed")
+	}
+}
+
+func TestInitializedStoreFailsClosedWhenStateDisappears(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	if _, err := store.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(); !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("get missing configured state: got %v want ErrInvalidState", err)
+	}
+	if _, err := store.Put(1, map[string]string{"TOKEN": "opaque"}); !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("put missing configured state: got %v want ErrInvalidState", err)
+	}
+}
+
+func TestStoreGenerationAndIdempotency(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	initial := map[string]string{"MODAL_TOKEN_ID": "opaque-one"}
+
+	status, err := store.Put(4, initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Seeded || status.Generation != 4 || status.Count != 1 {
+		t.Fatalf("unexpected initial status: %#v", status)
+	}
+	if _, err := store.Put(3, initial); !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("stale generation: got %v want ErrStaleGeneration", err)
+	}
+	if _, err := store.Put(4, initial); err != nil {
+		t.Fatalf("idempotent put: %v", err)
+	}
+	if _, err := store.Put(4, map[string]string{"MODAL_TOKEN_ID": "different"}); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("conflicting generation: got %v want ErrGenerationConflict", err)
+	}
+
+	next := map[string]string{"MODAL_TOKEN_SECRET": "opaque-two"}
+	status, err = store.Put(6, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Generation != 6 || status.Count != 1 {
+		t.Fatalf("unexpected next status: %#v", status)
+	}
+	state, seeded, err := Read(path)
+	if err != nil || !seeded {
+		t.Fatalf("read state: seeded=%v err=%v", seeded, err)
+	}
+	if got, want := state.ManagedNames, []string{"MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"}; !slices.Equal(got, want) {
+		t.Fatalf("managed names: got %v want %v", got, want)
+	}
+	if got, want := state.EnvironmentSHA256, EnvironmentSHA256(next); got != want {
+		t.Fatalf("digest: got %q want %q", got, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state permissions: got %o want 600", got)
+	}
+	reopenedStatus, err := NewStore(path).Get()
+	if err != nil {
+		t.Fatalf("reopen state: %v", err)
+	}
+	if reopenedStatus != status {
+		t.Fatalf("reopened status: got %#v want %#v", reopenedStatus, status)
+	}
+}
+
+func TestSameGenerationDistinguishesDifferentEmptyValuedKeys(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	if _, err := store.Put(1, map[string]string{"TOKEN_A": ""}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put(1, map[string]string{"TOKEN_B": ""}); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("same generation with a different key: got %v want ErrGenerationConflict", err)
+	}
+}
+
+func TestStoreRejectsReservedAndInvalidEnvironment(t *testing.T) {
+	tooMany := make(map[string]string, maxEnvironmentEntries+1)
+	for index := range maxEnvironmentEntries + 1 {
+		tooMany[fmt.Sprintf("TOKEN_%d", index)] = "opaque"
+	}
+	tests := []map[string]string{
+		nil,
+		{"bad-name": "opaque"},
+		{"telos_api_token": "opaque"},
+		{"Path": "opaque"},
+		{"TOKEN": "contains\x00nul"},
+		{"TOKEN": strings.Repeat("x", maxEnvironmentValue+1)},
+		tooMany,
+	}
+	for index, environment := range tests {
+		t.Run(fmt.Sprintf("case-%d", index), func(t *testing.T) {
+			store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+			if _, err := store.Put(1, environment); !errors.Is(err, ErrInvalidEnvironment) {
+				t.Fatalf("invalid environment: got %v want ErrInvalidEnvironment", err)
+			}
+		})
+	}
+}
+
+func TestApplyMasksDetachedInheritedNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	if _, err := store.Put(1, map[string]string{
+		"MODAL_TOKEN_ID":     "opaque-one",
+		"MODAL_TOKEN_SECRET": "opaque-two",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put(2, map[string]string{"NEW_TOKEN": "opaque-three"}); err != nil {
+		t.Fatal(err)
+	}
+	state, _, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := testEnvironmentMap(Apply([]string{
+		"MODAL_TOKEN_ID=opaque-one",
+		"MODAL_TOKEN_SECRET=opaque-two",
+		"UNCHANGED=keep",
+	}, state))
+	if _, ok := got["MODAL_TOKEN_ID"]; ok {
+		t.Fatal("detached MODAL_TOKEN_ID remained in the child environment")
+	}
+	if _, ok := got["MODAL_TOKEN_SECRET"]; ok {
+		t.Fatal("detached MODAL_TOKEN_SECRET remained in the child environment")
+	}
+	if got["NEW_TOKEN"] != "opaque-three" || got["UNCHANGED"] != "keep" {
+		t.Fatalf("unexpected applied environment: %v", got)
+	}
+
+	if _, err := store.Put(3, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+	state, _, err = Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = testEnvironmentMap(Apply([]string{
+		"MODAL_TOKEN_ID=opaque-one",
+		"MODAL_TOKEN_SECRET=opaque-two",
+		"UNCHANGED=keep",
+	}, state))
+	if _, ok := got["NEW_TOKEN"]; ok {
+		t.Fatal("detached dynamically added token remained in the child environment")
+	}
+	if got["UNCHANGED"] != "keep" {
+		t.Fatalf("unmanaged environment changed: %v", got)
+	}
+}
+
+func TestReadRejectsCorruptOrUnsafeState(t *testing.T) {
+	t.Run("invalid digest", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		data := []byte(`{"kind":"telos.runtime-credential-environment.v1","generation":1,"managed_names":["TOKEN"],"environment":{"TOKEN":"opaque"},"environment_sha256":"sha256:wrong"}`)
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := Read(path); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("invalid digest: got %v want ErrInvalidState", err)
+		}
+	})
+
+	t.Run("unsafe permissions", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := Read(path); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("unsafe permissions: got %v want ErrInvalidState", err)
+		}
+	})
+}
+
+func TestAtomicStateIsAlwaysReadableDuringUpdates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	if _, err := store.Put(0, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	const updates = 100
+	var readers sync.WaitGroup
+	errCh := make(chan error, 4)
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for range updates {
+				state, seeded, err := Read(path)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if !seeded || state.EnvironmentSHA256 != EnvironmentSHA256(state.Environment) {
+					errCh <- errors.New("reader observed a partial state")
+					return
+				}
+			}
+		}()
+	}
+	for generation := uint64(1); generation <= updates; generation++ {
+		if _, err := store.Put(generation, map[string]string{
+			"TOKEN": fmt.Sprintf("opaque-%d", generation),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readers.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+func testEnvironmentMap(environment []string) map[string]string {
+	values := make(map[string]string, len(environment))
+	for _, entry := range environment {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = value
+		}
+	}
+	return values
+}

--- a/internal/sessionapi/auth.go
+++ b/internal/sessionapi/auth.go
@@ -38,12 +38,13 @@ type Caller struct {
 type AccessAction string
 
 const (
-	ActionHealth            AccessAction = "health"
-	ActionCreateSession     AccessAction = "create_session"
-	ActionUpdateSessionSpec AccessAction = "update_session_spec"
-	ActionListSessions      AccessAction = "list_sessions"
-	ActionReadSession       AccessAction = "read_session"
-	ActionStopSession       AccessAction = "stop_session"
+	ActionHealth                             AccessAction = "health"
+	ActionCreateSession                      AccessAction = "create_session"
+	ActionUpdateSessionSpec                  AccessAction = "update_session_spec"
+	ActionListSessions                       AccessAction = "list_sessions"
+	ActionReadSession                        AccessAction = "read_session"
+	ActionStopSession                        AccessAction = "stop_session"
+	ActionManageRuntimeCredentialEnvironment AccessAction = "manage_runtime_credential_environment"
 )
 
 type AccessRequest struct {
@@ -171,6 +172,11 @@ func authorizeCaller(store *FileStore, caller Caller, req AccessRequest) error {
 		return requireSessionAccess(store, caller, req.SessionID, ScopeSessionsRead)
 	case ActionStopSession:
 		return requireSessionAccess(store, caller, req.SessionID, ScopeSessionsStop)
+	case ActionManageRuntimeCredentialEnvironment:
+		if caller.Role != RoleOperator {
+			return authError{status: http.StatusForbidden, detail: "runtime operator access required"}
+		}
+		return nil
 	default:
 		return authError{status: http.StatusForbidden, detail: "unsupported session API action"}
 	}

--- a/internal/sessionapi/manifest.go
+++ b/internal/sessionapi/manifest.go
@@ -83,17 +83,18 @@ const (
 )
 
 type Runner struct {
-	Kind         string  `json:"kind,omitempty"`
-	PID          int     `json:"pid,omitempty"`
-	PGID         int     `json:"pgid,omitempty"`
-	LogPath      string  `json:"log_path,omitempty"`
-	InCluster    bool    `json:"in_cluster"`
-	Hostname     string  `json:"hostname,omitempty"`
-	PodName      string  `json:"pod_name,omitempty"`
-	PodNamespace string  `json:"pod_namespace,omitempty"`
-	StartedAt    string  `json:"started_at,omitempty"`
-	FinishedAt   *string `json:"finished_at,omitempty"`
-	Status       string  `json:"status,omitempty"`
+	Kind         string   `json:"kind,omitempty"`
+	PID          int      `json:"pid,omitempty"`
+	PGID         int      `json:"pgid,omitempty"`
+	LogPath      string   `json:"log_path,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+	InCluster    bool     `json:"in_cluster"`
+	Hostname     string   `json:"hostname,omitempty"`
+	PodName      string   `json:"pod_name,omitempty"`
+	PodNamespace string   `json:"pod_namespace,omitempty"`
+	StartedAt    string   `json:"started_at,omitempty"`
+	FinishedAt   *string  `json:"finished_at,omitempty"`
+	Status       string   `json:"status,omitempty"`
 }
 
 type ScopedToken struct {

--- a/internal/sessionworker/BUILD.bazel
+++ b/internal/sessionworker/BUILD.bazel
@@ -5,12 +5,18 @@ go_library(
     srcs = ["process.go"],
     importpath = "github.com/telos-org/telos/internal/sessionworker",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/sessionapi"],
+    deps = [
+        "//internal/runtimeenv",
+        "//internal/sessionapi",
+    ],
 )
 
 go_test(
     name = "sessionworker_test",
     srcs = ["process_test.go"],
     embed = [":sessionworker"],
-    deps = ["//internal/sessionapi"],
+    deps = [
+        "//internal/runtimeenv",
+        "//internal/sessionapi",
+    ],
 )

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -6,15 +6,20 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/telos-org/telos/internal/runtimeenv"
 	"github.com/telos-org/telos/internal/sessionapi"
 )
 
 var ErrWorkerNotRunning = errors.New("worker is not running")
 var ErrWorkerAlreadyRunning = errors.New("worker is already running")
 var ErrSessionStopped = errors.New("session is stopped")
+
+const RuntimeCredentialEnvironmentCapability = "runtime-credential-environment-v1"
 
 type Ownership struct {
 	file *os.File
@@ -34,8 +39,9 @@ func (o *Ownership) Release() error {
 }
 
 type StartOptions struct {
-	Runtime    sessionapi.SessionRuntime
-	WakeReason string
+	Runtime                          sessionapi.SessionRuntime
+	WakeReason                       string
+	RuntimeCredentialEnvironmentPath string
 }
 
 func Start(sessionDir string, runtime sessionapi.SessionRuntime) error {
@@ -107,6 +113,9 @@ func Env(sessionDir string, opts StartOptions) []string {
 			"TELOS_WAKE_REASON="+opts.WakeReason,
 			"TELOS_WAKE_ID="+opts.WakeReason+":"+time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
 		)
+	}
+	if opts.RuntimeCredentialEnvironmentPath != "" {
+		env = append(env, runtimeenv.PathEnvironmentVariable+"="+opts.RuntimeCredentialEnvironmentPath)
 	}
 	return env
 }
@@ -189,6 +198,9 @@ func AcquireOwnership(sessionDir string, logPath string) (*Ownership, error) {
 		return nil, fmt.Errorf("acquire runner lock: %w", err)
 	}
 	runner := RunnerIdentity(os.Getpid())
+	if strings.TrimSpace(os.Getenv(runtimeenv.PathEnvironmentVariable)) != "" {
+		runner.Capabilities = []string{RuntimeCredentialEnvironmentCapability}
+	}
 	if logPath != "" {
 		runner.LogPath = logPath
 	}
@@ -201,6 +213,37 @@ func AcquireOwnership(sessionDir string, logPath string) (*Ownership, error) {
 		return nil, fmt.Errorf("record runner: %w", err)
 	}
 	return &Ownership{file: lock}, nil
+}
+
+// RuntimeCredentialEnvironmentCapabilityStatus reports whether a live worker
+// owns the session and, if so, whether that exact runner advertised dynamic
+// runtime credential environment support. A dead session has no unsafe worker
+// and will be relaunched by the current telosd binary.
+func RuntimeCredentialEnvironmentCapabilityStatus(sessionDir string) (live bool, supported bool, err error) {
+	live, err = workerAlive(sessionDir)
+	if err != nil || !live {
+		return live, false, err
+	}
+	manifest, err := sessionapi.ReadManifest(manifestPath(sessionDir))
+	if err != nil {
+		return true, false, fmt.Errorf("read live worker manifest: %w", err)
+	}
+	if manifest.Runner == nil {
+		return true, false, nil
+	}
+	pid, ok := manifest.Runner.ProcessID()
+	if !ok {
+		return true, false, nil
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return true, false, nil
+		}
+		if !errors.Is(err, syscall.EPERM) {
+			return true, false, fmt.Errorf("probe live worker process %d: %w", pid, err)
+		}
+	}
+	return true, slices.Contains(manifest.Runner.Capabilities, RuntimeCredentialEnvironmentCapability), nil
 }
 
 func workerAlive(sessionDir string) (bool, error) {

--- a/internal/sessionworker/process.go
+++ b/internal/sessionworker/process.go
@@ -18,6 +18,7 @@ import (
 var ErrWorkerNotRunning = errors.New("worker is not running")
 var ErrWorkerAlreadyRunning = errors.New("worker is already running")
 var ErrSessionStopped = errors.New("session is stopped")
+var ErrWorkerReadinessTransient = errors.New("worker readiness is transient")
 
 const RuntimeCredentialEnvironmentCapability = "runtime-credential-environment-v1"
 
@@ -229,15 +230,18 @@ func RuntimeCredentialEnvironmentCapabilityStatus(sessionDir string) (live bool,
 		return true, false, fmt.Errorf("read live worker manifest: %w", err)
 	}
 	if manifest.Runner == nil {
-		return true, false, nil
+		return true, false, fmt.Errorf("%w: live worker has no runner identity", ErrWorkerReadinessTransient)
+	}
+	if manifest.Runner.Kind != "local-subprocess" || strings.TrimSpace(manifest.Runner.StartedAt) == "" {
+		return true, false, fmt.Errorf("%w: live worker runner identity is incomplete", ErrWorkerReadinessTransient)
 	}
 	pid, ok := manifest.Runner.ProcessID()
 	if !ok {
-		return true, false, nil
+		return true, false, fmt.Errorf("%w: live worker runner PID is invalid", ErrWorkerReadinessTransient)
 	}
 	if err := syscall.Kill(pid, 0); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return true, false, nil
+			return true, false, fmt.Errorf("%w: live worker runner PID is not alive", ErrWorkerReadinessTransient)
 		}
 		if !errors.Is(err, syscall.EPERM) {
 			return true, false, fmt.Errorf("probe live worker process %d: %w", pid, err)

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -115,11 +115,41 @@ func TestRuntimeCredentialEnvironmentCapabilityStatusRejectsStaleRunnerPID(t *te
 	}
 
 	live, supported, err := RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrWorkerReadinessTransient) {
+		t.Fatalf("stale PID readiness: got %v want ErrWorkerReadinessTransient", err)
 	}
 	if !live || supported {
 		t.Fatalf("stale PID capability: live=%t supported=%t", live, supported)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentCapabilityStatusTreatsIncompleteRunnerAsTransient(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &sessionapi.Manifest{
+		SessionID:   filepath.Base(sessionDir),
+		SessionKind: sessionapi.KindController,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, filepath.Join(t.TempDir(), "credential-environment.json"))
+	owner, err := AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Release()
+	if _, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(manifest *sessionapi.Manifest) error {
+		manifest.Runner.Kind = ""
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	live, supported, err := RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
+	if !errors.Is(err, ErrWorkerReadinessTransient) {
+		t.Fatalf("incomplete runner readiness: got %v want ErrWorkerReadinessTransient", err)
+	}
+	if !live || supported {
+		t.Fatalf("incomplete runner capability: live=%t supported=%t", live, supported)
 	}
 }
 

--- a/internal/sessionworker/process_test.go
+++ b/internal/sessionworker/process_test.go
@@ -6,10 +6,29 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/telos-org/telos/internal/runtimeenv"
 	"github.com/telos-org/telos/internal/sessionapi"
 )
 
+func TestEnvIncludesRuntimeCredentialEnvironmentPath(t *testing.T) {
+	sessionDir := t.TempDir()
+	path := filepath.Join(t.TempDir(), "credential-environment.json")
+	environment := Env(sessionDir, StartOptions{
+		Runtime:                          sessionapi.RuntimeCloud,
+		RuntimeCredentialEnvironmentPath: path,
+	})
+
+	want := runtimeenv.PathEnvironmentVariable + "=" + path
+	for _, entry := range environment {
+		if entry == want {
+			return
+		}
+	}
+	t.Fatalf("runtime credential environment path missing from %v", environment)
+}
+
 func TestAcquireOwnershipIsExclusiveAndRecordsTopLevelRunner(t *testing.T) {
+	t.Setenv(runtimeenv.PathEnvironmentVariable, "")
 	sessionDir := t.TempDir()
 	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &sessionapi.Manifest{
 		SessionID:   filepath.Base(sessionDir),
@@ -35,6 +54,72 @@ func TestAcquireOwnershipIsExclusiveAndRecordsTopLevelRunner(t *testing.T) {
 	}
 	if manifest.Runner == nil || manifest.Runner.PID != os.Getpid() {
 		t.Fatalf("top-level runner not recorded: %#v", manifest.Runner)
+	}
+	if len(manifest.Runner.Capabilities) != 0 {
+		t.Fatalf("unconfigured worker advertised capabilities: %#v", manifest.Runner.Capabilities)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentCapabilityStatusUsesLiveConfiguredRunner(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &sessionapi.Manifest{
+		SessionID:   filepath.Base(sessionDir),
+		SessionKind: sessionapi.KindController,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, filepath.Join(t.TempDir(), "credential-environment.json"))
+	owner, err := AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	live, supported, err := RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !live || !supported {
+		t.Fatalf("configured live worker: live=%t supported=%t", live, supported)
+	}
+	if err := owner.Release(); err != nil {
+		t.Fatal(err)
+	}
+	live, supported, err = RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live || supported {
+		t.Fatalf("stale runner record: live=%t supported=%t", live, supported)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentCapabilityStatusRejectsStaleRunnerPID(t *testing.T) {
+	sessionDir := t.TempDir()
+	if err := sessionapi.WriteManifest(manifestPath(sessionDir), &sessionapi.Manifest{
+		SessionID:   filepath.Base(sessionDir),
+		SessionKind: sessionapi.KindController,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, filepath.Join(t.TempDir(), "credential-environment.json"))
+	owner, err := AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Release()
+	if _, err := sessionapi.MutateManifest(manifestPath(sessionDir), func(manifest *sessionapi.Manifest) error {
+		manifest.Runner.PID = 1 << 30
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	live, supported, err := RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !live || supported {
+		t.Fatalf("stale PID capability: live=%t supported=%t", live, supported)
 	}
 }
 

--- a/internal/telosd/BUILD.bazel
+++ b/internal/telosd/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "package_materializer.go",
         "platform_skills.go",
         "runtime_identity.go",
+        "runtime_credential_environment.go",
         "server.go",
         "session_bootstrap.go",
         "session_worker_helpers.go",
@@ -21,6 +22,7 @@ go_library(
         "//internal/cli",
         "//internal/evidence",
         "//internal/game",
+        "//internal/runtimeenv",
         "//internal/sessionapi",
         "//internal/sessionupdate",
         "//internal/sessionworker",
@@ -34,9 +36,11 @@ go_test(
     srcs = [
         "config_test.go",
         "controller_reconciler_test.go",
+        "local_process_worker_test.go",
         "package_materializer_test.go",
         "platform_skills_test.go",
         "runtime_identity_test.go",
+        "runtime_credential_environment_test.go",
         "server_test.go",
         "session_bootstrap_test.go",
         "worker_test.go",
@@ -44,7 +48,9 @@ go_test(
     embed = [":telosd"],
     deps = [
         "//internal/bundlelimits",
+        "//internal/runtimeenv",
         "//internal/sessionapi",
+        "//internal/sessionworker",
         "//internal/spec",
     ],
 )

--- a/internal/telosd/local_process_worker.go
+++ b/internal/telosd/local_process_worker.go
@@ -3,18 +3,23 @@ package telosd
 import (
 	"fmt"
 
+	"github.com/telos-org/telos/internal/runtimeenv"
 	"github.com/telos-org/telos/internal/sessionapi"
 	"github.com/telos-org/telos/internal/sessionworker"
 )
 
-type localProcessSubstrate struct{}
-
-func newLocalProcessSubstrate() localProcessSubstrate {
-	return localProcessSubstrate{}
+type localProcessSubstrate struct {
+	runtimeCredentialEnvironmentPath string
 }
 
-func newSessionSubstrate(Config) (sessionSubstrate, error) {
-	return newLocalProcessSubstrate(), nil
+func newLocalProcessSubstrate(runtimeCredentialEnvironmentPath string) localProcessSubstrate {
+	return localProcessSubstrate{
+		runtimeCredentialEnvironmentPath: runtimeCredentialEnvironmentPath,
+	}
+}
+
+func newSessionSubstrate(cfg Config) (sessionSubstrate, error) {
+	return newLocalProcessSubstrate(runtimeenv.Path(cfg.Root)), nil
 }
 
 func (s localProcessSubstrate) Apply(session *sessionapi.Session, wakeReason string) error {
@@ -26,8 +31,9 @@ func (s localProcessSubstrate) Apply(session *sessionapi.Session, wakeReason str
 		return fmt.Errorf("session %s has no session_dir", session.SessionID)
 	}
 	return sessionworker.EnsureStartedWithOptions(sessionDir, sessionworker.StartOptions{
-		Runtime:    sessionapi.RuntimeCloud,
-		WakeReason: wakeReason,
+		Runtime:                          sessionapi.RuntimeCloud,
+		WakeReason:                       wakeReason,
+		RuntimeCredentialEnvironmentPath: s.runtimeCredentialEnvironmentPath,
 	})
 }
 

--- a/internal/telosd/local_process_worker_test.go
+++ b/internal/telosd/local_process_worker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/telos-org/telos/internal/runtimeenv"
 	"github.com/telos-org/telos/internal/sessionapi"
 )
 
@@ -22,8 +23,12 @@ func TestNewSessionSubstrateDefaultsToLocalProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newSessionSubstrate: %v", err)
 	}
-	if _, ok := substrate.(localProcessSubstrate); !ok {
+	local, ok := substrate.(localProcessSubstrate)
+	if !ok {
 		t.Fatalf("substrate: got %T", substrate)
+	}
+	if got, want := local.runtimeCredentialEnvironmentPath, runtimeenv.Path(cfg.Root); got != want {
+		t.Fatalf("runtime credential environment path: got %q want %q", got, want)
 	}
 }
 
@@ -43,7 +48,9 @@ done
   echo "TELOS_SESSION_ID=$TELOS_SESSION_ID"
   echo "TELOS_API_TOKEN=$TELOS_API_TOKEN"
   echo "TELOS_WAKE_REASON=$TELOS_WAKE_REASON"
-} > "$session_dir/worker.env"
+  echo "TELOS_RUNTIME_CREDENTIAL_ENV_FILE=$TELOS_RUNTIME_CREDENTIAL_ENV_FILE"
+} > "$session_dir/worker.env.tmp"
+mv "$session_dir/worker.env.tmp" "$session_dir/worker.env"
 `), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +63,8 @@ done
 		t.Fatalf("Create: %v", err)
 	}
 
-	substrate := newLocalProcessSubstrate()
+	runtimeCredentialEnvironmentPath := filepath.Join(dir, "credential-environment.json")
+	substrate := newLocalProcessSubstrate(runtimeCredentialEnvironmentPath)
 	if err := substrate.Apply(session, "controller_started"); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -79,6 +87,7 @@ done
 		"TELOS_RUNTIME=cloud",
 		"TELOS_SESSION_ID=" + session.SessionID,
 		"TELOS_WAKE_REASON=controller_started",
+		"TELOS_RUNTIME_CREDENTIAL_ENV_FILE=" + runtimeCredentialEnvironmentPath,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("worker env missing %q:\n%s", want, text)

--- a/internal/telosd/runtime_credential_environment.go
+++ b/internal/telosd/runtime_credential_environment.go
@@ -64,11 +64,7 @@ func (h *runtimeCredentialEnvironmentHandler) get(w http.ResponseWriter, r *http
 	}
 	status.Supported, err = h.workersSupported()
 	if err != nil {
-		writeRuntimeCredentialEnvironmentError(
-			w,
-			http.StatusInternalServerError,
-			"runtime credential environment worker readiness is unavailable",
-		)
+		writeRuntimeCredentialEnvironmentReadinessError(w, err)
 		return
 	}
 	writeRuntimeCredentialEnvironmentJSON(w, http.StatusOK, status)
@@ -80,11 +76,7 @@ func (h *runtimeCredentialEnvironmentHandler) put(w http.ResponseWriter, r *http
 	}
 	supported, err := h.workersSupported()
 	if err != nil {
-		writeRuntimeCredentialEnvironmentError(
-			w,
-			http.StatusInternalServerError,
-			"runtime credential environment worker readiness is unavailable",
-		)
+		writeRuntimeCredentialEnvironmentReadinessError(w, err)
 		return
 	}
 	if !supported {
@@ -158,6 +150,22 @@ func runtimeCredentialEnvironmentWorkersSupported(store *sessionapi.FileStore) (
 		}
 	}
 	return true, nil
+}
+
+func writeRuntimeCredentialEnvironmentReadinessError(w http.ResponseWriter, err error) {
+	if errors.Is(err, sessionworker.ErrWorkerReadinessTransient) {
+		writeRuntimeCredentialEnvironmentError(
+			w,
+			http.StatusServiceUnavailable,
+			"runtime credential environment worker readiness is pending",
+		)
+		return
+	}
+	writeRuntimeCredentialEnvironmentError(
+		w,
+		http.StatusInternalServerError,
+		"runtime credential environment worker readiness is unavailable",
+	)
 }
 
 func (h *runtimeCredentialEnvironmentHandler) authorize(w http.ResponseWriter, r *http.Request) bool {

--- a/internal/telosd/runtime_credential_environment.go
+++ b/internal/telosd/runtime_credential_environment.go
@@ -1,0 +1,200 @@
+package telosd
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/telos-org/telos/internal/runtimeenv"
+	"github.com/telos-org/telos/internal/sessionapi"
+	"github.com/telos-org/telos/internal/sessionworker"
+)
+
+const maxRuntimeCredentialEnvironmentRequestBytes = 1 << 20
+
+type runtimeCredentialEnvironmentHandler struct {
+	store            *runtimeenv.Store
+	authorizer       sessionapi.Authorizer
+	workersSupported func() (bool, error)
+}
+
+type runtimeCredentialEnvironmentUpdateRequest struct {
+	Generation  uint64            `json:"generation"`
+	Environment map[string]string `json:"environment"`
+}
+
+func initializeRuntimeCredentialEnvironment(root string) (*runtimeenv.Store, error) {
+	store := runtimeenv.NewStore(runtimeenv.Path(root))
+	if _, err := store.Initialize(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func registerRuntimeCredentialEnvironmentRoutes(
+	mux *http.ServeMux,
+	store *runtimeenv.Store,
+	authorizer sessionapi.Authorizer,
+	workersSupported func() (bool, error),
+) {
+	handler := &runtimeCredentialEnvironmentHandler{
+		store:            store,
+		authorizer:       authorizer,
+		workersSupported: workersSupported,
+	}
+	mux.HandleFunc("GET /api/runtime/credential-environment", handler.get)
+	mux.HandleFunc("PUT /api/runtime/credential-environment", handler.put)
+}
+
+func (h *runtimeCredentialEnvironmentHandler) get(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r) {
+		return
+	}
+	status, err := h.store.Get()
+	if err != nil {
+		writeRuntimeCredentialEnvironmentError(
+			w,
+			http.StatusInternalServerError,
+			"runtime credential environment state is unavailable",
+		)
+		return
+	}
+	status.Supported, err = h.workersSupported()
+	if err != nil {
+		writeRuntimeCredentialEnvironmentError(
+			w,
+			http.StatusInternalServerError,
+			"runtime credential environment worker readiness is unavailable",
+		)
+		return
+	}
+	writeRuntimeCredentialEnvironmentJSON(w, http.StatusOK, status)
+}
+
+func (h *runtimeCredentialEnvironmentHandler) put(w http.ResponseWriter, r *http.Request) {
+	if !h.authorize(w, r) {
+		return
+	}
+	supported, err := h.workersSupported()
+	if err != nil {
+		writeRuntimeCredentialEnvironmentError(
+			w,
+			http.StatusInternalServerError,
+			"runtime credential environment worker readiness is unavailable",
+		)
+		return
+	}
+	if !supported {
+		writeRuntimeCredentialEnvironmentError(
+			w,
+			http.StatusServiceUnavailable,
+			"runtime credential environment is not supported by every live session worker",
+		)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRuntimeCredentialEnvironmentRequestBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var request runtimeCredentialEnvironmentUpdateRequest
+	if err := decoder.Decode(&request); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeRuntimeCredentialEnvironmentError(w, http.StatusRequestEntityTooLarge, "request body is too large")
+			return
+		}
+		writeRuntimeCredentialEnvironmentError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := requireRuntimeCredentialEnvironmentJSONEOF(decoder); err != nil {
+		writeRuntimeCredentialEnvironmentError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	status, err := h.store.Put(request.Generation, request.Environment)
+	if err != nil {
+		switch {
+		case errors.Is(err, runtimeenv.ErrInvalidEnvironment):
+			writeRuntimeCredentialEnvironmentError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, runtimeenv.ErrStaleGeneration):
+			writeRuntimeCredentialEnvironmentError(w, http.StatusConflict, "runtime credential environment generation is stale")
+		case errors.Is(err, runtimeenv.ErrGenerationConflict):
+			writeRuntimeCredentialEnvironmentError(w, http.StatusConflict, "runtime credential environment generation already has different contents")
+		default:
+			writeRuntimeCredentialEnvironmentError(
+				w,
+				http.StatusInternalServerError,
+				"runtime credential environment state is unavailable",
+			)
+		}
+		return
+	}
+	writeRuntimeCredentialEnvironmentJSON(w, http.StatusOK, status)
+}
+
+func runtimeCredentialEnvironmentWorkersSupported(store *sessionapi.FileStore) (bool, error) {
+	// Include live one-shot task workers as well as durable roots: either can
+	// launch another agent turn after a credential snapshot changes.
+	entries, err := os.ReadDir(store.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionDir := filepath.Join(store.Root, entry.Name())
+		live, supported, err := sessionworker.RuntimeCredentialEnvironmentCapabilityStatus(sessionDir)
+		if err != nil {
+			return false, err
+		}
+		if live && !supported {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (h *runtimeCredentialEnvironmentHandler) authorize(w http.ResponseWriter, r *http.Request) bool {
+	_, err := h.authorizer.Caller(r, sessionapi.AccessRequest{
+		Action: sessionapi.ActionManageRuntimeCredentialEnvironment,
+	})
+	if err == nil {
+		return true
+	}
+	if status, detail, ok := sessionapi.AuthHTTPError(err); ok {
+		writeRuntimeCredentialEnvironmentError(w, status, detail)
+		return false
+	}
+	writeRuntimeCredentialEnvironmentError(w, http.StatusForbidden, err.Error())
+	return false
+}
+
+func requireRuntimeCredentialEnvironmentJSONEOF(decoder *json.Decoder) error {
+	var extra json.RawMessage
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values")
+	}
+	return err
+}
+
+func writeRuntimeCredentialEnvironmentJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(value)
+}
+
+func writeRuntimeCredentialEnvironmentError(w http.ResponseWriter, status int, detail string) {
+	writeRuntimeCredentialEnvironmentJSON(w, status, map[string]string{"detail": detail})
+}

--- a/internal/telosd/runtime_credential_environment_test.go
+++ b/internal/telosd/runtime_credential_environment_test.go
@@ -302,6 +302,47 @@ func TestRuntimeCredentialEnvironmentFailsClosedForUnreadableLiveWorker(t *testi
 	}
 }
 
+func TestRuntimeCredentialEnvironmentReturnsUnavailableDuringWorkerHandoff(t *testing.T) {
+	root := t.TempDir()
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	stateStore, err := initializeRuntimeCredentialEnvironment(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, runtimeenv.Path(root))
+	owner := acquireRuntimeCredentialEnvironmentTestWorker(t, sessions.Root, "sess-handoff", sessionapi.KindController)
+	defer owner.Release()
+	manifestPath := filepath.Join(sessions.Root, "sess-handoff", "session.json")
+	if _, err := sessionapi.MutateManifest(manifestPath, func(manifest *sessionapi.Manifest) error {
+		manifest.Runner = nil
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := runtimeCredentialEnvironmentMux(stateStore, sessions, "operator-token")
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("get: got %d want 503: %s", response.Code, response.Body.String())
+	}
+	response = serveRuntimeCredentialEnvironmentRequest(
+		t,
+		mux,
+		http.MethodPut,
+		`{"generation":1,"environment":{"TOKEN":"opaque"}}`,
+	)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("put: got %d want 503: %s", response.Code, response.Body.String())
+	}
+	status, err := stateStore.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("transient readiness mutated state: %#v", status)
+	}
+}
+
 func runtimeCredentialEnvironmentTestMux(t *testing.T, operatorToken string) (*http.ServeMux, string) {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/telosd/runtime_credential_environment_test.go
+++ b/internal/telosd/runtime_credential_environment_test.go
@@ -1,0 +1,406 @@
+package telosd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/telos-org/telos/internal/runtimeenv"
+	"github.com/telos-org/telos/internal/sessionapi"
+	"github.com/telos-org/telos/internal/sessionworker"
+)
+
+func TestRuntimeCredentialEnvironmentRequiresOperator(t *testing.T) {
+	mux, sessionsRoot := runtimeCredentialEnvironmentTestMux(t, "operator-token")
+
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/credential-environment", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("missing auth: got %d want 401", response.Code)
+	}
+
+	for _, test := range []struct {
+		name string
+		kind sessionapi.SessionKind
+	}{
+		{name: "controller", kind: sessionapi.KindController},
+		{name: "task", kind: sessionapi.KindTask},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			token := writeRuntimeCredentialEnvironmentSessionToken(t, sessionsRoot, "sess-"+test.name, test.kind)
+			request := httptest.NewRequest(http.MethodGet, "/api/runtime/credential-environment", nil)
+			request.Header.Set("Authorization", "Bearer "+token)
+			response := httptest.NewRecorder()
+			mux.ServeHTTP(response, request)
+			if response.Code != http.StatusForbidden {
+				t.Fatalf("scoped auth: got %d want 403", response.Code)
+			}
+		})
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/runtime/credential-environment", nil)
+	request.Header.Set("Authorization", "Bearer operator-token")
+	response = httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("operator auth: got %d want 200: %s", response.Code, response.Body.String())
+	}
+	var status runtimeenv.Status
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.Supported || status.Seeded || status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if status.EnvironmentSHA256 != runtimeenv.EnvironmentSHA256(map[string]string{}) {
+		t.Fatalf("unexpected empty digest: %q", status.EnvironmentSHA256)
+	}
+}
+
+func TestInitializeRuntimeCredentialEnvironmentSeedsGenerationZero(t *testing.T) {
+	root := t.TempDir()
+	store, err := initializeRuntimeCredentialEnvironment(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := store.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Supported || !status.Seeded || status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("unexpected initialized status: %#v", status)
+	}
+	if status.EnvironmentSHA256 != runtimeenv.EnvironmentSHA256(map[string]string{}) {
+		t.Fatalf("unexpected initialized digest: %q", status.EnvironmentSHA256)
+	}
+	if _, err := os.Stat(runtimeenv.Path(root)); err != nil {
+		t.Fatalf("initialized state file: %v", err)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentPutAndStatusDoNotExposeValues(t *testing.T) {
+	mux, _ := runtimeCredentialEnvironmentTestMux(t, "operator-token")
+	payload := `{"generation":7,"environment":{"MODAL_TOKEN_ID":"opaque-value"}}`
+
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodPut, payload)
+	if response.Code != http.StatusOK {
+		t.Fatalf("put: got %d want 200: %s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "MODAL") || strings.Contains(response.Body.String(), "opaque") {
+		t.Fatalf("put response exposed environment data: %s", response.Body.String())
+	}
+	var status runtimeenv.Status
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.Seeded || status.Generation != 7 || status.Count != 1 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+
+	response = serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("get: got %d want 200: %s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "MODAL") || strings.Contains(response.Body.String(), "opaque") {
+		t.Fatalf("get response exposed environment data: %s", response.Body.String())
+	}
+}
+
+func TestRuntimeCredentialEnvironmentPutValidationAndConflicts(t *testing.T) {
+	mux, _ := runtimeCredentialEnvironmentTestMux(t, "operator-token")
+	tests := []struct {
+		name       string
+		payload    string
+		wantStatus int
+	}{
+		{name: "unknown field", payload: `{"generation":1,"environment":{},"extra":true}`, wantStatus: http.StatusBadRequest},
+		{name: "reserved name", payload: `{"generation":1,"environment":{"telos_api_token":"opaque"}}`, wantStatus: http.StatusBadRequest},
+		{name: "generation zero values", payload: `{"generation":0,"environment":{"TOKEN":"opaque"}}`, wantStatus: http.StatusBadRequest},
+		{name: "generation zero empty", payload: `{"generation":0,"environment":{}}`, wantStatus: http.StatusOK},
+		{name: "initial", payload: `{"generation":2,"environment":{"TOKEN":"one"}}`, wantStatus: http.StatusOK},
+		{name: "idempotent", payload: `{"generation":2,"environment":{"TOKEN":"one"}}`, wantStatus: http.StatusOK},
+		{name: "same generation differs", payload: `{"generation":2,"environment":{"TOKEN":"two"}}`, wantStatus: http.StatusConflict},
+		{name: "stale", payload: `{"generation":1,"environment":{"TOKEN":"one"}}`, wantStatus: http.StatusConflict},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodPut, test.payload)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status: got %d want %d: %s", response.Code, test.wantStatus, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestRuntimeCredentialEnvironmentCorruptStateReturnsServerError(t *testing.T) {
+	root := t.TempDir()
+	path := runtimeenv.Path(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	mux := http.NewServeMux()
+	registerRuntimeCredentialEnvironmentRoutes(
+		mux,
+		runtimeenv.NewStore(path),
+		sessionapi.NewBearerAuthorizer(sessions, "operator-token"),
+		func() (bool, error) {
+			return runtimeCredentialEnvironmentWorkersSupported(sessions)
+		},
+	)
+
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500: %s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "not-json") || strings.Contains(response.Body.String(), path) {
+		t.Fatalf("error response exposed state contents or path: %s", response.Body.String())
+	}
+}
+
+func TestRuntimeCredentialEnvironmentRejectsLiveLegacyWorkerWithoutMutation(t *testing.T) {
+	root := t.TempDir()
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	stateStore, err := initializeRuntimeCredentialEnvironment(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, "")
+	owner := acquireRuntimeCredentialEnvironmentTestWorker(t, sessions.Root, "sess-legacy", sessionapi.KindController)
+	defer owner.Release()
+
+	mux := runtimeCredentialEnvironmentMux(stateStore, sessions, "operator-token")
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("get: got %d want 200: %s", response.Code, response.Body.String())
+	}
+	var status runtimeenv.Status
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Supported {
+		t.Fatalf("legacy live worker reported supported: %#v", status)
+	}
+
+	response = serveRuntimeCredentialEnvironmentRequest(
+		t,
+		mux,
+		http.MethodPut,
+		`{"generation":1,"environment":{"TOKEN":"opaque"}}`,
+	)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("put: got %d want 503: %s", response.Code, response.Body.String())
+	}
+	status, err = stateStore.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("rejected update mutated state: %#v", status)
+	}
+}
+
+func TestRuntimeCredentialEnvironmentAcceptsLiveCurrentWorker(t *testing.T) {
+	root := t.TempDir()
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	stateStore, err := initializeRuntimeCredentialEnvironment(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, runtimeenv.Path(root))
+	owner := acquireRuntimeCredentialEnvironmentTestWorker(t, sessions.Root, "sess-current", sessionapi.KindController)
+	defer owner.Release()
+
+	mux := runtimeCredentialEnvironmentMux(stateStore, sessions, "operator-token")
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("get: got %d want 200: %s", response.Code, response.Body.String())
+	}
+	var status runtimeenv.Status
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.Supported {
+		t.Fatalf("current live worker reported unsupported: %#v", status)
+	}
+
+	response = serveRuntimeCredentialEnvironmentRequest(
+		t,
+		mux,
+		http.MethodPut,
+		`{"generation":1,"environment":{"TOKEN":"opaque"}}`,
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("put: got %d want 200: %s", response.Code, response.Body.String())
+	}
+}
+
+func TestRuntimeCredentialEnvironmentRejectsLiveLegacyTaskWorker(t *testing.T) {
+	root := t.TempDir()
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	t.Setenv(runtimeenv.PathEnvironmentVariable, "")
+	owner := acquireRuntimeCredentialEnvironmentTestWorker(t, sessions.Root, "sess-task", sessionapi.KindTask)
+	defer owner.Release()
+
+	supported, err := runtimeCredentialEnvironmentWorkersSupported(sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if supported {
+		t.Fatal("live legacy task worker reported supported")
+	}
+}
+
+func TestRuntimeCredentialEnvironmentFailsClosedForUnreadableLiveWorker(t *testing.T) {
+	root := t.TempDir()
+	sessions := sessionapi.NewFileStore(filepath.Join(root, "sessions"), sessionapi.RuntimeCloud)
+	stateStore, err := initializeRuntimeCredentialEnvironment(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtimeenv.PathEnvironmentVariable, runtimeenv.Path(root))
+	owner := acquireRuntimeCredentialEnvironmentTestWorker(t, sessions.Root, "sess-unreadable", sessionapi.KindController)
+	defer owner.Release()
+	manifestPath := filepath.Join(sessions.Root, "sess-unreadable", "session.json")
+	if err := os.WriteFile(manifestPath, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := runtimeCredentialEnvironmentMux(stateStore, sessions, "operator-token")
+	response := serveRuntimeCredentialEnvironmentRequest(t, mux, http.MethodGet, "")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("get: got %d want 500: %s", response.Code, response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "not-json") || strings.Contains(response.Body.String(), manifestPath) {
+		t.Fatalf("readiness error exposed manifest contents or path: %s", response.Body.String())
+	}
+	response = serveRuntimeCredentialEnvironmentRequest(
+		t,
+		mux,
+		http.MethodPut,
+		`{"generation":1,"environment":{"TOKEN":"opaque"}}`,
+	)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("put: got %d want 500: %s", response.Code, response.Body.String())
+	}
+	status, err := stateStore.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Generation != 0 || status.Count != 0 {
+		t.Fatalf("failed readiness check mutated state: %#v", status)
+	}
+}
+
+func runtimeCredentialEnvironmentTestMux(t *testing.T, operatorToken string) (*http.ServeMux, string) {
+	t.Helper()
+	root := t.TempDir()
+	sessionsRoot := filepath.Join(root, "sessions")
+	store := sessionapi.NewFileStore(sessionsRoot, sessionapi.RuntimeCloud)
+	mux := http.NewServeMux()
+	registerRuntimeCredentialEnvironmentRoutes(
+		mux,
+		runtimeenv.NewStore(runtimeenv.Path(root)),
+		sessionapi.NewBearerAuthorizer(store, operatorToken),
+		func() (bool, error) {
+			return runtimeCredentialEnvironmentWorkersSupported(store)
+		},
+	)
+	return mux, sessionsRoot
+}
+
+func runtimeCredentialEnvironmentMux(
+	stateStore *runtimeenv.Store,
+	sessions *sessionapi.FileStore,
+	operatorToken string,
+) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerRuntimeCredentialEnvironmentRoutes(
+		mux,
+		stateStore,
+		sessionapi.NewBearerAuthorizer(sessions, operatorToken),
+		func() (bool, error) {
+			return runtimeCredentialEnvironmentWorkersSupported(sessions)
+		},
+	)
+	return mux
+}
+
+func acquireRuntimeCredentialEnvironmentTestWorker(
+	t *testing.T,
+	sessionsRoot string,
+	sessionID string,
+	kind sessionapi.SessionKind,
+) *sessionworker.Ownership {
+	t.Helper()
+	manifest := sessionapi.ManifestFromInitial(sessionapi.InitialManifest{
+		SessionID:   sessionID,
+		SessionKind: kind,
+	})
+	sessionDir := filepath.Join(sessionsRoot, sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionapi.WriteManifest(filepath.Join(sessionDir, "session.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := sessionworker.AcquireOwnership(sessionDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return owner
+}
+
+func serveRuntimeCredentialEnvironmentRequest(
+	t *testing.T,
+	handler http.Handler,
+	method string,
+	payload string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	var body io.Reader
+	if payload != "" {
+		body = bytes.NewBufferString(payload)
+	}
+	request := httptest.NewRequest(method, "/api/runtime/credential-environment", body)
+	request.Header.Set("Authorization", "Bearer operator-token")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func writeRuntimeCredentialEnvironmentSessionToken(
+	t *testing.T,
+	root string,
+	sessionID string,
+	kind sessionapi.SessionKind,
+) string {
+	t.Helper()
+	access, err := sessionapi.NewScopedToken(sessionID, kind)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := sessionapi.ManifestFromInitial(sessionapi.InitialManifest{
+		SessionID:   sessionID,
+		SessionKind: kind,
+		Access:      access,
+	})
+	dir := filepath.Join(root, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionapi.WriteManifest(filepath.Join(dir, "session.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return access.APIToken
+}

--- a/internal/telosd/server.go
+++ b/internal/telosd/server.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/telos-org/telos/internal/runtimeenv"
 	"github.com/telos-org/telos/internal/sessionapi"
 )
 
@@ -35,7 +36,12 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 
 	baseStore := storeForConfig(cfg)
 	store := sessionapi.Store(baseStore)
+	var runtimeCredentialEnvironmentStore *runtimeenv.Store
 	if cfg.Mode == ModeCloud {
+		runtimeCredentialEnvironmentStore, err = initializeRuntimeCredentialEnvironment(cfg.Root)
+		if err != nil {
+			return fmt.Errorf("initialize runtime credential environment: %w", err)
+		}
 		substrate, err := newSessionSubstrate(cfg)
 		if err != nil {
 			return err
@@ -55,6 +61,16 @@ func Run(ctx context.Context, cfg Config, runtime sessionapi.RuntimeIdentity) er
 	mux := http.NewServeMux()
 	authorizer := authorizerForConfig(cfg, baseStore)
 	sessionapi.RegisterRoutes(mux, store, authorizer, runtime)
+	if cfg.Mode == ModeCloud {
+		registerRuntimeCredentialEnvironmentRoutes(
+			mux,
+			runtimeCredentialEnvironmentStore,
+			authorizer,
+			func() (bool, error) {
+				return runtimeCredentialEnvironmentWorkersSupported(baseStore)
+			},
+		)
+	}
 
 	var lastRequest atomic.Int64
 	lastRequest.Store(time.Now().UnixNano())

--- a/internal/telosd/worker.go
+++ b/internal/telosd/worker.go
@@ -49,8 +49,8 @@ func runSessionWorker(
 		return 1, err
 	}
 	defer wakeParent(sessionDir)
-	defer clearRunner(sessionDir, os.Getpid())
 	defer owner.Release()
+	defer clearRunner(sessionDir, os.Getpid())
 
 	failures := 0
 	for {


### PR DESCRIPTION
## Summary

- Add an operator-authenticated runtime credential-environment API.
- Persist complete opaque placeholder snapshots atomically and apply them immediately before each new agent subprocess starts.
- Retain managed variable names so detach operations remove values inherited at initial claim.
- Advertise a PID-checked worker capability and fail closed when a legacy live worker cannot consume dynamic state.
- Preserve an already-running agent turn while making the next turn observe the new snapshot.
- Repair the group-only state-file permission change introduced during pod recreation before performing strict runtime reads.
- Report incomplete worker startup or shutdown handoffs as retryable 503 responses instead of misclassifying them as legacy workers.

## Safety and rollout

- The API never returns environment names or values and never receives raw OpenBao credential values.
- Missing, corrupt, symlinked, nonregular, or other-accessible configured state blocks process launch.
- Runtime reads remain strict at mode 0600; startup only repairs the known owner/group-only mode drift.
- No Cell, pod, or session-worker restart is performed by this change.
- Deploy this runtime support before enabling the corresponding Cloud control-plane change. Existing legacy workers report unsupported until a current runtime is deployed.

## Verification

- Full Go test suite
- Race tests for runtimeenv, sessionworker, and telosd
- Focused Go vet and Bazel tests
- Linux cross-compilation for changed Telos packages
- git diff --check
- Final adversarial review: GO, with no P0 or P1 blocker
