### PR TITLE
fix(cli): retry interrupted Cloud monitoring reads

### DIFF
--- a/internal/cloud/BUILD.bazel
+++ b/internal/cloud/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cliauth.go",
         "client.go",
         "inference.go",
+        "read_retry.go",
     ],
     importpath = "github.com/telos-org/telos/internal/cloud",
     visibility = ["//:__subpackages__"],
@@ -23,6 +24,9 @@ go_test(
         "account_test.go",
         "cliauth_test.go",
         "client_test.go",
+        "read_retry_review_test.go",
+        "read_retry_test.go",
+        "retry_adversarial_test.go",
     ],
     embed = [":cloud"],
     deps = [

--- a/internal/cloud/account.go
+++ b/internal/cloud/account.go
@@ -1,9 +1,8 @@
 package cloud
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -22,19 +21,7 @@ type AccountBootstrapRecord struct {
 }
 
 func (c *Client) AccountBootstrap() (*AccountBootstrapRecord, error) {
-	resp, err := c.do("GET", "/api/account/bootstrap", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, readError(resp)
-	}
-	var account AccountBootstrapRecord
-	if err := json.NewDecoder(resp.Body).Decode(&account); err != nil {
-		return nil, err
-	}
-	return &account, nil
+	return getJSONWithRetry[AccountBootstrapRecord](context.Background(), c, "/api/account/bootstrap")
 }
 
 func (c *Client) ResolveContext(value string) (*OrganizationRecord, error) {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -3,6 +3,7 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -585,35 +586,15 @@ func (c *Client) UpdateSession(sessionID string, opts SessionUpdateOptions) (*Se
 }
 
 func (c *Client) ListSessions() ([]SessionRecord, error) {
-	resp, err := c.do("GET", "/api/deployments", nil)
+	response, err := getJSONWithRetry[sessionListResponse](context.Background(), c, "/api/deployments")
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, readError(resp)
-	}
-	var response sessionListResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, err
 	}
 	return response.Sessions, nil
 }
 
 func (c *Client) GetSession(sessionID string) (*SessionRecord, error) {
-	resp, err := c.do("GET", "/api/deployments/"+url.PathEscape(sessionID), nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, readError(resp)
-	}
-	var response SessionRecord
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, err
-	}
-	return &response, nil
+	return getJSONWithRetry[SessionRecord](context.Background(), c, "/api/deployments/"+url.PathEscape(sessionID))
 }
 
 func (c *Client) DeleteSession(sessionID string) (*SessionRecord, error) {
@@ -645,16 +626,8 @@ func (c *Client) GetSessionLogPage(sessionID string, tail int) (*SessionLogPage,
 	if tail > 0 {
 		path += "?tail=" + strconv.Itoa(tail)
 	}
-	resp, err := c.do("GET", path, nil)
+	response, err := getJSONWithRetry[deploymentLogEventsResponse](context.Background(), c, path)
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, readError(resp)
-	}
-	var response deploymentLogEventsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, err
 	}
 	events := make([]sessionapi.SessionEvent, 0, len(response.Events))
@@ -685,11 +658,15 @@ func (c *Client) do(method, path string, body []byte) (*http.Response, error) {
 }
 
 func (c *Client) doRaw(method, path string, body []byte, contentType string) (*http.Response, error) {
+	return c.doRawContext(context.Background(), method, path, body, contentType)
+}
+
+func (c *Client) doRawContext(ctx context.Context, method, path string, body []byte, contentType string) (*http.Response, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)
 	}
