### PR TITLE
fix(cli): preserve cloud log row tails

### DIFF
--- a/cmd/telos/logs.go
+++ b/cmd/telos/logs.go
@@ -128,11 +128,13 @@ func printCloudSessionLogs(
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	tail := options.Tail
-	if raw || options.All || tail > maxCloudLogTail {
-		tail = 0
-	}
-	page, err := control.GetSessionLogPage(session.ID, tail)
+	page, err := getCloudSessionLogPage(
+		control,
+		session.ID,
+		options,
+		jsonOutput,
+		raw,
+	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -156,6 +158,51 @@ func printCloudSessionLogs(
 		return
 	}
 	printStructuredLogs(os.Stdout, page.Events, options)
+}
+
+func getCloudSessionLogPage(
+	control *cloud.Client,
+	sessionID string,
+	options logViewOptions,
+	jsonOutput bool,
+	raw bool,
+) (*cloud.SessionLogPage, error) {
+	if raw || options.All || options.Tail > maxCloudLogTail {
+		return control.GetSessionLogPage(sessionID, cloud.SessionLogPageQuery{})
+	}
+	if jsonOutput {
+		return control.GetSessionLogPage(
+			sessionID,
+			cloud.SessionLogPageQuery{Tail: options.Tail},
+		)
+	}
+
+	query := cloud.SessionLogPageQuery{Tail: maxCloudLogTail}
+	page, err := control.GetSessionLogPage(sessionID, query)
+	if err != nil {
+		return nil, err
+	}
+	pageSize := len(page.Events)
+	for len(renderLogRows(page.Events)) < options.Tail && pageSize == maxCloudLogTail {
+		if !page.CanPageBackward {
+			return control.GetSessionLogPage(sessionID, cloud.SessionLogPageQuery{})
+		}
+		query.BeforeRuntime = page.BeforeRuntime
+		query.BeforeControl = page.BeforeControl
+		older, err := control.GetSessionLogPage(sessionID, query)
+		if err != nil {
+			return nil, err
+		}
+		pageSize = len(older.Events)
+		if pageSize == maxCloudLogTail && !older.CanPageBackward {
+			return control.GetSessionLogPage(sessionID, cloud.SessionLogPageQuery{})
+		}
+		page.Events = append(older.Events, page.Events...)
+		page.BeforeRuntime = older.BeforeRuntime
+		page.BeforeControl = older.BeforeControl
+		page.CanPageBackward = older.CanPageBackward
+	}
+	return page, nil
 }
 
 func enabledFlagCount(values ...bool) int {

--- a/cmd/telos/logs_cloud_test.go
+++ b/cmd/telos/logs_cloud_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/telos-org/telos/internal/cloud"
+)
+
+func TestCloudSessionLogsPageBackwardUntilTailRowsExist(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		query := r.URL.Query()
+		if query.Get("tail") != "1000" {
+			t.Fatalf("tail: got %q", query.Get("tail"))
+		}
+
+		events := make([]map[string]any, 0, maxCloudLogTail)
+		switch requestCount {
+		case 1:
+			if query.Get("before_rt") != "" || query.Get("before_cp") != "" {
+				t.Fatalf("initial query: got %q", r.URL.RawQuery)
+			}
+			for sequence := int64(1001); sequence <= 2000; sequence++ {
+				events = append(events, map[string]any{
+					"event":     "round_start",
+					"event_seq": sequence,
+				})
+			}
+			events[len(events)-1] = map[string]any{
+				"event":     "agent_progress",
+				"event_seq": 2000,
+				"data": map[string]any{
+					"kind": "progress_update",
+					"text": "Newest visible row",
+				},
+			}
+		case 2:
+			if query.Get("before_rt") != "1001" || query.Get("before_cp") != "" {
+				t.Fatalf("older query: got %q", r.URL.RawQuery)
+			}
+			events = append(events, map[string]any{
+				"event":     "agent_progress",
+				"event_seq": 1000,
+				"data": map[string]any{
+					"kind": "progress_update",
+					"text": "Older visible row",
+				},
+			})
+		default:
+			t.Fatalf("unexpected request %d", requestCount)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"events": events})
+	}))
+	defer srv.Close()
+
+	page, err := getCloudSessionLogPage(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		logViewOptions{Tail: 2},
+		false,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("getCloudSessionLogPage: %v", err)
+	}
+	rows := renderLogRows(page.Events)
+	if requestCount != 2 || len(rows) != 2 ||
+		rows[0].Summary != "Older visible row" || rows[1].Summary != "Newest visible row" {
+		t.Fatalf("requests=%d rows=%#v", requestCount, rows)
+	}
+}
+
+func TestCloudSessionLogsFallBackOnceForKeylessHistory(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var events []map[string]any
+		if requestCount == 1 {
+			if r.URL.Query().Get("tail") != "1000" {
+				t.Fatalf("initial query: got %q", r.URL.RawQuery)
+			}
+			events = make([]map[string]any, maxCloudLogTail)
+			for index := range events {
+				events[index] = map[string]any{"event": "round_start"}
+			}
+		} else {
+			if requestCount != 2 || r.URL.RawQuery != "" {
+				t.Fatalf("fallback query: request=%d query=%q", requestCount, r.URL.RawQuery)
+			}
+			events = []map[string]any{
+				{"event": "agent_progress", "data": map[string]any{"text": "Older row"}},
+				{"event": "agent_progress", "data": map[string]any{"text": "Newer row"}},
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"events": events})
+	}))
+	defer srv.Close()
+
+	page, err := getCloudSessionLogPage(
+		cloud.NewClient(srv.URL, "test-token"),
+		"sess_123",
+		logViewOptions{Tail: 2},
+		false,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("getCloudSessionLogPage: %v", err)
+	}
+	if rows := renderLogRows(page.Events); requestCount != 2 || len(rows) != 2 {
+		t.Fatalf("requests=%d rows=%#v", requestCount, rows)
+	}
+}

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -104,11 +104,21 @@ type deploymentLogEventsResponse struct {
 	Events []json.RawMessage `json:"events"`
 }
 
