### PR TITLE
feat: add cloud workspace downloads

### DIFF
--- a/cmd/telos/download.go
+++ b/cmd/telos/download.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/telos-org/telos/internal/cloud"
+)
+
+var workspaceDownloadSessionIDRE = regexp.MustCompile(`^sess_[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+func cmdDownload(args []string) {
+	fs := newCommandFlagSet("download", "telos download SESSION [flags]")
+	contextValue := cloudContextFlag(fs)
+	parseFlags(fs, args)
+	requireArgCount(fs, 1, "one Cloud SESSION")
+
+	sessionID := strings.TrimSpace(fs.Arg(0))
+	if isLocalApplyID(sessionID) {
+		exitWithError(errors.New("workspace download is only available for Cloud sessions"))
+	}
+	destination, err := workspaceArchiveDestination(sessionID)
+	if err != nil {
+		exitWithError(err)
+	}
+	contextOverride, err := cloudContextOverride(fs, *contextValue)
+	if err != nil {
+		exitWithError(err)
+	}
+	control, err := cloud.ControlClientForContext(contextOverride)
+	if err != nil {
+		exitWithError(err)
+	}
+	destination, err = downloadWorkspaceArchive(control, sessionID, destination)
+	if err != nil {
+		exitWithError(err)
+	}
+
+	fmt.Fprintln(os.Stdout, "downloaded workspace")
+	fmt.Fprintln(os.Stdout)
+	printSummaryField(os.Stdout, "Session", sessionID)
+	printSummaryField(os.Stdout, "Context", control.ContextName())
+	printSummaryField(os.Stdout, "Path", destination)
+}
+
+func workspaceArchiveDestination(sessionID string) (string, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if !workspaceDownloadSessionIDRE.MatchString(sessionID) {
+		return "", fmt.Errorf("invalid Cloud session ID %q", sessionID)
+	}
+	return "telos-workspace-" + sessionID + ".tar.gz", nil
+}
+
+func downloadWorkspaceArchive(
+	control *cloud.Client,
+	sessionID string,
+	destination string,
+) (string, error) {
+	if control == nil {
+		return "", errors.New("cloud client is required")
+	}
+	destination = strings.TrimSpace(destination)
+	if destination == "" {
+		return "", errors.New("workspace archive destination is required")
+	}
+	destination = filepath.Clean(destination)
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return "", err
+	}
+	if _, err := os.Lstat(destination); err == nil {
+		return "", fmt.Errorf("%s already exists", destination)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	file, err := os.CreateTemp(
+		filepath.Dir(destination),
+		"."+filepath.Base(destination)+".*.partial",
+	)
+	if err != nil {
+		return "", err
+	}
+	temporaryPath := file.Name()
+	defer os.Remove(temporaryPath)
+	if err := control.DownloadSessionWorkspaceArchive(sessionID, file); err != nil {
+		_ = file.Close()
+		return "", fmt.Errorf("download workspace: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Link(temporaryPath, destination); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return "", fmt.Errorf("%s already exists", destination)
+		}
+		return "", err
+	}
+	return destination, nil
+}

--- a/cmd/telos/download_test.go
+++ b/cmd/telos/download_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/telos-org/telos/internal/cloud"
+)
+
+func TestWorkspaceArchiveDestinationUsesSessionID(t *testing.T) {
+	got, err := workspaceArchiveDestination(" sess_123 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "telos-workspace-sess_123.tar.gz"; got != want {
+		t.Fatalf("destination = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceArchiveDestinationRejectsUnsafeSessionID(t *testing.T) {
+	if _, err := workspaceArchiveDestination("sess_../../secret"); err == nil {
+		t.Fatal("expected unsafe session ID to be rejected")
+	}
+}
+
+func TestDownloadWorkspaceArchiveWritesPrivateFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = io.WriteString(w, "workspace archive")
+	}))
+	defer srv.Close()
+
+	destination := filepath.Join(t.TempDir(), "nested", "workspace.tar.gz")
+	got, err := downloadWorkspaceArchive(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		destination,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != destination {
+		t.Fatalf("destination = %q, want %q", got, destination)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "workspace archive" {
+		t.Fatalf("archive = %q", data)
+	}
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("archive mode = %o, want 600", got)
+	}
+}
+
+func TestDownloadWorkspaceArchiveDoesNotOverwrite(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = io.WriteString(w, "replacement")
+	}))
+	defer srv.Close()
+
+	destination := filepath.Join(t.TempDir(), "workspace.tar.gz")
+	if err := os.WriteFile(destination, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := downloadWorkspaceArchive(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		destination,
+	)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v", err)
+	}
+	data, readErr := os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != "keep" {
+		t.Fatalf("existing archive = %q", data)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestDownloadWorkspaceArchiveRemovesFailedDownload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"detail":"workspace archive is not ready"}`)
+	}))
+	defer srv.Close()
+
+	destination := filepath.Join(t.TempDir(), "workspace.tar.gz")
+	_, err := downloadWorkspaceArchive(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		destination,
+	)
+	if err == nil || !strings.Contains(err.Error(), "workspace archive is not ready") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, statErr := os.Stat(destination); !os.IsNotExist(statErr) {
+		t.Fatalf("failed download remains at destination: %v", statErr)
+	}
+	assertNoWorkspaceDownloadTemps(t, destination)
+}
+
+func TestDownloadWorkspaceArchivePublishesOnlyCompleteFileWithoutOverwrite(t *testing.T) {
+	downloadStarted := make(chan struct{})
+	finishDownload := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "partial ")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(downloadStarted)
+		<-finishDownload
+		_, _ = io.WriteString(w, "archive")
+	}))
+	defer srv.Close()
+
+	destination := filepath.Join(t.TempDir(), "workspace.tar.gz")
+	result := make(chan error, 1)
+	go func() {
+		_, err := downloadWorkspaceArchive(
+			cloud.NewClient(srv.URL, "test-token"),
+			"sess_123",
+			destination,
+		)
+		result <- err
+	}()
+
+	<-downloadStarted
+	if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("destination became visible before completion: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	close(finishDownload)
+	if err := <-result; err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v", err)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "keep" {
+		t.Fatalf("existing archive = %q", data)
+	}
+	assertNoWorkspaceDownloadTemps(t, destination)
+}
+
+func assertNoWorkspaceDownloadTemps(t *testing.T, destination string) {
+	t.Helper()
+	matches, err := filepath.Glob(
+		filepath.Join(filepath.Dir(destination), "."+filepath.Base(destination)+".*.partial"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary downloads remain: %v", matches)
+	}
+}

--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -40,6 +40,8 @@ func main() {
 		cmdList(os.Args[2:])
 	case "get":
 		cmdGet(os.Args[2:])
+	case "download":
+		cmdDownload(os.Args[2:])
 	case "describe":
 		cmdDescribe(os.Args[2:])
 	case "logs":
@@ -82,6 +84,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  push SPEC.md       Publish a versioned spec or skill for reuse")
 	fmt.Fprintln(out, "  pull PACKAGE       Download a package; use `pull skill REF` for a skill")
 	fmt.Fprintln(out, "  get SESSION        Download a session's package")
+	fmt.Fprintln(out, "  download SESSION   Download a saved Pro Cloud workspace")
 	fmt.Fprintln(out, "  logout             Log out and revoke this device's token")
 	fmt.Fprintln(out, "  config             Show or update CLI configuration")
 	fmt.Fprintln(out, "  version            Show version")

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -84,6 +84,7 @@ func TestTopLevelUsageMentionsHelpAndVersion(t *testing.T) {
 		"--help",
 		"apply SPEC.md      Create or update a durable session from a spec",
 		"get SESSION        Download a session's package",
+		"download SESSION   Download a saved Pro Cloud workspace",
 		"delete SESSION     Delete a session",
 		"pull PACKAGE       Download a package; use `pull skill REF` for a skill",
 		"version            Show version",

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -615,6 +615,64 @@ func (c *Client) GetSession(sessionID string) (*SessionRecord, error) {
 	return &response, nil
 }
 
+// DownloadSessionWorkspaceArchive streams the latest completely saved
+// workspace checkpoint to dst without holding the archive in memory.
+func (c *Client) DownloadSessionWorkspaceArchive(sessionID string, dst io.Writer) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return fmt.Errorf("session ID is required")
+	}
+	if dst == nil {
+		return fmt.Errorf("workspace archive destination is required")
+	}
+	streamHTTP, closeIdleConnections := c.httpClientForStreaming()
+	defer closeIdleConnections()
+	streamClient := *c
+	streamClient.HTTP = streamHTTP
+	resp, err := streamClient.do(
+		"GET",
+		"/api/deployments/"+url.PathEscape(sessionID)+"/workspace/archive",
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return readError(resp)
+	}
+	if _, err := io.Copy(dst, resp.Body); err != nil {
+		return fmt.Errorf("read workspace archive: %w", err)
+	}
+	return nil
+}
+
+// httpClientForStreaming keeps connection and response-header timeouts while
+// removing the total request timeout, which otherwise also limits body reads.
+func (c *Client) httpClientForStreaming() (*http.Client, func()) {
+	base := c.HTTP
+	if base == nil {
+		base = http.DefaultClient
+	}
+	client := *base
+	client.Timeout = 0
+
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	baseTransport, ok := transport.(*http.Transport)
+	if !ok {
+		return &client, func() {}
+	}
+	streamTransport := baseTransport.Clone()
+	if streamTransport.ResponseHeaderTimeout == 0 {
+		streamTransport.ResponseHeaderTimeout = DefaultTimeout
+	}
+	client.Transport = streamTransport
+	return &client, streamTransport.CloseIdleConnections
+}
+
 func (c *Client) DeleteSession(sessionID string) (*SessionRecord, error) {
 	resp, err := c.do("DELETE", "/api/deployments/"+url.PathEscape(sessionID), nil)
 	if err != nil {

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/telos-org/telos/internal/config"
 	"github.com/telos-org/telos/internal/sessionapi"
@@ -30,6 +31,85 @@ func TestNormalizeEndpoint(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("NormalizeEndpoint(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
+	}
+}
+
+func TestClientDownloadsSessionWorkspaceArchive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/deployments/sess_123/workspace/archive" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("X-Telos-Org-Id"); got != "org_test" {
+			t.Fatalf("X-Telos-Org-Id = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = io.WriteString(w, "checkpoint ")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = io.WriteString(w, "bytes")
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	client.OrgID = "org_test"
+	var archive strings.Builder
+	if err := client.DownloadSessionWorkspaceArchive("sess_123", &archive); err != nil {
+		t.Fatal(err)
+	}
+	if got := archive.String(); got != "checkpoint bytes" {
+		t.Fatalf("archive = %q", got)
+	}
+}
+
+func TestClientWorkspaceArchiveAllowsSlowStreamingBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "first ")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(30 * time.Millisecond)
+		_, _ = io.WriteString(w, "second")
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	client.HTTP.Timeout = time.Millisecond
+	var archive strings.Builder
+	if err := client.DownloadSessionWorkspaceArchive("sess_123", &archive); err != nil {
+		t.Fatal(err)
+	}
+	if got := archive.String(); got != "first second" {
+		t.Fatalf("archive = %q", got)
+	}
+	if got := client.HTTP.Timeout; got != time.Millisecond {
+		t.Fatalf("shared HTTP timeout changed to %s", got)
+	}
+}
+
+func TestClientWorkspaceArchivePreservesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = io.WriteString(w, `{"detail":"downloading workspaces requires the pro plan"}`)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-token")
+	err := client.DownloadSessionWorkspaceArchive("sess_123", io.Discard)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T", err)
+	}
+	if apiErr.StatusCode != http.StatusPaymentRequired ||
+		apiErr.Detail != "downloading workspaces requires the pro plan" {
+		t.Fatalf("APIError = %+v", apiErr)
 	}
 }
 