-	req, err := http.NewRequest(method, c.Endpoint+path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, c.Endpoint+path, bodyReader)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cloud/read_retry.go
+++ b/internal/cloud/read_retry.go
@@ -1,0 +1,97 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+const (
+	readMaxAttempts = 3
+	readRetryDelay  = 250 * time.Millisecond
+)
+
+// getJSONWithRetry is opt-in for monitoring GETs. Keep writes and token claims
+// on the single-attempt path: a lost response does not mean they were rejected.
+func getJSONWithRetry[T any](ctx context.Context, c *Client, path string) (*T, error) {
+	timeout := c.HTTP.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		result, err := getJSONAttempt[T](ctx, c, path)
+		if err == nil {
+			return result, nil
+		}
+		var apiError *APIError
+		if errors.As(err, &apiError) {
+			return nil, err
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if attempt+1 >= readMaxAttempts || !retryableReadError(err) {
+			return nil, err
+		}
+
+		// Equal jitter spreads clients across the latter half of each backoff.
+		delay := readRetryDelay << attempt
+		delay = delay/2 + time.Duration(rand.Int64N(int64(delay/2)))
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func getJSONAttempt[T any](ctx context.Context, c *Client, path string) (*T, error) {
+	resp, err := c.doRawContext(ctx, http.MethodGet, path, nil, "application/json")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+	// Finish reading the HTTP body before decoding. A truncated transfer is
+	// retryable; malformed JSON in a complete response is a terminal API bug.
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Each attempt owns its result, so partial data cannot leak into a later
+	// response or the caller's log output.
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func retryableReadError(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	var networkError net.Error
+	return errors.As(err, &networkError) && networkError.Timeout()
+}

--- a/internal/cloud/read_retry.go
+++ b/internal/cloud/read_retry.go
@@ -89,7 +89,14 @@ func retryableReadError(err error) bool {
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) ||
-		errors.Is(err, syscall.EPIPE) {
+		errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// DNS resolvers mark failures such as SERVFAIL as temporary without
+	// marking them as timeouts. Inspect DNS errors through all wrappers;
+	// net.Error.Temporary is deprecated and includes unrelated local failures.
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) && dnsError.IsTemporary {
 		return true
 	}
 	var networkError net.Error

--- a/internal/cloud/read_retry_review_test.go
+++ b/internal/cloud/read_retry_review_test.go
@@ -1,0 +1,192 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type readReviewBody struct {
+	io.Reader
+	closed bool
+}
+
+func (body *readReviewBody) Close() error {
+	body.closed = true
+	return nil
+}
+
+type readReviewTruncatedBody struct {
+	data string
+}
+
+func (body *readReviewTruncatedBody) Read(p []byte) (int, error) {
+	n := copy(p, body.data)
+	body.data = body.data[n:]
+	if len(body.data) > 0 {
+		return n, nil
+	}
+	return n, io.ErrUnexpectedEOF
+}
+
+type readReviewStalledBody struct {
+	ctx context.Context
+}
+
+func (body readReviewStalledBody) Read([]byte) (int, error) {
+	<-body.ctx.Done()
+	return 0, body.ctx.Err()
+}
+
+func TestMonitoringReadCompleteMalformedJSONIsTerminal(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: ""},
+		{name: "whitespace", body: " \n\t"},
+		{name: "partial object", body: `{"id":"incomplete"`},
+		{name: "trailing garbage", body: `{"id":"first"} garbage`},
+		{name: "multiple JSON values", body: `{"id":"first"}{"id":"second"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				body := &readReviewBody{Reader: strings.NewReader(tt.body)}
+				client := NewClient("https://api.example.test", "test-token")
+				client.HTTP.Transport = readRetryTransport(func(req *http.Request) (*http.Response, error) {
+					attempts++
+					if attempts > 1 {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(strings.NewReader(`{"id":"unexpected retry"}`)),
+						}, nil
+					}
+					return &http.Response{
+						StatusCode:    http.StatusOK,
+						ContentLength: int64(len(tt.body)),
+						Body:          body,
+					}, nil
+				})
+
+				result, err := client.GetSession("session-test")
+				var syntaxError *json.SyntaxError
+				if result != nil || !errors.As(err, &syntaxError) {
+					t.Fatalf("GetSession() = %v, %v; want a terminal JSON syntax error", result, err)
+				}
+				if attempts != 1 {
+					t.Fatalf("attempts = %d, want 1 for a complete HTTP response with invalid JSON", attempts)
+				}
+				if !body.closed {
+					t.Fatal("malformed response body was not closed")
+				}
+			})
+		})
+	}
+}
+
+func TestMonitoringReadCompleteJSONInTruncatedHTTPBodyRetries(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		attempts := 0
+		// A JSON decoder can accept this first object before noticing that the
+		// HTTP response is incomplete. No fields from it may survive the retry.
+		firstBody := &readReviewBody{Reader: &readReviewTruncatedBody{
+			data: `{"id":"first","name":"discarded","failure_reason":"stale"}`,
+		}}
+		secondBody := &readReviewBody{Reader: strings.NewReader(`{"id":"second"}`)}
+		client := NewClient("https://api.example.test", "test-token")
+		client.HTTP.Transport = readRetryTransport(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			body := secondBody
+			if attempts == 1 {
+				body = firstBody
+			} else if !firstBody.closed {
+				t.Error("first response body was not closed before retrying")
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+		})
+
+		result, err := client.GetSession("session-test")
+		if err != nil {
+			t.Fatalf("GetSession: %v", err)
+		}
+		if result.ID != "second" || result.Name != "" || result.FailureReason != nil {
+			t.Fatalf("GetSession() = %+v; want only fields from the complete second response", result)
+		}
+		if attempts != 2 {
+			t.Fatalf("attempts = %d, want 2", attempts)
+		}
+		if !firstBody.closed || !secondBody.closed {
+			t.Fatal("response bodies were not both closed")
+		}
+	})
+}
+
+func TestMonitoringReadTerminalStatusSurvivesErrorBodyDeadline(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				var body *readReviewBody
+				client := NewClient("https://api.example.test", "test-token")
+				client.HTTP.Timeout = time.Second
+				client.HTTP.Transport = readRetryTransport(func(req *http.Request) (*http.Response, error) {
+					attempts++
+					body = &readReviewBody{Reader: readReviewStalledBody{ctx: req.Context()}}
+					return &http.Response{StatusCode: status, Body: body}, nil
+				})
+
+				start := time.Now()
+				result, err := client.GetSession("session-test")
+				if result != nil || !IsStatus(err, status) {
+					t.Fatalf("GetSession() = %v, %v; want HTTP %d after error body timed out", result, err, status)
+				}
+				if attempts != 1 {
+					t.Fatalf("attempts = %d, want 1 for a terminal HTTP status", attempts)
+				}
+				if elapsed := time.Since(start); elapsed != time.Second {
+					t.Fatalf("elapsed = %v, want the one-second operation timeout", elapsed)
+				}
+				if !body.closed {
+					t.Fatal("timed-out error response body was not closed")
+				}
+			})
+		})
+	}
+}
+
+func TestMonitoringReadResponseHeaderTimeoutRetries(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if attempts.Add(1) == 1 {
+			<-req.Context().Done()
+			return
+		}
+		_, _ = io.WriteString(w, `{"id":"session-test"}`)
+	}))
+	defer server.Close()
+	client := NewClient(server.URL, "test-token")
+	client.HTTP.Timeout = 5 * time.Second
+	transport := &http.Transport{
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: 100 * time.Millisecond,
+	}
+	defer transport.CloseIdleConnections()
+	client.HTTP.Transport = transport
+
+	result, err := client.GetSession("session-test")
+	if err != nil || result == nil || result.ID != "session-test" {
+		t.Fatalf("GetSession() = %v, %v; want recovery from a response-header timeout", result, err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}

--- a/internal/cloud/read_retry_test.go
+++ b/internal/cloud/read_retry_test.go
@@ -1,0 +1,196 @@
+package cloud
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type readRetryTransport func(*http.Request) (*http.Response, error)
+
+func (transport readRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return transport(req)
+}
+
+func TestMonitoringReadRetriesOnlyTransientErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		attempts int
+	}{
+		{"reset", &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}, 3},
+		{"aborted", syscall.ECONNABORTED, 3},
+		{"broken_pipe", syscall.EPIPE, 3},
+		{"eof", io.EOF, 3},
+		{"truncated_body", io.ErrUnexpectedEOF, 3},
+		{"timeout", &net.DNSError{Err: "temporary timeout", IsTimeout: true}, 3},
+		// Transport timeouts can match DeadlineExceeded before the operation's
+		// deadline expires (for example, ResponseHeaderTimeout).
+		{"transport_deadline", &net.OpError{Op: "read", Net: "tcp", Err: context.DeadlineExceeded}, 3},
+		{"canceled", context.Canceled, 1},
+		{"unknown_host", &net.DNSError{Err: "no such host", IsNotFound: true}, 1},
+		{"certificate", x509.UnknownAuthorityError{}, 1},
+		{"invalid_json", &json.SyntaxError{}, 1},
+		{"unexpected_error", errors.New("unsupported protocol"), 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				client := NewClient("https://api.example.test", "")
+				client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
+					attempts++
+					return nil, test.err
+				})
+				result, err := client.GetSession("session-test")
+				if result != nil || !errors.Is(err, test.err) {
+					t.Fatalf("result = %v, error = %v; want original error %v", result, err, test.err)
+				}
+				if attempts != test.attempts {
+					t.Fatalf("attempts = %d, want %d", attempts, test.attempts)
+				}
+			})
+		})
+	}
+}
+
+func TestMonitoringReadRecoversOnLastAttempt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var starts []time.Time
+		client := NewClient("https://api.example.test", "")
+		client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
+			starts = append(starts, time.Now())
+			if len(starts) < 3 {
+				return nil, syscall.ECONNRESET
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"session-test","state":"running"}`)),
+			}, nil
+		})
+		result, err := client.GetSession("session-test")
+		if err != nil || result.ID != "session-test" || result.State != "running" {
+			t.Fatalf("result = %v, error = %v", result, err)
+		}
+		if len(starts) != 3 {
+			t.Fatalf("attempts = %d, want 3", len(starts))
+		}
+		for index, bounds := range [][2]time.Duration{
+			{125 * time.Millisecond, 250 * time.Millisecond},
+			{250 * time.Millisecond, 500 * time.Millisecond},
+		} {
+			wait := starts[index+1].Sub(starts[index])
+			if wait < bounds[0] || wait >= bounds[1] {
+				t.Errorf("wait %d = %v, want [%v, %v)", index+1, wait, bounds[0], bounds[1])
+			}
+		}
+	})
+}
+
+func TestMonitoringReadSharesTimeoutAcrossAttempts(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := NewClient("https://api.example.test", "")
+		client.HTTP.Timeout = time.Second
+		attempts := 0
+		client.HTTP.Transport = readRetryTransport(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 3 {
+				time.Sleep(100 * time.Millisecond)
+				return nil, syscall.ECONNRESET
+			}
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+		start := time.Now()
+		_, err := client.GetSession("session-test")
+		if !errors.Is(err, context.DeadlineExceeded) || attempts != 3 {
+			t.Fatalf("attempts = %d, error = %v", attempts, err)
+		}
+		if elapsed := time.Since(start); elapsed != time.Second {
+			t.Fatalf("elapsed = %v, want one shared 1s budget", elapsed)
+		}
+	})
+}
+
+func TestMonitoringReadBoundsClientsWithoutHTTPTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := NewClient("https://api.example.test", "")
+		client.HTTP.Timeout = 0
+		attempts := 0
+		client.HTTP.Transport = readRetryTransport(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+		start := time.Now()
+		_, err := client.GetSession("session-test")
+		if !errors.Is(err, context.DeadlineExceeded) || attempts != 1 {
+			t.Fatalf("attempts = %d, error = %v", attempts, err)
+		}
+		if elapsed := time.Since(start); elapsed != 30*time.Second {
+			t.Fatalf("elapsed = %v, want the default 30s budget", elapsed)
+		}
+	})
+}
+
+func TestMonitoringReadStopsDuringBackoff(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		name := "deadline"
+		if canceled {
+			name = "cancellation"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				client := NewClient("https://api.example.test", "")
+				client.HTTP.Timeout = 50 * time.Millisecond
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				wantErr := context.DeadlineExceeded
+				if canceled {
+					client.HTTP.Timeout = time.Second
+					wantErr = context.Canceled
+					go func() {
+						time.Sleep(50 * time.Millisecond)
+						cancel()
+					}()
+				}
+				attempts := 0
+				client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
+					attempts++
+					return nil, syscall.ECONNRESET
+				})
+				start := time.Now()
+				_, err := getJSONWithRetry[SessionRecord](ctx, client, "/api/deployments/session-test")
+				if !errors.Is(err, wantErr) || attempts != 1 {
+					t.Fatalf("attempts = %d, error = %v; want %v", attempts, err, wantErr)
+				}
+				if elapsed := time.Since(start); elapsed != 50*time.Millisecond {
+					t.Fatalf("elapsed = %v; wait should stop at 50ms", elapsed)
+				}
+			})
+		})
+	}
+}
+
+func TestMonitoringReadHonorsAlreadyCanceledContext(t *testing.T) {
+	client := NewClient("https://api.example.test", "")
+	client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
+		t.Fatal("canceled read must not send a request")
+		return nil, context.Canceled
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := getJSONWithRetry[SessionRecord](ctx, client, "/api/deployments/session-test")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/cloud/read_retry_test.go
+++ b/internal/cloud/read_retry_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -28,16 +30,22 @@ func TestMonitoringReadRetriesOnlyTransientErrors(t *testing.T) {
 		attempts int
 	}{
 		{"reset", &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}, 3},
+		{"connection_refused", syscall.ECONNREFUSED, 3},
+		{"wrapped_connection_refused", &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}, 3},
 		{"aborted", syscall.ECONNABORTED, 3},
 		{"broken_pipe", syscall.EPIPE, 3},
 		{"eof", io.EOF, 3},
 		{"truncated_body", io.ErrUnexpectedEOF, 3},
 		{"timeout", &net.DNSError{Err: "temporary timeout", IsTimeout: true}, 3},
