### PR TITLE
docs: document token authentication for agents and CI

### DIFF
--- a/skills/telos-cli/SKILL.md
+++ b/skills/telos-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telos-cli
-description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud login and context, session inspection, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
+description: Install and use the Telos CLI to apply persistent Goals or run bounded work. Use for Telos setup, SPEC.md authoring, plan/apply/run workflows, Cloud authentication and context, unattended agents and CI, session inspection, publishing or pulling packages and skills, nested child Goals, and Telos troubleshooting.
 metadata:
   registry: "@telos/telos-cli"
   public_guide: "references/use-telos.md"
@@ -30,13 +30,25 @@ telos <command> --help
 
 For installation or a requested CLI update, read
 [Install Telos](references/install.md). `telos update [VERSION]` replaces only
-the CLI, not `telosd`, installed skills, or deployed runtimes. Cloud work also
-needs an authenticated account and a confirmed context:
+the CLI, not `telosd`, installed skills, or deployed runtimes. For Cloud work,
+check authentication and context without displaying credentials:
 
 ```bash
-telos login
 telos config
 ```
+
+Reuse a valid saved login or a supplied `TELOS_AUTH_TOKEN`. Telos already
+supports non-interactive authentication for agents and CI through this
+environment variable; `TELOS_TOKEN` is not a supported alias. Set the intended
+context with `TELOS_CONTEXT` or a command's `--context` flag.
+
+Run Cloud commands directly when a token is supplied. `telos login` checks
+saved credentials and may start browser approval even when `TELOS_AUTH_TOKEN`
+is set. Use it when credentials are needed and a person can approve the login.
+For an unattended job with missing or rejected credentials, report that it
+needs a valid token instead of starting a browser login. Read
+[Cloud authentication](references/cloud.md#authenticate) for token setup,
+environment precedence, and a CI example.
 
 Choose the lifecycle that matches the requested outcome:
 
@@ -162,7 +174,7 @@ published, updated, or deleted.
 - [The Goal lifecycle](references/lifecycle.md) — identity, states, revisions, and evidence
 - [Glossary](references/glossary.md) — canonical Telos product vocabulary
 - [Bounded runs](references/bounded-runs.md) — local work with an explicit stopping bound
-- [Telos Cloud](references/cloud.md) — contexts and managed-runtime preflight
+- [Telos Cloud](references/cloud.md) — browser and token authentication, CI, contexts, and managed-runtime preflight
 - [Models and inference](references/inference.md) — Cloud and local model selection
 - [Packages and skills](references/packages-and-skills.md) — immutable registry artifacts and rubrics
 - [Nested Goals](references/nested-goals.md) — bounded child work

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Telos Cloud
-description: Choose a Cloud context and confirm that a Goal fits the managed runtime before applying it.
+description: Authenticate through a browser or a token for agents and CI, choose a Cloud context, and confirm that a Goal fits the managed runtime.
 group: Platform
 ---
 
@@ -14,15 +14,78 @@ A CLI **context** selects the personal or team Cloud workspace that owns the
 deployment. Inside an environment, **workspace** means the agent's retained
 filesystem. The two uses are related but not interchangeable.
 
-## Choose the context
+## Authenticate
 
-`telos config` shows the active account, context, and machine-local default
-model:
+Telos supports both browser login and non-interactive token authentication.
+A token is a secret login credential that the CLI sends with Cloud requests.
+
+### Browser login on your computer
+
+For an initial interactive login:
 
 ```bash
 telos login
 telos config
 ```
+
+Approve the login in your browser. The CLI saves the resulting device API
+token as `auth_token` in `~/.telos/config.yaml`, or the file selected by
+`TELOS_CONFIG`. Later Cloud commands reuse that token without another browser
+approval while it remains valid.
+
+### Token authentication for agents and CI
+
+For an unattended job, supply an existing Telos API token through the
+`TELOS_AUTH_TOKEN` environment variable. An environment variable is a named
+setting passed to a program when it starts. Set it through your runner's
+secret store, then run Cloud commands directly; the job needs no `telos login`
+step or browser approval.
+
+Obtain the token before the job starts. For example, an approved `telos login`
+creates the saved device token described above. Store the token privately in
+the runner's secret settings without printing it in logs or committing it to
+the repository. A job using that token loses access if the token is revoked.
+
+Once the CLI is installed, this GitHub Actions step uses a repository secret
+named `TELOS_AUTH_TOKEN` to check access to your personal workspace:
+
+```yaml
+- name: Check Telos access
+  env:
+    TELOS_AUTH_TOKEN: ${{ secrets.TELOS_AUTH_TOKEN }}
+    TELOS_CONTEXT: personal
+  run: |
+    telos config
+    telos list --cloud --json
+```
+
+Use the intended `@team-handle` instead of `personal` for a team workspace.
+`telos config` reports authentication status without showing the token;
+`telos list --cloud --json` makes a read-only Cloud request and fails if access
+is rejected. The token authenticates an existing account and its permissions.
+
+### Configuration precedence
+
+| Setting | Effect |
+| --- | --- |
+| `TELOS_AUTH_TOKEN` | A non-empty value overrides the saved `auth_token`. |
+| `TELOS_API_ENDPOINT` | A non-empty value overrides the saved API endpoint. With neither set, Cloud defaults to `https://api.usetelos.ai`. |
+| `TELOS_CONTEXT` | A non-empty value overrides the saved context; a command's `--context` flag takes precedence over both. |
+| `TELOS_CONFIG` | Selects a configuration file instead of `~/.telos/config.yaml`. |
+
+The Cloud account token setting is `TELOS_AUTH_TOKEN`. `TELOS_TOKEN` is not a
+supported alias, and `TELOS_API_TOKEN` serves a separate runtime session role.
+
+`telos login` checks the saved login rather than `TELOS_AUTH_TOKEN` and may
+open a browser if no valid saved login exists. When you supply a token through
+the environment, check it with `telos config` and run your Cloud command
+directly. If that token is rejected, replace or unset the override; a new
+browser login does not replace the token in the environment.
+
+## Choose the context
+
+`telos config` shows authentication status, the active context, and the
+machine-local default model.
 
 The personal context is `personal`. Team contexts use their handle:
 
@@ -40,6 +103,10 @@ command-level `--context` overrides `TELOS_CONTEXT` and stored configuration
 for that invocation without changing either. Carry the chosen context through
 `plan`, `apply`, `describe`, `logs`, and `delete` so each action has one visible
 target.
+
+For jobs using injected credentials, choose the context with `TELOS_CONTEXT`
+or `--context`. `telos config --context` changes saved configuration and uses
+saved credentials rather than the token and endpoint environment overrides.
 
 ## Preflight the managed runtime
 

--- a/skills/telos-cli/references/cloud.md
+++ b/skills/telos-cli/references/cloud.md
@@ -36,10 +36,9 @@ approval while it remains valid.
 ### Token authentication for agents and CI
 
 For an unattended job, supply an existing Telos API token through the
-`TELOS_AUTH_TOKEN` environment variable. An environment variable is a named
-setting passed to a program when it starts. Set it through your runner's
-secret store, then run Cloud commands directly; the job needs no `telos login`
-step or browser approval.
+`TELOS_AUTH_TOKEN` environment variable using your runner's secret store.
+Run Cloud commands directly; the job needs no `telos login` step or browser
+approval.
 
 Obtain the token before the job starts. For example, an approved `telos login`
 creates the saved device token described above. Store the token privately in

--- a/skills/telos-cli/references/install.md
+++ b/skills/telos-cli/references/install.md
@@ -22,12 +22,16 @@ Cloud-only use does not require `pi` on your machine, including when you use
 Claude Code or Codex to operate Telos Cloud. The installer's `pi` setup
 instructions apply only to local Telos runs.
 
-For Cloud work, sign in and confirm the target context:
+For first-time interactive Cloud setup, sign in and confirm the target context:
 
 ```bash
 telos login
 telos config
 ```
+
+Agents and CI jobs can use an existing token supplied as `TELOS_AUTH_TOKEN`
+and run Cloud commands without a browser login step. See
+[Cloud authentication](cloud.md#authenticate) for token setup and a CI example.
 
 Then continue with [Use Telos](use-telos.md).
 

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -13,6 +13,7 @@ Start with the command that can distinguish the observed symptom:
 | `telos` is unavailable | `command -v telos` | Binary path or missing installation |
 | A local run will not start | `telos plan SPEC.md` | Platform or spec validation error |
 | Cloud authentication or target is wrong | `telos config` | Authentication and active context |
+| An agent or CI job waits for browser login | Check the job's authentication setup against [token authentication](cloud.md#token-authentication-for-agents-and-ci) | A supplied `TELOS_AUTH_TOKEN` lets the job run Cloud commands directly |
 | A spec is rejected | `telos plan SPEC.md` | First validation error |
 | A skill publish is rejected | Read the original `push` error and inspect the local frontmatter | Invalid bundle input or immutable-version conflict |
 | A deployment is not `ready` | `telos describe SESSION_ID --context CONTEXT --json` | Status, digest, and reason |
@@ -34,8 +35,20 @@ supported by the installed release.
 ## Cloud authentication or context is wrong
 
 `telos config` shows whether authentication is valid and which context the CLI
-will use. Log in again if needed, then pass the intended `--context` explicitly
-through the Cloud workflow.
+will use without displaying the token. Pass the intended `--context`
+explicitly through the Cloud workflow.
+
+For an agent or CI job, supply a valid Telos API token as `TELOS_AUTH_TOKEN`
+and run the Cloud command directly. `TELOS_TOKEN` is not a supported alias.
+Running `telos login` can still request browser approval because it checks
+saved credentials rather than the environment token. See
+[Cloud authentication](cloud.md#authenticate) for setup and a CI example.
+
+A non-empty `TELOS_AUTH_TOKEN` takes precedence over the saved login. If it
+is rejected, replace or unset that override before retrying; signing in again
+will not change the environment value. Without an injected token, use
+`telos login` when a person can approve it in a browser. An unattended job
+needs its token supplied before it can proceed.
 
 ## Plan or publish rejects a spec or skill
 

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -34,21 +34,14 @@ supported by the installed release.
 
 ## Cloud authentication or context is wrong
 
-`telos config` shows whether authentication is valid and which context the CLI
-will use without displaying the token. Pass the intended `--context`
-explicitly through the Cloud workflow.
+Check `telos config` for authentication status and the active context, then
+pass the intended `--context` explicitly.
 
-For an agent or CI job, supply a valid Telos API token as `TELOS_AUTH_TOKEN`
-and run the Cloud command directly. `TELOS_TOKEN` is not a supported alias.
-Running `telos login` can still request browser approval because it checks
-saved credentials rather than the environment token. See
-[Cloud authentication](cloud.md#authenticate) for setup and a CI example.
-
-A non-empty `TELOS_AUTH_TOKEN` takes precedence over the saved login. If it
-is rejected, replace or unset that override before retrying; signing in again
-will not change the environment value. Without an injected token, use
-`telos login` when a person can approve it in a browser. An unattended job
-needs its token supplied before it can proceed.
+If an injected `TELOS_AUTH_TOKEN` is rejected, replace or unset it; browser
+login does not change the override. If an unattended job waits for browser
+approval, supply a valid token and run the Cloud command directly. See
+[Cloud authentication](cloud.md#authenticate) for setup, precedence, and a CI
+example.
 
 ## Plan or publish rejects a spec or skill
 

--- a/skills/telos-cli/references/use-telos.md
+++ b/skills/telos-cli/references/use-telos.md
@@ -19,8 +19,11 @@ the command and field shapes match the current CLI.
 
 ## Sign in and choose a context
 
-Install Telos first if needed, then authenticate and inspect the available
-Cloud contexts:
+Install Telos first if needed. For first-time interactive setup, authenticate
+and inspect the available Cloud contexts as shown below. If you already have
+a valid saved login, proceed to `telos config`. Agents and CI can instead
+supply `TELOS_AUTH_TOKEN` and skip `telos login`; see
+[Cloud authentication](cloud.md#authenticate).
 
 ```console
 $ telos login


### PR DESCRIPTION
The CLI skill sent Cloud users through browser login without documenting the existing `TELOS_AUTH_TOKEN` path, making unattended authentication difficult for agents and CI jobs to discover.

Document token authentication in the skill's discovery text and initial workflow, explain when browser login is needed, and add a GitHub Actions example plus configuration-precedence and troubleshooting guidance. Link the same guidance from the installation and getting-started pages.

Validation:

- Skill frontmatter validation and Markdown link/YAML example checks.
- Focused authentication and configuration tests in `internal/config` and `cmd/telos`.
- `bazel build //skills:telos_cli_bundle`, with the changed files verified against the bundle.
- `git diff --check`.

Release: publish and promote a new Telos release to distribute this skill and update the public guide. Existing installations need the refreshed skill bundle through the full installer; `telos update` replaces only the CLI executable.