--- a/internal/sessionapi/dashboard_doc_open_other.go
+++ b/internal/sessionapi/dashboard_doc_open_other.go
@@ -17,3 +17,26 @@ func openDashboardDocFile(path string) (*os.File, error) {
 	}
 	return os.Open(path)
 }
+
+func openRootRegularFile(root *os.Root, path string) (*os.File, error) {
+	before, err := root.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, os.ErrInvalid
+	}
+	file, err := root.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	opened, openedErr := file.Stat()
+	after, afterErr := root.Lstat(path)
+	if openedErr != nil || afterErr != nil || !opened.Mode().IsRegular() ||
+		!after.Mode().IsRegular() ||
+		(!os.SameFile(opened, before) && !os.SameFile(opened, after)) {
+		file.Close()
+		return nil, os.ErrInvalid
+	}
+	return file, nil
+}

--- a/internal/sessionapi/dashboard_doc_open_unix.go
+++ b/internal/sessionapi/dashboard_doc_open_unix.go
@@ -3,6 +3,7 @@
 package sessionapi
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -15,4 +16,34 @@ func openDashboardDocFile(path string) (*os.File, error) {
 		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW,
 		0,
 	)
+}
+
+func openRootRegularFile(root *os.Root, path string) (*os.File, error) {
+	before, err := root.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, os.ErrInvalid
+	}
+	file, err := root.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW,
+		0,
+	)
+	if errors.Is(err, syscall.ELOOP) {
+		return nil, os.ErrInvalid
+	}
+	if err != nil {
+		return nil, err
+	}
+	opened, openedErr := file.Stat()
+	after, afterErr := root.Lstat(path)
+	if openedErr != nil || afterErr != nil || !opened.Mode().IsRegular() ||
+		!after.Mode().IsRegular() ||
+		(!os.SameFile(opened, before) && !os.SameFile(opened, after)) {
+		file.Close()
+		return nil, os.ErrInvalid
+	}
+	return file, nil
 }