-// SessionLogPage keeps both the normalized events used by the human/JSON
-// views and their original wire records for --raw output.
+// SessionLogPageQuery selects one bounded window of merged Cloud events.
+type SessionLogPageQuery struct {
+	Tail          int
+	BeforeRuntime *int64
+	BeforeControl *int64
+}
+
+// SessionLogPage keeps normalized and raw events plus their oldest source
+// cursors, which select the next page backward.
 type SessionLogPage struct {
-	Events    []sessionapi.SessionEvent
-	RawEvents []json.RawMessage
+	Events          []sessionapi.SessionEvent
+	RawEvents       []json.RawMessage
+	BeforeRuntime   *int64
+	BeforeControl   *int64
+	CanPageBackward bool
 }
 
 type deploymentLogEvent struct {
@@ -116,6 +126,7 @@ type deploymentLogEvent struct {
 	EventID          *string        `json:"event_id,omitempty"`
 	Event            string         `json:"event"`
 	EventSeq         *int64         `json:"event_seq,omitempty"`
+	ControlSeq       *int64         `json:"seq,omitempty"`
 	EpochID          *int           `json:"epoch_id,omitempty"`
 	Round            *int           `json:"round,omitempty"`
 	Role             *string        `json:"role,omitempty"`
@@ -633,17 +644,30 @@ func (c *Client) DeleteSession(sessionID string) (*SessionRecord, error) {
 }
 
 func (c *Client) GetSessionLogs(sessionID string) ([]sessionapi.SessionEvent, error) {
-	page, err := c.GetSessionLogPage(sessionID, 0)
+	page, err := c.GetSessionLogPage(sessionID, SessionLogPageQuery{})
 	if err != nil {
 		return nil, err
 	}
 	return page.Events, nil
 }
 
-func (c *Client) GetSessionLogPage(sessionID string, tail int) (*SessionLogPage, error) {
+func (c *Client) GetSessionLogPage(
+	sessionID string,
+	query SessionLogPageQuery,
+) (*SessionLogPage, error) {
 	path := "/api/deployments/" + url.PathEscape(sessionID) + "/logs"
-	if tail > 0 {
-		path += "?tail=" + strconv.Itoa(tail)
+	params := url.Values{}
+	if query.Tail > 0 {
+		params.Set("tail", strconv.Itoa(query.Tail))
+	}
+	if query.BeforeRuntime != nil {
+		params.Set("before_rt", strconv.FormatInt(*query.BeforeRuntime, 10))
+	}
+	if query.BeforeControl != nil {
+		params.Set("before_cp", strconv.FormatInt(*query.BeforeControl, 10))
+	}
+	if encoded := params.Encode(); encoded != "" {
+		path += "?" + encoded
 	}
 	resp, err := c.do("GET", path, nil)
 	if err != nil {
@@ -658,16 +682,36 @@ func (c *Client) GetSessionLogPage(sessionID string, tail int) (*SessionLogPage,
 		return nil, err
 	}
 	events := make([]sessionapi.SessionEvent, 0, len(response.Events))
+	beforeRuntime := query.BeforeRuntime
+	beforeControl := query.BeforeControl
+	canPageBackward := len(response.Events) > 0
+	cursorAdvanced := false
 	for _, raw := range response.Events {
 		var event deploymentLogEvent
 		if err := json.Unmarshal(raw, &event); err != nil {
 			return nil, fmt.Errorf("decode session log event: %w", err)
 		}
+		if event.EventSeq == nil && event.ControlSeq == nil {
+			canPageBackward = false
+		}
+		if event.EventSeq != nil && (beforeRuntime == nil || *event.EventSeq < *beforeRuntime) {
+			value := *event.EventSeq
+			beforeRuntime = &value
+			cursorAdvanced = true
+		}
+		if event.ControlSeq != nil && (beforeControl == nil || *event.ControlSeq < *beforeControl) {
+			value := *event.ControlSeq
+			beforeControl = &value
+			cursorAdvanced = true
+		}
 		events = append(events, event.asSessionEvent())
 	}
 	return &SessionLogPage{
-		Events:    events,
-		RawEvents: response.Events,
+		Events:          events,
+		RawEvents:       response.Events,
+		BeforeRuntime:   beforeRuntime,
+		BeforeControl:   beforeControl,
+		CanPageBackward: canPageBackward && cursorAdvanced,
 	}, nil
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -713,7 +713,10 @@ func TestClientSessionLogPagePreservesRawEvents(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123", 0)
+	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage(
+		"sess_123",
+		SessionLogPageQuery{},
+	)
 	if err != nil {
 		t.Fatalf("GetSessionLogPage: %v", err)
 	}
@@ -737,18 +740,55 @@ func TestClientSessionLogPagePreservesRawEvents(t *testing.T) {
 	}
 }
 
-func TestClientSessionLogPageRequestsTail(t *testing.T) {
+func TestClientSessionLogPageRequestsWindow(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/deployments/sess_123/logs" || r.URL.Query().Get("tail") != "50" {
+		query := r.URL.Query()
+		if r.URL.Path != "/api/deployments/sess_123/logs" ||
+			query.Get("tail") != "50" ||
+			query.Get("before_rt") != "30" ||
+			query.Get("before_cp") != "4" {
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = w.Write([]byte(`{"events":[]}`))
+		_, _ = w.Write([]byte(`{"events":[{"event":"r29","event_seq":29},{"event":"deployment.accepted","seq":3}]}`))
 	}))
 	defer srv.Close()
 
-	if _, err := NewClient(srv.URL, "test-token").GetSessionLogPage("sess_123", 50); err != nil {
+	beforeRuntime := int64(30)
+	beforeControl := int64(4)
+	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage(
+		"sess_123",
+		SessionLogPageQuery{
+			Tail:          50,
+			BeforeRuntime: &beforeRuntime,
+			BeforeControl: &beforeControl,
+		},
+	)
+	if err != nil {
 		t.Fatalf("GetSessionLogPage: %v", err)
+	}
+	if !page.CanPageBackward || page.BeforeRuntime == nil || *page.BeforeRuntime != 29 ||
+		page.BeforeControl == nil || *page.BeforeControl != 3 {
+		t.Fatalf("page cursors: got %#v", page)
+	}
+}
+
+func TestClientSessionLogPageMarksAStalledCursorUnpageable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"events":[{"event":"r30","event_seq":30}]}`))
+	}))
+	defer srv.Close()
+
+	beforeRuntime := int64(30)
+	page, err := NewClient(srv.URL, "test-token").GetSessionLogPage(
+		"sess_123",
+		SessionLogPageQuery{Tail: 50, BeforeRuntime: &beforeRuntime},
+	)
+	if err != nil {
+		t.Fatalf("GetSessionLogPage: %v", err)
+	}
+	if page.CanPageBackward {
+		t.Fatalf("stalled page can continue: %#v", page)
 	}
 }
 


### PR DESCRIPTION
## Summary

- fetch human Cloud logs in bounded 1,000-event pages until the requested rendered row tail exists
- page backward with the existing runtime and control-plane cursors
- fall back once to the legacy full-history request when events are keyless or a cursor stalls
- leave `--json`, `--raw`, `--all`, and tails above the server window unchanged

PR #45 bounded the request by event count, but the human renderer filters and deduplicates those events afterward. This preserves the documented `--tail N` activity-row contract without returning to unbounded downloads on cursor-capable deployments. No documentation change is needed because the existing user-visible behavior is restored.

## Verification

- `go test ./...`
- `bazel test //...`
- live read-only checks against a long-running deployment: human `--tail 3` returned 3 rows, human `--tail 50` returned 50 rows, and JSON `--tail 50` returned 50 events in 2.8–3.8 seconds

## Release

A Telos CLI release must be published and promoted before users receive this fix. No Cloud infrastructure change is required.