### PR TITLE
fix(cli): bound cloud log requests

### DIFF
--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -16,6 +16,8 @@ import (
 
 // -- logs ---------------------------------------------------------------------
 
+const maxCloudLogTail = 1000
+
 func cmdLogs(args []string) {
 	fs := newCommandFlagSet("logs", "telos logs SESSION [flags]")
 	jsonOutput := fs.Bool("json", false, "Print newline-delimited JSON events")
@@ -126,7 +128,11 @@ func printCloudSessionLogs(
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	page, err := control.GetSessionLogPage(session.ID)
+	tail := options.Tail
+	if raw || options.All || tail > maxCloudLogTail {
+		tail = 0
+	}
+	page, err := control.GetSessionLogPage(session.ID, tail)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -632,15 +633,19 @@ func (c *Client) DeleteSession(sessionID string) (*SessionRecord, error) {
 }
 
 func (c *Client) GetSessionLogs(sessionID string) ([]sessionapi.SessionEvent, error) {
-	page, err := c.GetSessionLogPage(sessionID)
+	page, err := c.GetSessionLogPage(sessionID, 0)
 	if err != nil {
 		return nil, err
 	}
 	return page.Events, nil
 }
 
-func (c *Client) GetSessionLogPage(sessionID string) (*SessionLogPage, error) {
-	resp, err := c.do("GET", "/api/deployments/"+url.PathEscape(sessionID)+"/logs", nil)
+func (c *Client) GetSessionLogPage(sessionID string, tail int) (*SessionLogPage, error) {
+	path := "/api/deployments/" + url.PathEscape(sessionID) + "/logs"
+	if tail > 0 {
+		path += "?tail=" + strconv.Itoa(tail)
+	}
+	resp, err := c.do("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -713,7 +713,7 @@ func TestClientSessionLogPagePreservesRawEvents(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123")
+	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123", 0)
 	if err != nil {
 		t.Fatalf("GetSessionLogPage: %v", err)
 	}
@@ -734,6 +734,21 @@ func TestClientSessionLogPagePreservesRawEvents(t *testing.T) {
 		if !strings.Contains(raw, field) {
 			t.Fatalf("raw event dropped %s: %s", field, raw)
 		}
+	}
+}
+
+func TestClientSessionLogPageRequestsTail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/deployments/sess_123/logs" || r.URL.Query().Get("tail") != "50" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"events":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123", 50); err != nil {
+		t.Fatalf("GetSessionLogPage: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- pass the requested activity tail to the Cloud deployment logs endpoint
- preserve full-history fetches for `--all`, `--raw`, and tails above the server window
- cover the bounded request at the HTTP client boundary

This keeps one rendering path while avoiding full-history downloads for the default and ordinary `--tail` views.

## Verification

- `go test ./...`
- `bazel test //...`
- read-only Cloud smoke test against a long-running deployment

## Release

A Telos CLI release must be published and promoted before users receive this fix. No Cloud infrastructure change is required.