+		{"temporary_dns", &net.DNSError{Err: "server misbehaving", IsTemporary: true}, 3},
+		{"wrapped_temporary_dns", &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("resolve endpoint: %w", &net.DNSError{Err: "server misbehaving", IsTemporary: true})}, 3},
 		// Transport timeouts can match DeadlineExceeded before the operation's
 		// deadline expires (for example, ResponseHeaderTimeout).
 		{"transport_deadline", &net.OpError{Op: "read", Net: "tcp", Err: context.DeadlineExceeded}, 3},
 		{"canceled", context.Canceled, 1},
 		{"unknown_host", &net.DNSError{Err: "no such host", IsNotFound: true}, 1},
+		{"permanent_dns", &net.DNSError{Err: "invalid DNS response"}, 1},
+		{"canceled_temporary_dns", &net.DNSError{Err: "lookup canceled", IsTemporary: true, UnwrapErr: context.Canceled}, 1},
 		{"certificate", x509.UnknownAuthorityError{}, 1},
 		{"invalid_json", &json.SyntaxError{}, 1},
 		{"unexpected_error", errors.New("unsupported protocol"), 1},
@@ -64,36 +72,47 @@ func TestMonitoringReadRetriesOnlyTransientErrors(t *testing.T) {
 }
 
 func TestMonitoringReadRecoversOnLastAttempt(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		var starts []time.Time
-		client := NewClient("https://api.example.test", "")
-		client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
-			starts = append(starts, time.Now())
-			if len(starts) < 3 {
-				return nil, syscall.ECONNRESET
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"id":"session-test","state":"running"}`)),
-			}, nil
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{"connection_reset", syscall.ECONNRESET},
+		{"connection_refused", &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}},
+		{"temporary_dns", &net.DNSError{Err: "server misbehaving", IsTemporary: true}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var starts []time.Time
+				client := NewClient("https://api.example.test", "")
+				client.HTTP.Transport = readRetryTransport(func(*http.Request) (*http.Response, error) {
+					starts = append(starts, time.Now())
+					if len(starts) < 3 {
+						return nil, test.err
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"id":"session-test","state":"running"}`)),
+					}, nil
+				})
+				result, err := client.GetSession("session-test")
+				if err != nil || result.ID != "session-test" || result.State != "running" {
+					t.Fatalf("result = %v, error = %v", result, err)
+				}
+				if len(starts) != 3 {
+					t.Fatalf("attempts = %d, want 3", len(starts))
+				}
+				for index, bounds := range [][2]time.Duration{
+					{125 * time.Millisecond, 250 * time.Millisecond},
+					{250 * time.Millisecond, 500 * time.Millisecond},
+				} {
+					wait := starts[index+1].Sub(starts[index])
+					if wait < bounds[0] || wait >= bounds[1] {
+						t.Errorf("wait %d = %v, want [%v, %v)", index+1, wait, bounds[0], bounds[1])
+					}
+				}
+			})
 		})