--- a/internal/sessionapi/server.go
+++ b/internal/sessionapi/server.go
@@ -22,6 +22,7 @@ const maxSessionRequestBytes = 4 << 20
 //	GET  /api/sessions/{id}/spec
 //	PUT  /api/sessions/{name}/spec
 //	POST /api/sessions/{id}/stop
+//	GET  /api/sessions/{id}/workspace/archive
 //	GET  /api/sessions/{id}/transcript
 //	GET  /api/sessions/{id}/events
 //	GET  /api/healthz
@@ -38,6 +39,7 @@ func RegisterRoutes(mux *http.ServeMux, store Store, authorizer Authorizer, runt
 	mux.HandleFunc("GET /api/sessions/{id}/spec", h.getSpec)
 	mux.HandleFunc("PUT /api/sessions/{name}/spec", h.updateSpec)
 	mux.HandleFunc("POST /api/sessions/{id}/stop", h.stopSession)
+	mux.HandleFunc("GET /api/sessions/{id}/workspace/archive", h.getWorkspaceArchive)
 	mux.HandleFunc("GET /api/sessions/{id}/transcript", h.getTranscript)
 	mux.HandleFunc("GET /api/sessions/{id}/events", h.getEvents)
 }
@@ -232,6 +234,39 @@ func (h *handler) stopSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, session)
+}
+
+func (h *handler) getWorkspaceArchive(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if _, ok := h.authorize(w, r, AccessRequest{Action: ActionReadSession, SessionID: id}); !ok {
+		return
+	}
+	archive, err := h.store.OpenWorkspaceArchive(id)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, ErrInvalidSession):
+			writeError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, ErrConflict):
+			writeError(w, http.StatusConflict, "workspace archive is not ready")
+		default:
+			writeError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	defer archive.Close()
+
+	info, err := archive.Stat()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Disposition", `attachment; filename="telos-workspace.tar.gz"`)
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	http.ServeContent(w, r, "telos-workspace.tar.gz", info.ModTime(), archive)
 }
 
 func (h *handler) getTranscript(w http.ResponseWriter, r *http.Request) {

--- a/internal/sessionapi/server_test.go
+++ b/internal/sessionapi/server_test.go
@@ -1566,6 +1566,98 @@ func TestStopSessionNotFound(t *testing.T) {
 	assertEqual(t, "status_code", "404", itoa(resp.StatusCode))
 }
 
+// --------- GET /api/sessions/{id}/workspace/archive ----------------------------------------------------------------------------------------------------------
+
+func TestWorkspaceArchiveNotReady(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "workspace"))
+	resp, err := http.Get(srv.URL + "/api/sessions/" + created.SessionID + "/workspace/archive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 409 before the first checkpoint, got %d: %s", resp.StatusCode, body)
+	}
+	archivePath := filepath.Join(store.Root, created.SessionID, "specs", "workspace", "workspace.tar.gz")
+	for _, path := range []string{archivePath, archivePath + ".partial"} {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("download request created %s: %v", path, err)
+		}
+	}
+}
+
+func TestWorkspaceArchivePresent(t *testing.T) {
+	srv, store := newTestServer(t)
+	defer srv.Close()
+
+	created := createSession(t, srv.URL, createSessionBody(t, "workspace"))
+	want := []byte("complete checkpoint bytes")
+	archivePath := filepath.Join(store.Root, created.SessionID, "specs", "workspace", "workspace.tar.gz")
+	if err := os.WriteFile(archivePath, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/sessions/" + created.SessionID + "/workspace/archive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/gzip" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if got := resp.Header.Get("Content-Disposition"); got != `attachment; filename="telos-workspace.tar.gz"` {
+		t.Fatalf("Content-Disposition = %q", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("archive body = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceArchiveSessionNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/sessions/missing/workspace/archive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestWorkspaceArchiveRequiresAuthentication(t *testing.T) {
+	srv, _ := newBearerTestServer(t, "operator-token")
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/sessions/sess_private/workspace/archive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, body)
+	}
+}
+
 // --------- GET /api/sessions/{id}/transcript ------------------------------------------------------------------------------------------------------------------
 
 func TestTranscriptNotFound(t *testing.T) {

--- a/internal/sessionapi/store.go
+++ b/internal/sessionapi/store.go
@@ -66,6 +66,7 @@ type Store interface {
 	List() ([]Session, error)
 	Get(id string) (*Session, error)
 	Stop(id string) (*Session, error)
+	OpenWorkspaceArchive(id string) (*os.File, error)
 	Transcript(id string) (string, error)
 	Events(id string) ([]SessionEvent, error)
 }
@@ -897,6 +898,69 @@ func (fs *FileStore) Stop(id string) (*Session, error) {
 	}
 
 	return fs.deriveSession(id, m)
+}
+
+// OpenWorkspaceArchive opens the latest completely saved root-workspace
+// checkpoint. Checkpoints are atomically renamed into place by the runner, so
+// an open file descriptor always refers to one complete archive even if the
+// next checkpoint replaces it concurrently.
+func (fs *FileStore) OpenWorkspaceArchive(id string) (*os.File, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if id == "" || id == "." || id == ".." || filepath.Base(id) != id {
+		return nil, fmt.Errorf("invalid session id %q: %w", id, ErrInvalidSession)
+	}
+
+	root, err := os.OpenRoot(fs.Root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("session %s: %w", id, ErrNotFound)
+		}
+		return nil, err
+	}
+	defer root.Close()
+
+	manifestFile, err := openRootRegularFile(root, filepath.Join(id, "session.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("session %s: %w", id, ErrNotFound)
+		}
+		if errors.Is(err, os.ErrInvalid) {
+			return nil, fmt.Errorf("session %s has an invalid manifest: %w", id, ErrInvalidSession)
+		}
+		return nil, err
+	}
+	var manifest Manifest
+	decodeErr := json.NewDecoder(manifestFile).Decode(&manifest)
+	closeErr := manifestFile.Close()
+	if decodeErr != nil {
+		return nil, fmt.Errorf("parse manifest for session %s: %w", id, decodeErr)
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	if manifest.SessionID != id || !isTopLevelManifest(&manifest) {
+		return nil, fmt.Errorf("session %s is not a root session: %w", id, ErrInvalidSession)
+	}
+	if !specDirNameRE.MatchString(manifest.SpecName) {
+		return nil, fmt.Errorf("session %s has an invalid spec name: %w", id, ErrInvalidSession)
+	}
+
+	archive, err := openRootRegularFile(
+		root,
+		filepath.Join(id, "specs", manifest.SpecName, "workspace.tar.gz"),
+	)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("session %s workspace archive is not ready: %w", id, ErrConflict)
+		}
+		if errors.Is(err, os.ErrInvalid) {
+			return nil, fmt.Errorf("session %s workspace archive is not a regular file: %w", id, ErrConflict)
+		}
+		return nil, err
+	}
+	return archive, nil
 }
 
 // Transcript returns the session transcript markdown for the first spec.

