### PR TITLE
feat(cli): add telos update for latest and exact releases

### DIFF
--- a/cmd/telos/main.go
+++ b/cmd/telos/main.go
@@ -28,6 +28,8 @@ func main() {
 	case "version":
 		fmt.Println("telos " + Version)
 		return
+	case "update":
+		cmdUpdate(os.Args[2:])
 	case "plan":
 		cmdPlan(os.Args[2:])
 	case "push":
@@ -85,6 +87,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  logout             Log out and revoke this device's token")
 	fmt.Fprintln(out, "  config             Show or update CLI configuration")
 	fmt.Fprintln(out, "  version            Show version")
+	fmt.Fprintln(out, "  update [VERSION]   Update this CLI to latest or an exact release")
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "global flags:")
 	fmt.Fprintln(out, "  -h, --help         Show help")

--- a/cmd/telos/main_test.go
+++ b/cmd/telos/main_test.go
@@ -87,6 +87,7 @@ func TestTopLevelUsageMentionsHelpAndVersion(t *testing.T) {
 		"delete SESSION     Delete a session",
 		"pull PACKAGE       Download a package; use `pull skill REF` for a skill",
 		"version            Show version",
+		"update [VERSION]   Update this CLI to latest or an exact release",
 		"--version",
 		"telos <command> --help",
 	} {

--- a/cmd/telos/update.go
+++ b/cmd/telos/update.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/telos-org/telos/internal/spec"
+)
+
+const releaseBaseURL = "https://usetelos.ai/releases"
+
+type cliReleaseManifest struct {
+	Version   string `json:"version"`
+	Platforms []struct {
+		OS    string `json:"os"`
+		Arch  string `json:"arch"`
+		Telos string `json:"telos"`
+	} `json:"platforms"`
+}
+
+func cmdUpdate(args []string) {
+	fs := newCommandFlagSet("update", "telos update [latest|VERSION]")
+	parseFlags(fs, args)
+	if fs.NArg() > 1 {
+		requireArgCount(fs, 1, "at most one release version")
+	}
+	requested := fs.Arg(0)
+	executable, err := os.Executable()
+	if err == nil && Version == "dev" {
+		err = fmt.Errorf("development builds must be rebuilt from source; install a released CLI to use telos update")
+	}
+	client := &http.Client{
+		Timeout: 2 * time.Minute,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("refusing release redirect to non-HTTPS URL")
+			}
+			if len(via) >= 10 {
+				return fmt.Errorf("too many release redirects")
+			}
+			return nil
+		},
+	}
+	var version string
+	if err == nil {
+		version, err = updateCLI(executable, Version, requested, releaseBaseURL, client)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if version == Version {
+		fmt.Printf("telos is already up to date (%s)\n", version)
+		return
+	}
+	fmt.Printf("updated telos %s -> %s\n", Version, version)
+}
+
+func updateCLI(executable, current, requested, baseURL string, client *http.Client) (string, error) {
+	version := requested
+	if version == "" {
+		version = "latest"
+	}
+	if version != "latest" {
+		if !validCLIReleaseVersion(version) {
+			return "", fmt.Errorf("invalid release version %q; use latest or a version such as v0.1.5", version)
+		}
+		version = "v" + strings.TrimPrefix(version, "v")
+	}
+	target, err := cliUpdateTarget(executable)
+	if err != nil {
+		return "", err
+	}
+	var metadata bytes.Buffer
+	if err := downloadCLIUpdate(client, baseURL+"/"+version+"/manifest.json", &metadata, 1<<20); err != nil {
+		return "", err
+	}
+	var manifest cliReleaseManifest
+	if err := json.Unmarshal(metadata.Bytes(), &manifest); err != nil {
+		return "", fmt.Errorf("invalid release manifest: %w", err)
+	}
+	if !strings.HasPrefix(manifest.Version, "v") || !validCLIReleaseVersion(manifest.Version) {
+		return "", fmt.Errorf("invalid version in release manifest: %q", manifest.Version)
+	}
+	if version != "latest" && manifest.Version != version {
+		return "", fmt.Errorf("release manifest version %q does not match requested %q", manifest.Version, version)
+	}
+	artifact, err := cliReleaseArtifact(manifest, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", err
+	}
+	if manifest.Version == current {
+		return current, nil
+	}
+	// Pin every subsequent request to the immutable version, even if latest moves.
+	immutableURL := baseURL + "/" + manifest.Version
+	metadata.Reset()
+	if err := downloadCLIUpdate(client, immutableURL+"/SHA256SUMS", &metadata, 1<<20); err != nil {
+		return "", err
+	}
+	expected, err := cliReleaseChecksum(metadata.String(), artifact)
+	if err != nil {
+		return "", err
+	}
+	stage, err := os.CreateTemp(filepath.Dir(target), ".telos-update-*")
+	if err != nil {
+		return "", fmt.Errorf("cannot stage CLI update beside %s (check directory permissions): %w", target, err)
+	}
+	defer os.Remove(stage.Name())
+	defer stage.Close()
+	hash := sha256.New()
+	if err := downloadCLIUpdate(client, immutableURL+"/"+artifact, io.MultiWriter(stage, hash), 256<<20); err != nil {
+		return "", err
+	}
+	if !bytes.Equal(hash.Sum(nil), expected) {
+		return "", fmt.Errorf("checksum verification failed for %s; existing CLI is unchanged", artifact)
+	}
+	if err := stage.Chmod(0o755); err != nil {
+		return "", err
+	}
+	if err := stage.Sync(); err != nil {
+		return "", err
+	}
+	if err := stage.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(stage.Name(), target); err != nil {
+		return "", fmt.Errorf("replace CLI %s: %w", target, err)
+	}
+	return manifest.Version, nil
+}
+
+func validCLIReleaseVersion(version string) bool {
+	bare := strings.TrimPrefix(version, "v")
+	return bare == strings.TrimSpace(bare) && spec.IsSemver(bare)
+}
+
+func cliUpdateTarget(executable string) (string, error) {
+	target, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", fmt.Errorf("resolve CLI executable: %w", err)
+	}
+	for _, managed := range []struct{ path, command string }{
+		{"/Cellar/", "brew upgrade telos"},
+		{"/nix/store/", "your Nix configuration"},
+		{"/snap/", "snap refresh telos"},
+		{"/opt/local/", "port upgrade telos"},
+	} {
+		if strings.Contains(filepath.ToSlash(target), managed.path) {
+			return "", fmt.Errorf("CLI is package-manager-owned; update it with %s", managed.command)
+		}
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("CLI executable is not a regular file: %s", target)
+	}
+	return target, nil
+}
+
+func cliReleaseArtifact(manifest cliReleaseManifest, goos, goarch string) (string, error) {
+	if (goos != "darwin" && goos != "linux") || (goarch != "amd64" && goarch != "arm64") {
+		return "", fmt.Errorf("CLI updates are unsupported on %s/%s", goos, goarch)
+	}
+	for _, platform := range manifest.Platforms {
+		if platform.OS == goos && platform.Arch == goarch {
+			if platform.Telos != "telos-"+goos+"-"+goarch {
+				return "", fmt.Errorf("invalid CLI artifact in release manifest: %q", platform.Telos)
+			}
+			return platform.Telos, nil
+		}
+	}
+	return "", fmt.Errorf("release %s has no CLI for %s/%s", manifest.Version, goos, goarch)
+}
+
+func cliReleaseChecksum(sums, artifact string) ([]byte, error) {
+	var checksum []byte
+	for _, line := range strings.Split(sums, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[1] != artifact {
+			continue
+		}
+		decoded, err := hex.DecodeString(fields[0])
+		if err != nil || len(decoded) != sha256.Size || checksum != nil {
+			return nil, fmt.Errorf("invalid or duplicate checksum for %s", artifact)
+		}
+		checksum = decoded
+	}
+	if checksum == nil {
+		return nil, fmt.Errorf("checksum missing for %s", artifact)
+	}
+	return checksum, nil
+}
+
+func downloadCLIUpdate(client *http.Client, url string, out io.Writer, limit int64) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("download release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: %s", url, resp.Status)
+	}
+	n, err := io.Copy(out, io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	if n > limit {
+		return fmt.Errorf("release download exceeds %d bytes", limit)
+	}
+	return nil
+}