-		result, err := client.GetSession("session-test")
-		if err != nil || result.ID != "session-test" || result.State != "running" {
-			t.Fatalf("result = %v, error = %v", result, err)
-		}
-		if len(starts) != 3 {
-			t.Fatalf("attempts = %d, want 3", len(starts))
-		}
-		for index, bounds := range [][2]time.Duration{
-			{125 * time.Millisecond, 250 * time.Millisecond},
-			{250 * time.Millisecond, 500 * time.Millisecond},
-		} {
-			wait := starts[index+1].Sub(starts[index])
-			if wait < bounds[0] || wait >= bounds[1] {
-				t.Errorf("wait %d = %v, want [%v, %v)", index+1, wait, bounds[0], bounds[1])
-			}
-		}
-	})
+	}
 }
 
 func TestMonitoringReadSharesTimeoutAcrossAttempts(t *testing.T) {

--- a/internal/cloud/retry_adversarial_test.go
+++ b/internal/cloud/retry_adversarial_test.go
@@ -1,0 +1,333 @@
+package cloud
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests use real HTTP connections independently of the retry helper.
+// Disable connection reuse so net/http's own stale-connection retry cannot
+// conceal missing application retries or change the observed attempt count.
+func TestAdversarialCloudReadsRecoverOnWire(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		path     string
+		query    string
+		partial  string
+		complete string
+		check    func(*testing.T, *Client)
+	}{
+		{
+			name:     "session",
+			path:     "/api/deployments/sess%2Fwith%20space%3Fx",
+			partial:  `{"id":"discard-me","status_reason":"stale","state":`,
+			complete: `{"id":"sess/with space?x","state":"healthy","status":"ready"}`,
+			check: func(t *testing.T, client *Client) {
+				record, err := client.GetSession("sess/with space?x")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if record.ID != "sess/with space?x" || record.State != "healthy" || record.Status != "ready" || record.StatusReason != "" {
+					t.Fatalf("recovered session contains missing or stale fields: %+v", record)
+				}
+			},
+		},
+		{
+			name:     "session list",
+			path:     "/api/deployments",
+			partial:  `{"deployments":[{"id":"discard-me","state":"failed"},`,
+			complete: `{"deployments":[{"id":"fresh","state":"healthy"}]}`,
+			check: func(t *testing.T, client *Client) {
+				records, err := client.ListSessions()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(records) != 1 || records[0].ID != "fresh" || records[0].State != "healthy" {
+					t.Fatalf("recovered list contains missing or stale records: %+v", records)
+				}
+			},
+		},
+		{
+			name:     "log page",
+			path:     "/api/deployments/sess%2Fwith%20space%3Fx/logs",
+			query:    "tail=2",
+			partial:  `{"events":[{"event":"discard-me","event_id":"stale","event_seq":100},`,
+			complete: `{"events":[{"event":"agent_progress","event_id":"evt_101","event_seq":101,"data":{"text":"first"},"extension":"preserve"},{"event":"agent_progress","event_id":"evt_102","event_seq":102,"data":{"text":"second"}}]}`,
+			check: func(t *testing.T, client *Client) {
+				page, err := client.GetSessionLogPage("sess/with space?x", 2)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(page.Events) != 2 || len(page.RawEvents) != 2 {
+					t.Fatalf("recovered page lost or duplicated events: %+v", page)
+				}
+				for index, event := range page.Events {
+					wantSequence := int64(101 + index)
+					wantID := fmt.Sprintf("evt_%d", wantSequence)
+					if event.EventSeq == nil || *event.EventSeq != wantSequence || event.EventID == nil || *event.EventID != wantID {
+						t.Fatalf("event %d lost its identity or order: %+v", index, event)
+					}
+				}
+				wantRaw := []string{
+					`{"event":"agent_progress","event_id":"evt_101","event_seq":101,"data":{"text":"first"},"extension":"preserve"}`,
+					`{"event":"agent_progress","event_id":"evt_102","event_seq":102,"data":{"text":"second"}}`,
+				}
+				gotRaw := []string{string(page.RawEvents[0]), string(page.RawEvents[1])}
+				if !reflect.DeepEqual(gotRaw, wantRaw) {
+					t.Fatalf("retry changed raw events: got %q, want %q", gotRaw, wantRaw)
+				}
+			},
+		},
+		{
+			name:     "account bootstrap",
+			path:     "/api/account/bootstrap",
+			partial:  `{"personal_org_id":"org_stale","organizations":[{"id":"org_stale"},`,
+			complete: `{"personal_org_id":"org_fresh","organizations":[{"id":"org_fresh","kind":"personal"}]}`,
+			check: func(t *testing.T, client *Client) {
+				account, err := client.AccountBootstrap()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if account.PersonalOrgID != "org_fresh" || len(account.Organizations) != 1 || account.Organizations[0].ID != "org_fresh" {
+					t.Fatalf("recovered account contains missing or stale organizations: %+v", account)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		for _, failure := range []string{"reset before headers", "reset during body", "truncated content length"} {
+			t.Run(test.name+"/"+failure, func(t *testing.T) {
+				t.Parallel()
+				var attempts atomic.Int32
+				headersObserved := make(chan struct{})
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					attempt := attempts.Add(1)
+					assertAdversarialRequest(t, r, http.MethodGet, "/proxy"+test.path, test.query)
+					if attempt == 1 {
+						breakAdversarialResponse(t, w, failure, http.StatusOK, test.partial, headersObserved)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, test.complete)
+				}))
+				t.Cleanup(server.Close)
+				client := newAdversarialClient(t, server.URL+"/proxy", headersObserved)
+				test.check(t, client)
+				if got := attempts.Load(); got != 2 {
+					t.Fatalf("server received %d requests after one recoverable failure, want 2", got)
+				}
+			})
+		}
+	}
+}
+
+func TestAdversarialCloudReadExhaustionReturnsNoPartialLogs(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	headersObserved := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		assertAdversarialRequest(t, r, http.MethodGet, "/api/deployments/sess_123/logs", "tail=2")
+		breakAdversarialResponse(t, w, "truncated content length", http.StatusOK,
+			`{"events":[{"event":"agent_progress","event_id":"partial","event_seq":1},`, headersObserved)
+	}))
+	t.Cleanup(server.Close)
+	client := newAdversarialClient(t, server.URL, headersObserved)
+	page, err := client.GetSessionLogPage("sess_123", 2)
+	if err == nil || page != nil {
+		t.Fatalf("exhausted read exposed a partial page or hid the error: page=%+v, err=%v", page, err)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("exhausted read lost the body failure: %v", err)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("persistent body failures made %d requests, want 3", got)
+	}
+}
+
+func TestAdversarialCloudHTTPFailuresStayTerminal(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusTooManyRequests, http.StatusServiceUnavailable} {
+		for _, brokenBody := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%d/broken_body=%t", status, brokenBody), func(t *testing.T) {
+				t.Parallel()
+				var attempts atomic.Int32
+				headersObserved := make(chan struct{})
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					attempts.Add(1)
+					if brokenBody {
+						breakAdversarialResponse(t, w, "reset during body", status, `{"detail":"interrupted`, headersObserved)
+						return
+					}
+					w.Header().Set("Retry-After", "1")
+					w.WriteHeader(status)
+					_, _ = io.WriteString(w, `{"detail":"terminal response"}`)
+				}))
+				t.Cleanup(server.Close)
+				client := newAdversarialClient(t, server.URL, headersObserved)
+				record, err := client.GetSession("sess_123")
+				if record != nil || !IsStatus(err, status) {
+					t.Fatalf("HTTP failure lost its status: record=%+v, err=%v, want HTTP %d", record, err, status)
+				}
+				if got := attempts.Load(); got != 1 {
+					t.Fatalf("HTTP %d was retried: got %d requests", status, got)
+				}
+			})
+		}
+	}
+}
+
+func TestAdversarialCloudMutationResponseLossNeverReplays(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		call   func(*Client) (*SessionRecord, error)
+	}{
+		{
+			name:   "create",
+			method: http.MethodPost,
+			path:   "/api/deployments",
+			call: func(client *Client) (*SessionRecord, error) {
+				return client.CreateSession(SessionCreateOptions{Name: "test", PackageRef: "@test/package:1.0.0"})
+			},
+		},
+		{
+			name:   "update",
+			method: http.MethodPut,
+			path:   "/api/deployments/sess_123",
+			call: func(client *Client) (*SessionRecord, error) {
+				return client.UpdateSession("sess_123", SessionUpdateOptions{PackageRef: "@test/package:2.0.0", Force: true})
+			},
+		},
+		{
+			name:   "delete",
+			method: http.MethodDelete,
+			path:   "/api/deployments/sess_123",
+			call: func(client *Client) (*SessionRecord, error) {
+				return client.DeleteSession("sess_123")
+			},
+		},
+	}
+	for _, test := range tests {
+		for _, failure := range []string{"reset before headers", "reset during body", "truncated content length"} {
+			t.Run(test.name+"/"+failure, func(t *testing.T) {
+				t.Parallel()
+				var mutations atomic.Int32
+				headersObserved := make(chan struct{})
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assertAdversarialRequest(t, r, test.method, test.path, "")
+					if _, err := io.Copy(io.Discard, r.Body); err != nil {
+						t.Errorf("read mutation request: %v", err)
+					}
+					// Model an accepted mutation whose response is then lost.
+					if mutations.Add(1) == 1 {
+						breakAdversarialResponse(t, w, failure, http.StatusOK, `{"id":"sess_123","state":`, headersObserved)
+						return
+					}
+					_, _ = io.WriteString(w, `{"id":"duplicate-mutation","state":"healthy"}`)
+				}))
+				t.Cleanup(server.Close)
+				client := newAdversarialClient(t, server.URL, headersObserved)
+				record, err := test.call(client)
+				if err == nil || record != nil {
+					t.Fatalf("lost mutation response did not remain an error: record=%+v, err=%v", record, err)
+				}
+				if got := mutations.Load(); got != 1 {
+					t.Fatalf("accepted %s was replayed after response loss: %d mutations", test.name, got)
+				}
+			})
+		}
+	}
+}
+
+type adversarialRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTrip adversarialRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func newAdversarialClient(t *testing.T, endpoint string, headersObserved chan struct{}) *Client {
+	t.Helper()
+	transport := &http.Transport{DisableKeepAlives: true}
+	t.Cleanup(transport.CloseIdleConnections)
+	var firstResponse sync.Once
+	client := NewClient(endpoint, "local-test-token")
+	client.OrgID = " org_retry "
+	client.HTTP = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: adversarialRoundTripper(func(request *http.Request) (*http.Response, error) {
+			response, err := transport.RoundTrip(request)
+			if response != nil {
+				firstResponse.Do(func() { close(headersObserved) })
+			}
+			return response, err
+		}),
+	}
+	return client
+}
+
+func assertAdversarialRequest(t *testing.T, request *http.Request, method, path, query string) {
+	t.Helper()
+	if request.Method != method || request.URL.EscapedPath() != path || request.URL.RawQuery != query {
+		t.Errorf("request changed: got %s %s, want %s %s with query %q", request.Method, request.RequestURI, method, path, query)
+	}
+	for name, want := range map[string]string{
+		"Authorization":  "Bearer local-test-token",
+		"X-Telos-Org-Id": "org_retry",
+		"User-Agent":     UserAgent,
+	} {
+		if got := request.Header.Get(name); got != want {
+			t.Errorf("%s changed: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+func breakAdversarialResponse(t *testing.T, writer http.ResponseWriter, failure string, status int, partial string, headersObserved <-chan struct{}) {
+	t.Helper()
+	connection, buffered, err := writer.(http.Hijacker).Hijack()
+	if err != nil {
+		t.Errorf("hijack test connection: %v", err)
+		return
+	}
+	defer connection.Close()
+	if failure != "reset before headers" {
+		_, err = fmt.Fprintf(buffered, "HTTP/1.1 %d %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", status, http.StatusText(status), len(partial)+100, partial)
+		if err == nil {
+			err = buffered.Flush()
+		}
+		if err != nil {
+			t.Errorf("write partial response: %v", err)
+			return
+		}
+		// Ensure headers reached the client before cutting the connection so
+		// these cases exercise response-body recovery, not just HTTP.Do errors.
+		select {
+		case <-headersObserved:
+		case <-time.After(5 * time.Second):
+			t.Error("client did not receive response headers")
+			return
+		}
+	}
+	if failure != "truncated content length" {
+		tcp, ok := connection.(*net.TCPConn)
+		if !ok {
+			t.Errorf("test connection is %T, want *net.TCPConn", connection)
+			return
+		}
+		if err := tcp.SetLinger(0); err != nil {
+			t.Errorf("configure TCP reset: %v", err)
+		}
+	}
+}

--- a/skills/telos-cli/references/lifecycle.md
+++ b/skills/telos-cli/references/lifecycle.md
@@ -87,6 +87,10 @@ An agent observation loop has four operations:
 4. Stop if the digest changes or the 30-minute deadline expires, then return the
    last state instead of waiting indefinitely.
 
+Cloud monitoring reads automatically retry brief connection interruptions within
+each read's timeout. See [connection recovery](troubleshooting.md#cloud-status-or-log-checks-lose-their-connection)
+for the retry limits and what to do if a read still fails.
+
 `logs` supplies the work and verification evidence behind the state:
 
 ```bash

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -40,8 +40,9 @@ through the Cloud workflow.
 
 ## Cloud status or log checks lose their connection
 
-Telos automatically retries brief connection interruptions while reading Cloud
-session lists, session details, logs, and account information for your context.
+Telos automatically retries brief connection interruptions, refused connections,
+and temporary DNS lookup failures while reading Cloud session lists, session
+details, logs, and account information for your context.
 Each read makes up to three attempts with short, increasing, randomized waits.
 The attempts and waits share the normal 30-second timeout for that read; a
 command can perform more than one read. This recovery also covers a connection
@@ -49,8 +50,9 @@ that drops partway through a response.
 
 If you still receive a connection error, repeat the read with the same session
 and context. A failed status or log check does not by itself mean the remote
-session stopped. Authentication failures and other API error responses are
-returned without retrying. Session creation, updates, deletion, and login token
+session stopped. Permanent DNS failures, such as an unknown hostname, certificate
+errors, authentication failures, and other API error responses are returned
+without retrying. Session creation, updates, deletion, and login token
 claims are not automatically resubmitted by this recovery mechanism.
 
 ## Plan or publish rejects a spec or skill

--- a/skills/telos-cli/references/troubleshooting.md
+++ b/skills/telos-cli/references/troubleshooting.md
@@ -13,6 +13,7 @@ Start with the command that can distinguish the observed symptom:
 | `telos` is unavailable | `command -v telos` | Binary path or missing installation |
 | A local run will not start | `telos plan SPEC.md` | Platform or spec validation error |
 | Cloud authentication or target is wrong | `telos config` | Authentication and active context |
+| A Cloud status or log check loses its connection | Repeat the read with the same session and context | Connection error and the next successful status or log response |
 | A spec is rejected | `telos plan SPEC.md` | First validation error |
 | A skill publish is rejected | Read the original `push` error and inspect the local frontmatter | Invalid bundle input or immutable-version conflict |
 | A deployment is not `ready` | `telos describe SESSION_ID --context CONTEXT --json` | Status, digest, and reason |
@@ -36,6 +37,21 @@ supported by the installed release.
 `telos config` shows whether authentication is valid and which context the CLI
 will use. Log in again if needed, then pass the intended `--context` explicitly
 through the Cloud workflow.
+
+## Cloud status or log checks lose their connection
+
+Telos automatically retries brief connection interruptions while reading Cloud
+session lists, session details, logs, and account information for your context.
+Each read makes up to three attempts with short, increasing, randomized waits.
+The attempts and waits share the normal 30-second timeout for that read; a
+command can perform more than one read. This recovery also covers a connection
+that drops partway through a response.
+
+If you still receive a connection error, repeat the read with the same session
+and context. A failed status or log check does not by itself mean the remote
+session stopped. Authentication failures and other API error responses are
+returned without retrying. Session creation, updates, deletion, and login token
+claims are not automatically resubmitted by this recovery mechanism.
 
 ## Plan or publish rejects a spec or skill
 


### PR DESCRIPTION
A transient network failure can make Cloud status, session-list, or log reads fail immediately, even when repeating the read would succeed. Add bounded recovery for these reads and the account bootstrap needed to resolve team contexts.

The CLI makes up to three application attempts with short, increasing, randomized waits, sharing the configured timeout for each read (30 seconds by default). It retries interrupted connections and response bodies, refused connections, and DNS failures explicitly marked temporary. Each attempt reads the complete HTTP body before decoding JSON and discards failed-attempt data. HTTP error responses, permanent DNS failures, certificate errors, and malformed complete JSON remain terminal. Creation, updates, deletion, publishing, and login token claims stay outside the retry path.

Update the lifecycle and troubleshooting guides with the retry scope, limits, and recovery guidance.

## Validation

All local checks passed:

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `bazel test --lockfile_mode=off //internal/cloud:cloud_test`
- `bazel build --lockfile_mode=off //skills:telos_cli_bundle`
- `git diff --check`

Three independent subagents adversarially reviewed the implementation and tests. The 34-case real-network suite covers connection resets before headers and during bodies, truncated transfers, preserved request/log identity, retry exhaustion, terminal HTTP errors, and accepted mutations whose responses are lost. All 12 recovery cases fail against unchanged master, confirming they detect the original gap.

Additional regressions cover direct and wrapped connection-refusal and temporary-DNS errors, recovery on the last attempt, permanent DNS failures, the shared deadline, cancellation, response cleanup, malformed JSON, preserved authentication status after an error-body timeout, and recoverable response-header timeouts.

Independent local TCP and DNS probes also verified that refused connections and actual DNS SERVFAIL responses recover, while DNS NXDOMAIN stays terminal. These probes passed with race detection.

## Release

A new Telos release must be published and promoted before users receive the CLI behavior and the rendered Web guide updates. No API or Web repository changes are required.