--- a/internal/sessionapi/store_dashboard_doc_unix_test.go
+++ b/internal/sessionapi/store_dashboard_doc_unix_test.go
@@ -3,6 +3,7 @@
 package sessionapi
 
 import (
+	"errors"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -29,5 +30,44 @@ func TestReadDashboardDocRejectsNamedPipe(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("reading a dashboard_doc named pipe blocked")
+	}
+}
+
+func TestOpenWorkspaceArchiveRejectsSymlink(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	archivePath := filepath.Join(store.Root, session.SessionID, "specs", "service", "workspace.tar.gz")
+	if err := syscall.Symlink("../../session.json", archivePath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.OpenWorkspaceArchive(session.SessionID)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("symlink archive error = %v, want ErrConflict", err)
+	}
+}
+
+func TestOpenWorkspaceArchiveRejectsNamedPipeWithoutBlocking(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	archivePath := filepath.Join(store.Root, session.SessionID, "specs", "service", "workspace.tar.gz")
+	if err := syscall.Mkfifo(archivePath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		archive, err := store.OpenWorkspaceArchive(session.SessionID)
+		if archive != nil {
+			archive.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrConflict) {
+			t.Fatalf("named pipe error = %v, want ErrConflict", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("opening a named-pipe workspace archive blocked")
 	}
 }

--- a/internal/sessionapi/store_test.go
+++ b/internal/sessionapi/store_test.go
@@ -1,6 +1,7 @@
 package sessionapi
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -100,6 +101,43 @@ func TestListRootWorkerSessionsReadsOnlyEligibleManifests(t *testing.T) {
 	}
 	if rootSession.SessionDir == nil || *rootSession.SessionDir != filepath.Join(root, "sess_root") {
 		t.Fatalf("session dir: %#v", rootSession.SessionDir)
+	}
+}
+
+func TestOpenWorkspaceArchiveKeepsCompleteCheckpointDuringReplacement(t *testing.T) {
+	store, session := createCloudStoreSession(t)
+	archivePath := filepath.Join(store.Root, session.SessionID, "specs", "service", "workspace.tar.gz")
+	if err := os.WriteFile(archivePath, []byte("first checkpoint"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := store.OpenWorkspaceArchive(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archive.Close()
+
+	nextPath := archivePath + ".partial"
+	if err := os.WriteFile(nextPath, []byte("second checkpoint"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(nextPath, archivePath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := io.ReadAll(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first checkpoint" {
+		t.Fatalf("opened checkpoint changed during replacement: %q", got)
+	}
+	latest, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(latest) != "second checkpoint" {
+		t.Fatalf("replacement checkpoint = %q", latest)
 	}
 }
 

--- a/internal/telosd/session_bootstrap_test.go
+++ b/internal/telosd/session_bootstrap_test.go
@@ -2,6 +2,7 @@ package telosd
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -57,6 +58,9 @@ func (s *fakeReconcileStore) UpdateSpec(string, sessionapi.SessionSpecUpdateRequ
 	return nil, sessionapi.ErrNotFound
 }
 func (s *fakeReconcileStore) Get(string) (*sessionapi.Session, error) {
+	return nil, sessionapi.ErrNotFound
+}
+func (s *fakeReconcileStore) OpenWorkspaceArchive(string) (*os.File, error) {
 	return nil, sessionapi.ErrNotFound
 }
 func (s *fakeReconcileStore) Transcript(string) (string, error) {

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telos-cli
-description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud login and context, session inspection, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
+description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud login and context, session inspection and workspace downloads, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
 metadata:
   registry: "@telos/telos-cli"
   public_guide: "references/use-telos.md"
@@ -82,6 +82,18 @@ runtime.
    telos logs SESSION_ID --context CONTEXT
    ```
 
+Managers of a Pro Cloud workspace can download its latest completely saved
+agent workspace from deployments provisioned with runtime `v0.1.6` or newer,
+without loading the archive into CLI memory:
+
+```bash
+telos download SESSION_ID
+```
+
+This uses the active Cloud context and writes
+`telos-workspace-SESSION_ID.tar.gz` in the current directory. Use `--context`
+only when you need to select a different Cloud workspace.
+
 5. Verify the live behavior promised by the spec. Submission, a running
    process, and old green evidence are not completion of the current revision.
 
@@ -135,7 +147,7 @@ Inside a Telos session, the same command creates a linked child session; see
 | Effect | Commands |
 | --- | --- |
 | Inspect state | `plan`, `list`, `describe`, `logs` |
-| Materialize files or change local configuration | `get`, `pull`, `login`, `logout`, `config --context`, `config --model` |
+| Materialize files or change local configuration | `get`, `pull`, `download`, `login`, `logout`, `config --context`, `config --model` |
 | Start bounded local execution; may spend money | `run` |
 | Publish or change remote state; `apply` may spend money | `apply`, `push`, `delete` |
 

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -38,8 +38,33 @@ context consistent across commands.
 `telos config --context personal` returns to the personal context. A
 command-level `--context` overrides `TELOS_CONTEXT` and stored configuration
 for that invocation without changing either. Carry the chosen context through
-`plan`, `apply`, `describe`, `logs`, and `delete` so each action has one visible
-target.
+`plan`, `apply`, `describe`, `logs`, `download`, and `delete` so each action has
+one visible target.
+
+## Download a saved workspace
+
+If you are a manager of a Pro workspace, you can download the agent's latest
+completely saved root workspace as a compressed archive:
+
+```bash
+telos download SESSION_ID
+```
+
+This uses your active Cloud context and writes
+`telos-workspace-SESSION_ID.tar.gz` in the current directory. Use `--context`
+only when you need to select a different Cloud workspace.
+
+The deployment must have been provisioned with runtime `v0.1.6` or newer.
+Older deployments keep their immutable runtime and cannot use workspace
+download; create a new deployment on `v0.1.6` or newer instead. The download
+contains the full saved workspace, including files created or changed by
+agents. It does not take a live snapshot while an agent is writing. Before the
+first completed checkpoint, Telos reports that the archive is not ready. During
+active work, the archive may be one completed cycle behind.
+
+Telos creates the archive file with private permissions and does not overwrite
+an existing file. The command requires a Pro workspace; teammates without
+manager access cannot download it.
 
 ## Preflight the managed runtime
 

--- a/skills/telos-cli/references/packages-and-skills.md
+++ b/skills/telos-cli/references/packages-and-skills.md
@@ -68,4 +68,6 @@ Use `telos get SESSION_ID --context CONTEXT` when the starting point is a
 session rather than a known registry ref. Telos verifies registry digests
 before materializing packages and skills. `apply` deploys an exact registry
 package without materializing or republishing it. [The Goal lifecycle](lifecycle.md)
-explains how that package digest identifies a revision.
+explains how that package digest identifies a revision. `telos get` retrieves
+the immutable input package; use `telos download SESSION_ID` when you need the
+files from the agent's saved Cloud workspace instead.


### PR DESCRIPTION
## Summary

- Add a runtime endpoint that serves the latest completed root-workspace checkpoint.
- Add the simple CLI command: telos download SESSION_ID.
- Stream the archive to an automatically named telos-workspace-SESSION_ID.tar.gz file without buffering it all in memory.
- Refuse to overwrite an existing file and publish the download only after it completes successfully.
- Reject symlinks and non-regular archive files, including FIFOs.
- Update the CLI reference documentation.

## What users receive

The archive contains the files in the saved root workspace, including hidden files and repository metadata such as .git. It does not include Telos control-plane state stored outside that workspace. Because agents can write secrets into project files, the archive must still be treated as sensitive.

This is the latest completed checkpoint, not a live snapshot. It is unavailable before the first checkpoint and can be one cycle behind while work is actively running.

## Rollout

Publish and verify the exact v0.1.6 runtime before the dependent Cloud PR is merged or deployed. Cloud pins new deployments to that version. Existing durable deployments keep their older immutable runtime, so users need a new v0.1.6-or-newer deployment to use workspace download.

The bundled CLI documentation becomes available through the normal Telos release and promotion process.

## Verification

- go test ./...
- go test -race ./cmd/telos ./internal/cloud ./internal/sessionapi ./internal/telosd ./internal/platform
- bazel build //skills:telos_cli_bundle
- Independent adversarial review found no remaining material issues
- Occam review passed: reuse the existing checkpoint and streaming APIs without adding export jobs, storage, or signed URLs