--- a/cmd/telos/update.go
+++ b/cmd/telos/update.go
@@ -36,9 +36,6 @@ func cmdUpdate(args []string) {
 	}
 	requested := fs.Arg(0)
 	executable, err := os.Executable()
-	if err == nil && Version == "dev" {
-		err = fmt.Errorf("development builds must be rebuilt from source; install a released CLI to use telos update")
-	}
 	client := &http.Client{
 		Timeout: 2 * time.Minute,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -67,6 +64,9 @@ func cmdUpdate(args []string) {
 }
 
 func updateCLI(executable, current, requested, baseURL string, client *http.Client) (string, error) {
+	if current == "dev" || strings.HasPrefix(current, "v0.0.0-dev.") {
+		return "", fmt.Errorf("development builds must be rebuilt from source; install a released CLI to use telos update")
+	}
 	version := requested
 	if version == "" {
 		version = "latest"

--- a/cmd/telos/update_test.go
+++ b/cmd/telos/update_test.go
@@ -22,6 +22,37 @@ func updateTestManifest(version string) string {
 		version, runtime.GOOS, runtime.GOARCH, "telos-"+runtime.GOOS+"-"+runtime.GOARCH)
 }
 
+func TestCLIUpdateRejectsDevelopmentBuilds(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected release request", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	for _, current := range []string{"dev", "v0.0.0-dev.a7f94f8013ea"} {
+		for _, requested := range []string{"latest", "v0.1.5"} {
+			t.Run(current+"/"+requested, func(t *testing.T) {
+				dir := t.TempDir()
+				target := filepath.Join(dir, "telos")
+				if err := os.WriteFile(target, []byte("original"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := updateCLI(target, current, requested, srv.URL, srv.Client()); err == nil || !strings.Contains(err.Error(), "development builds must be rebuilt from source") {
+					t.Fatalf("error = %v", err)
+				}
+				data, err := os.ReadFile(target)
+				if err != nil || string(data) != "original" {
+					t.Fatalf("original changed: %q, %v", data, err)
+				}
+				assertNoUpdateStage(t, dir)
+			})
+		}
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("development build made %d release requests", requests.Load())
+	}
+}
+
 func TestCLIUpdateReleaseSelection(t *testing.T) {
 	for _, requested := range []string{"", "latest", "v0.1.5+master.abc123", "0.1.5+master.abc123"} {
 		t.Run(requested, func(t *testing.T) {
@@ -55,7 +86,7 @@ func TestCLIUpdateReleaseSelection(t *testing.T) {
 			}))
 			defer srv.Close()
 			// An explicit older release is allowed: no semver ordering blocks rollback.
-			got, err := updateCLI(target, "v0.2.0", requested, srv.URL, srv.Client())
+			got, err := updateCLI(target, "v0.2.0+master.def456", requested, srv.URL, srv.Client())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/telos/update_test.go
+++ b/cmd/telos/update_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func updateTestManifest(version string) string {
+	return fmt.Sprintf(`{"version":%q,"base_url":"https://unused.invalid","platforms":[{"os":%q,"arch":%q,"telos":%q}]}`,
+		version, runtime.GOOS, runtime.GOARCH, "telos-"+runtime.GOOS+"-"+runtime.GOARCH)
+}
+
+func TestCLIUpdateReleaseSelection(t *testing.T) {
+	for _, requested := range []string{"", "latest", "v0.1.5+master.abc123", "0.1.5+master.abc123"} {
+		t.Run(requested, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "telos")
+			for _, name := range []string{"telos", "telosd", "config.yaml", "SKILL.md"} {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte("original"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			version := "v0.1.5+master.abc123"
+			artifact := "telos-" + runtime.GOOS + "-" + runtime.GOARCH
+			payload := []byte("verified replacement")
+			manifestVersion := version
+			if requested == "" || requested == "latest" {
+				manifestVersion = "latest"
+			}
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				switch r.URL.Path {
+				case "/" + manifestVersion + "/manifest.json":
+					fmt.Fprint(w, updateTestManifest(version))
+				case "/" + version + "/SHA256SUMS":
+					fmt.Fprintf(w, "%x  %s\n", sha256.Sum256(payload), artifact)
+				case "/" + version + "/" + artifact:
+					w.Write(payload)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			// An explicit older release is allowed: no semver ordering blocks rollback.
+			got, err := updateCLI(target, "v0.2.0", requested, srv.URL, srv.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != version {
+				t.Fatalf("version = %q", got)
+			}
+			data, err := os.ReadFile(target)
+			if err != nil || !bytes.Equal(data, payload) {
+				t.Fatalf("replacement = %q, %v", data, err)
+			}
+			info, err := os.Stat(target)
+			if err != nil || info.Mode().Perm() != 0o755 {
+				t.Fatalf("replacement permissions: %v, %v", info, err)
+			}
+			for _, name := range []string{"telosd", "config.yaml", "SKILL.md"} {
+				data, err := os.ReadFile(filepath.Join(dir, name))
+				if err != nil || string(data) != "original" {
+					t.Fatalf("changed %s", name)
+				}
+			}
+			if requests.Load() != 3 {
+				t.Fatalf("requests = %d", requests.Load())
+			}
+			assertNoUpdateStage(t, dir)
+		})
+	}
+}
+
+func TestCLIUpdateNoop(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "telos")
+	if err := os.WriteFile(target, []byte("original"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.Stat(target)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest/manifest.json" {
+			t.Errorf("unexpected request %s", r.URL.Path)
+		}
+		fmt.Fprint(w, updateTestManifest("v0.1.5"))
+	}))
+	defer srv.Close()
+	got, err := updateCLI(target, "v0.1.5", "latest", srv.URL, srv.Client())
+	if err != nil || got != "v0.1.5" {
+		t.Fatalf("update = %q, %v", got, err)
+	}
+	after, _ := os.Stat(target)
+	if !os.SameFile(before, after) {
+		t.Fatal("no-op replaced the executable")
+	}
+	assertNoUpdateStage(t, dir)
+}
+
+func TestCLIUpdateFailuresKeepOriginal(t *testing.T) {
+	for _, failure := range []string{"manifest-http", "manifest-json", "manifest-version", "wrong-version", "missing-platform", "unsafe-artifact", "checksum-http", "checksum-missing", "checksum-invalid", "checksum-duplicate", "checksum-mismatch", "binary-http", "truncated-binary"} {
+		t.Run(failure, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "telos")
+			if err := os.WriteFile(target, []byte("original"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			payload := []byte("new binary")
+			artifact := "telos-" + runtime.GOOS + "-" + runtime.GOARCH
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch filepath.Base(r.URL.Path) {
+				case "manifest.json":
+					switch failure {
+					case "manifest-http":
+						http.Error(w, "not found", 404)
+					case "manifest-json":
+						fmt.Fprint(w, "not json")
+					case "manifest-version":
+						fmt.Fprint(w, updateTestManifest("../../unsafe"))
+					case "wrong-version":
+						fmt.Fprint(w, updateTestManifest("v0.9.0"))
+					case "missing-platform":
+						fmt.Fprint(w, `{"version":"v0.1.5","platforms":[]}`)
+					case "unsafe-artifact":
+						fmt.Fprint(w, strings.ReplaceAll(updateTestManifest("v0.1.5"), artifact, "../telosd"))
+					default:
+						fmt.Fprint(w, updateTestManifest("v0.1.5"))
+					}
+				case "SHA256SUMS":
+					line := fmt.Sprintf("%x  %s\n", sha256.Sum256(payload), artifact)
+					switch failure {
+					case "checksum-http":
+						http.Error(w, "unavailable", 503)
+					case "checksum-missing":
+						fmt.Fprint(w, "")
+					case "checksum-invalid":
+						fmt.Fprintf(w, "not-a-hash  %s\n", artifact)
+					case "checksum-duplicate":
+						fmt.Fprint(w, line+line)
+					case "checksum-mismatch":
+						fmt.Fprintf(w, "%x  %s\n", sha256.Sum256([]byte("other")), artifact)
+					default:
+						fmt.Fprint(w, line)
+					}
+				case artifact:
+					if failure == "binary-http" {
+						http.Error(w, "unavailable", 503)
+						return
+					}
+					if failure == "truncated-binary" {
+						w.Header().Set("Content-Length", "1000")
+					}
+					w.Write(payload)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			if _, err := updateCLI(target, "v0.1.4", "v0.1.5", srv.URL, srv.Client()); err == nil {
+				t.Fatal("expected update failure")
+			}
+			data, err := os.ReadFile(target)
+			if err != nil || string(data) != "original" {
+				t.Fatalf("original changed: %q, %v", data, err)
+			}
+			assertNoUpdateStage(t, dir)
+		})
+	}
+}
+
+func TestCLIUpdatePreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-telos")
+	link := filepath.Join(dir, "telos")
+	if err := os.WriteFile(target, []byte("original"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := cliUpdateTarget(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != want {
+		t.Fatalf("target = %q", resolved)
+	}
+	info, err := os.Lstat(link)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("changed symlink")
+	}
+}
+
+func TestCLIUpdateRejectsManagedTargets(t *testing.T) {
+	for _, path := range []string{"opt/homebrew/Cellar/telos/0.1.5/bin/telos", "nix/store/hash-telos/bin/telos", "snap/telos/1/bin/telos", "opt/local/bin/telos"} {
+		t.Run(path, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), path)
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, []byte("managed"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := cliUpdateTarget(target); err == nil || !strings.Contains(err.Error(), "package-manager") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestCLIReleaseVersions(t *testing.T) {
+	for _, valid := range []string{"v0.1.5", "0.1.5", "v0.1.5+master.abc123", "v1.2.3-rc.1"} {
+		if !validCLIReleaseVersion(valid) {
+			t.Errorf("rejected %q", valid)
+		}
+	}
+	for _, invalid := range []string{"", "dev", "latest", "v1", "v01.2.3", "../../etc", "v1.2.3/foo", "v1.2.3?foo", "v1.2.3#foo", " v1.2.3", "v 1.2.3", "v1.2.3\n"} {
+		if validCLIReleaseVersion(invalid) {
+			t.Errorf("accepted %q", invalid)
+		}
+	}
+}
+
+func TestCLIUpdateDownloadBound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "too large") }))
+	defer srv.Close()
+	var out bytes.Buffer
+	if err := downloadCLIUpdate(srv.Client(), srv.URL, &out, 3); err == nil {
+		t.Fatal("accepted oversized response")
+	}
+	if out.Len() != 4 {
+		t.Fatalf("read %d bytes", out.Len())
+	}
+}
+
+func TestCLIUpdateRunningExecutable(t *testing.T) {
+	if endpoint := os.Getenv("TELOS_TEST_SELF_UPDATE_URL"); endpoint != "" {
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := updateCLI(executable, "v0.1.4", "latest", endpoint, &http.Client{Timeout: time.Second * 10}); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "telos")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	dest, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(dest, source); err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.Close(); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("replacement CLI")
+	artifact := "telos-" + runtime.GOOS + "-" + runtime.GOARCH
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Base(r.URL.Path) {
+		case "manifest.json":
+			fmt.Fprint(w, updateTestManifest("v0.1.5"))
+		case "SHA256SUMS":
+			fmt.Fprintf(w, "%x  %s\n", sha256.Sum256(payload), artifact)
+		case artifact:
+			w.Write(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	cmd := exec.Command(target, "-test.run=^TestCLIUpdateRunningExecutable$")
+	cmd.Env = append(os.Environ(), "TELOS_TEST_SELF_UPDATE_URL="+srv.URL)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("running update: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || !bytes.Equal(data, payload) {
+		t.Fatalf("replacement = %q, %v", data, err)
+	}
+	assertNoUpdateStage(t, dir)
+}
+
+func assertNoUpdateStage(t *testing.T, dir string) {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, ".telos-update-*"))
+	if err != nil || len(paths) != 0 {
+		t.Fatalf("staging files left: %v, %v", paths, err)
+	}
+}

--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -28,7 +28,9 @@ telos --version
 telos <command> --help
 ```
 
-If Telos is absent, read [Install Telos](references/install.md). Cloud work also
+For installation or a requested CLI update, read
+[Install Telos](references/install.md). `telos update [VERSION]` replaces only
+the CLI, not `telosd`, installed skills, or deployed runtimes. Cloud work also
 needs an authenticated account and a confirmed context:
 
 ```bash

--- a/skills/telos-cli/references/install.md
+++ b/skills/telos-cli/references/install.md
@@ -40,6 +40,38 @@ Prefix the shell receiving the installer pipe:
 curl -fsSL https://usetelos.ai/install.sh | TELOS_INSTALL_VERSION=v0.1.2 sh
 ```
 
+## Update the CLI
+
+Update the currently running CLI to the latest promoted release, or choose
+an exact release:
+
+```bash
+telos update
+telos update latest
+telos update v0.1.5+master.db65a24fa89d
+telos --version
+```
+
+An explicit older version rolls the CLI back. If you already have the selected
+version, the command makes no changes. Exact versions accept an optional `v`
+prefix; a `+master.<commit>` suffix identifies an immutable build, not a new
+semantic-version tag.
+
+The updater downloads the matching macOS or Linux binary, checks its SHA-256
+checksum, and atomically replaces the executable you invoked. A failed download
+or checksum check leaves the existing CLI untouched. Its directory must be
+writable; the updater does not request elevated privileges. Symlinks continue
+to point at the updated executable.
+
+Only `telos` changes. Your configuration, credentials, `telosd`, installed skill
+bundle, and deployed sessions are unchanged. To update the full local
+installation, rerun the installer above instead. Older CLIs without `update`
+also need the installer once to get this command.
+
+If you installed Telos with a package manager, update through that manager.
+The updater refuses recognized Homebrew, Nix, Snap, and MacPorts paths.
+Development builds must be rebuilt from source.
+
 ## Repair the command path
 
 If the shell cannot find `telos`, add `$HOME/.local/bin` to `PATH` or set


### PR DESCRIPTION
## Summary

Add `telos update` (latest promoted release) and `telos update VERSION` (an exact release, including rollback). This command updates only the currently invoked CLI executable.

## Design

- Use the installer's existing HTTPS release manifest, platform artifacts, and SHA256SUMS format. After resolving latest, pin subsequent requests to its immutable version; do not execute an installer shell script.
- Stage the verified binary in the executable's directory and atomically rename it into place. Downloads are time/size bounded; missing or mismatched checksums, malformed metadata, and failed downloads leave the existing executable untouched.
- Preserve symlinks by replacing their resolved target. Refuse recognized Homebrew, Nix, Snap, and MacPorts locations, and explain source rebuilds for development binaries. Do not elevate privileges.
- Accept exact versions with or without `v`, permit explicit older versions, and make an already-current version a no-op.
- Leave telosd, configuration, credentials, installed skill bundles, Cloud pins, and running sessions unchanged. The full installer remains the way to update the complete local installation.
- Add command help and document usage/scope in the canonical CLI skill and installation guide. No new dependencies, internal service modules, or release/version changes.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `bazel test //...` (16 test targets)
- `bazel build //skills:telos_cli_bundle`
- Skill frontmatter validation and `git diff --check`
- Tests cover latest/exact selection, rollback, no-op, manifest/version/platform validation, checksum failures, HTTP failures, truncated downloads, size limits, symlinks, managed locations, staging cleanup, and subprocess replacement of an executing binary.
- Real public-release smoke tests on disposable macOS CLI binaries: latest resolves to `v0.1.5+master.db65a24fa89d`; exact rollback installs `v0.1.5+master.ffc01abd3a73`. In both cases the resulting executable reports the requested version. The installed workstation CLI was not changed.

## Release

A Telos release must be published and promoted before this command and the updated guide are available. Older CLIs need the installer once to acquire `update`. Merging to master runs the repository's existing automatic publication/promotion workflow; this PR does not bump a semantic-version tag. This PR is intentionally left unmerged pending review.
