### PR TITLE
fix: clarify local Pi requirements in installer

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -209,9 +209,9 @@ fi
 echo "installed telos \$version to \$install_dir"
 echo "installed @telos/telos-cli:${skill_version} to \$agent_skills_dir/telos-cli"
 if ! command -v pi >/dev/null 2>&1; then
-  echo "pi is required for local runs but was not found on PATH"
-  echo "install pi with: npm install -g @earendil-works/pi-coding-agent"
-  echo "then run pi and use /login to configure model credentials before running telos"
+  echo "Cloud-only use, including with Claude Code or Codex, does not require pi locally."
+  echo "For local Telos runs, install pi with: npm install -g @earendil-works/pi-coding-agent"
+  echo "Then run pi and use /login to configure model credentials before your first local run."
   echo "pi setup: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md"
 fi
 if ! command -v telos >/dev/null 2>&1; then

--- a/skills/telos-cli/references/install.md
+++ b/skills/telos-cli/references/install.md
@@ -18,6 +18,10 @@ It installs `telos` and `telosd` under
 `${TELOS_INSTALL_DIR:-$HOME/.local/bin}` and this skill under
 `${TELOS_AGENT_SKILLS_DIR:-$HOME/.agents/skills}/telos-cli`.
 
+Cloud-only use does not require `pi` on your machine, including when you use
+Claude Code or Codex to operate Telos Cloud. The installer's `pi` setup
+instructions apply only to local Telos runs.
+
 For Cloud work, sign in and confirm the target context:
 
 ```bash
@@ -27,7 +31,7 @@ telos config
 
 Then continue with [Use Telos](use-telos.md).
 
-For a local run, install `pi` if the installer reports it missing and
+For a local run, install `pi` if it is not already installed and
 authenticate the intended provider with `pi` → `/login`. Then follow
 [Bounded runs](bounded-runs.md). Managed Cloud deployments do not use the
 workstation's local model credentials.


### PR DESCRIPTION
When `pi` is missing, the installer tells users to configure it "before running telos," which makes it sound required for Cloud-only workflows. Clarify that operating Telos Cloud through Claude Code or Codex requires no local Pi installation, limit the Pi setup instructions to local runs, and update the installation guide to match.

Validation:

- Checked shell syntax for the release builder and generated installer.
- Ran the generated installer against local release fixtures with Pi present and absent; both cases installed the binaries and skill successfully.
- Built `//skills:telos_cli_bundle` and verified the packaged install guide matches its source.

Release: Publish and promote a new Telos release before the updated installer message and rendered guide become available to users.
